### PR TITLE
Fixing windows path strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ end)
 
 ## FAQ
 ### Pane CWD is not correct on Windows
-If you pane CWD is incorrect then it might be a problem with the shell integration and OSC 7. See [Wezterm documentation](https://wezfurlong.org/wezterm/shell-integration.html#osc-7-on-windows-with-powershell-with-starship).
+If you pane CWD is incorrect then it might be a problem with the shell integration and OSC 7. See [Wezterm documentation](https://wezfurlong.org/wezterm/shell-integration.html).
 
 ## Contributions
 Suggestions, Issues and PRs are welcome! The features currently implemented are the ones I use the most, but your workflow might differ. As such, if you have any proposals on how to improve the plugin please feel free to make an issue or even better a PR!

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ wezterm.on('augment-command-palette', function(window, pane)
 end)
 ```
 
+## FAQ
+### Pane CWD is not correct on Windows
+If you pane CWD is incorrect then it might be a problem with the shell integration and OSC 7. See [Wezterm documentation](https://wezfurlong.org/wezterm/shell-integration.html#osc-7-on-windows-with-powershell-with-starship).
+
 ## Contributions
 Suggestions, Issues and PRs are welcome! The features currently implemented are the ones I use the most, but your workflow might differ. As such, if you have any proposals on how to improve the plugin please feel free to make an issue or even better a PR!
 

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -57,11 +57,7 @@ local function get_file_path(file_name, type, opt_name)
 	if opt_name then
 		file_name = opt_name
 	end
-	if is_windows() then
-		return string.format('"%s%s\\%s.json"', pub.save_state_dir, type, file_name:gsub("\\", "+"))
-	else
-		return string.format("%s%s/%s.json", pub.save_state_dir, type, file_name:gsub("/", "+"))
-	end
+	return string.format("%s%s" .. separator .. "%s.json", pub.save_state_dir, type, file_name:gsub(separator, "+"))
 end
 
 ---@param file_path string

--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -1,8 +1,15 @@
+local wezterm = require("wezterm")
 local pub = {}
 
 ---@alias Pane any
 ---@alias PaneInformation {left: integer, top: integer, height: integer, width: integer}
 ---@alias pane_tree {left: integer, top: integer, height: integer, width: integer, bottom: pane_tree?, right: pane_tree?, text: string[], cwd: string, process: string, pane: Pane?, is_active: boolean, is_zoomed: boolean}
+
+--- checks if the user is on windows
+--- @return boolean
+local function is_windows()
+	return wezterm.target_triple == "x86_64-pc-windows-msvc"
+end
 
 ---compare function returns true if a is more left than b
 ---@param a PaneInformation
@@ -73,7 +80,9 @@ function pub.get_shell_process(process)
 		return process
 	elseif process == "sh" then
 		return process
-	elseif process == "powershell" then
+	elseif process == "pwsh.exe" then
+		return process
+	elseif process == "cmd.exe" then
 		return process
 	else
 		return nil
@@ -89,6 +98,9 @@ local function insert_panes(root, panes)
 	end
 
 	root.cwd = root.pane:get_current_working_dir().file_path
+	if is_windows() then
+		root.cwd = root.cwd:gsub("^/([a-zA-Z]):", "%1:")
+	end
 	root.process = root.pane:get_foreground_process_name()
 	if pub.get_shell_process(root.process) then
 		root.text = root.pane:get_lines_as_escapes(root.pane:get_dimensions().scrollback_rows)


### PR DESCRIPTION
Paths in windows that contain spaces need to be escaped in qoutes. 
The CWD for windows processes in the paneinformation might start with a `/` which needs to be removed.
