### PR TITLE
Handle different possible plugin dirnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ resurrect.save_state_dir = "C:\\Users\\Admin\\Desktop\\state\\" -- Set some dire
 
 2. Saving workspace state:
 ```lua
-local workspace_state = require(resurrect.get_require_path() .. ".plugin.resurrect.workspace_state")
+local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm")
+local workspace_state = resurrect.workspace_state
+
 config.keys = {
   -- ...
   {
@@ -32,7 +34,6 @@ config.keys = {
   mods = "ALT",
   action = wezterm.action.Multiple({
     wezterm.action_callback(function(win, pane)
-      local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm/")
       resurrect.save_state(workspace_state.get_workspace_state())
     end),
     }),
@@ -43,7 +44,7 @@ config.keys = {
 3. Loading workspace state via. fuzzy finder:
 ```lua
 local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm")
-local workspace_state = require(resurrect.get_require_path() .. ".plugin.resurrect.workspace_state")
+local workspace_state = resurrect.workspace_state
 
 config.keys = {
   -- ...
@@ -57,11 +58,10 @@ config.keys = {
 	  id = string.match(id, "([^/]+)$")
 	  id = string.match(id, "(.+)%..+$")
 	  local state = resurrect.load_state(id, "workspace")
-	  local workspace_state = require(resurrect.get_require_path() .. ".plugin.resurrect.workspace_state")
 	  workspace_state.restore_workspace(state, {
 	    relative = true,
 	    restore_text = true,
-	    on_pane_restore = (require(resurrect.get_require_path() .. ".plugin.resurrect.tab_state")).default_on_pane_restore,
+            on_pane_restore = resurrect.tab_state.default_on_pane_restore,
 	  })
 	end)
       end),
@@ -79,19 +79,19 @@ I have added the following to my configuration to be able to do this whenever I 
 ```lua
 -- loads the state whenever I create a new workspace
 wezterm.on("smart_workspace_switcher.workspace_switcher.created", function(window, path, label)
-  local workspace_state = require(resurrect.get_require_path() .. ".plugin.resurrect.workspace_state")
+  local workspace_state = resurrect.workspace_state
 
   workspace_state.restore_workspace(resurrect.load_state(label, "workspace"), {
     window = window,
     relative = true,
     restore_text = true,
-    on_pane_restore = (require(resurrect.get_require_path() .. ".plugin.resurrect.tab_state")).default_on_pane_restore,
+    on_pane_restore = resurrect.tab_state.default_on_pane_restore,
   })
 end)
 
 -- Saves the state whenever I select a workspace
 wezterm.on("smart_workspace_switcher.workspace_switcher.selected", function(window, path, label)
-  local workspace_state = require(resurrect.get_require_path() .. ".plugin.resurrect.workspace_state")
+  local workspace_state = resurrect.workspace_state
   resurrect.save_state(workspace_state.get_workspace_state())
 end)
 ```
@@ -159,6 +159,7 @@ State files are json files, which will be decoded into lua tables. This can be u
 If you would like to add entries in your Wezterm command palette for renaming and switching workspaces:
 ```lua
 wezterm.on('augment-command-palette', function(window, pane)
+  local workspace_state = resurrect.workspace_state
   return {
     {
       brief = 'Window | Workspace: Switch Workspace',

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -41,8 +41,7 @@ end
 
 enable_sub_modules()
 
-pub.save_state_dir = is_windows() and plugin_dir .. separator .. pub.get_require_path() .. "\\state\\"
-	or plugin_dir .. separator .. pub.get_require_path() .. "/state/"
+pub.save_state_dir = plugin_dir .. separator .. pub.get_require_path() .. separator .. "state" .. separator
 
 ---Changes the directory to save the state to
 ---@param directory string

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -1,6 +1,4 @@
-local wezterm = require("wezterm")
-local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm/")
-local pane_tree_mod = require(resurrect.get_require_path() .. ".plugin.resurrect.pane_tree")
+local pane_tree_mod = require("resurrect.pane_tree")
 local pub = {}
 
 ---Function used to split panes when mapping over the pane_tree

--- a/plugin/resurrect/window_state.lua
+++ b/plugin/resurrect/window_state.lua
@@ -1,6 +1,4 @@
-local wezterm = require("wezterm")
-local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm/")
-local tab_state_mod = require(resurrect.get_require_path() .. ".plugin.resurrect.tab_state")
+local tab_state_mod = require("resurrect.tab_state")
 local pub = {}
 
 ---Returns the state of the window

--- a/plugin/resurrect/workspace_state.lua
+++ b/plugin/resurrect/workspace_state.lua
@@ -1,6 +1,5 @@
 local wezterm = require("wezterm")
-local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm/")
-local window_state_mod = require(resurrect.get_require_path() .. ".plugin.resurrect.window_state")
+local window_state_mod = require("resurrect.window_state")
 local pub = {}
 
 ---restore workspace state


### PR DESCRIPTION
Depending on how the plugin is imported:
`local resurrect = wezterm.plugin.require 'https://github.com/MLFlexer/resurrect.wezterm'` or `local resurrect = wezterm.plugin.require 'https://github.com/MLFlexer/resurrect.wezterm/'`, a different directory in the Wezterm plugins folder will be created. If you require the plugin with a `/` at the end, the plugin directory will have `sZs` at the end. You can end up duplicate plugin directories with different names

This PR:
1) checks for the existence of these directories and will return `httpssCssZssZsgithubsDscomsZsMLFlexersZsresurrectsDswezterm` by default 
2) creates an `is_windows()` utility function to use throughout.