### PR TITLE
51 ensure saving of pane text is correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ config.keys = {
           })
         elseif type == "window" then
           state = resurrect.load_state(id, "window")
-          resurrect.window_state.restore_window(win:mux_window(), state, {
+          resurrect.window_state.restore_window(pane:window(), state, {
             relative = true,
             restore_text = true,
             on_pane_restore = resurrect.tab_state.default_on_pane_restore,

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -173,9 +173,7 @@ end
 local function sanitize_json(data)
 	wezterm.emit("resurrect.sanitize_json.start", data)
 	data = data:gsub("[\x00-\x1F]", function(c)
-		local byte = string.byte(c)
-
-		return string.format("\\u00%02X", byte)
+		return string.format("\\u00%02X", string.byte(c))
 	end)
 	wezterm.emit("resurrect.sanitize_json.finished")
 	return data

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -66,13 +66,8 @@ end
 ---@return boolean
 ---@return string
 local function execute_cmd_with_stdin(cmd, input)
-	-- if is_windows then
-	-- 	input = input:gsub("\\", "\\\\"):gsub('"', '`"'):gsub("\n", "`n"):gsub("\r", "`r")
-	-- end
-
 	if is_windows and #input < 32000 then -- Check if input is larger than max cmd length on Windows
-		input = input:gsub("\\", "\\\\"):gsub('"', '`"'):gsub("\n", "`n"):gsub("\r", "`r")
-		cmd = string.format('Write-Output -NoEnumerate "%s" | %s', input, cmd)
+		cmd = string.format("%s | %s", wezterm.shell_join_args({ "Write-Output", "-NoEnumerate", input }), cmd)
 		local process_args = { "pwsh.exe", "-NoProfile", "-Command", cmd }
 
 		local success, stdout, stderr = wezterm.run_child_process(process_args)
@@ -177,7 +172,6 @@ end
 --- @return string
 local function sanitize_json(data)
 	wezterm.emit("resurrect.sanitize_json.start", data)
-	-- data = data:gsub("[\x00-\x1F\x7F]", function(c)
 	data = data:gsub("[\x00-\x1F]", function(c)
 		local byte = string.byte(c)
 
@@ -233,9 +227,6 @@ local function load_json(file_path)
 			wezterm.log_error("Decryption failed: " .. tostring(output))
 		else
 			json = output
-			if is_windows then
-				json = json:gsub("\\\\", "\\"):gsub('`"', '"'):gsub("`n", "\n"):gsub("`r", "\r")
-			end
 			wezterm.emit("resurrect.decrypt.finished", file_path)
 		end
 	else

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -172,6 +172,7 @@ end
 --- @return string
 local function sanitize_json(data)
 	wezterm.emit("resurrect.sanitize_json.start", data)
+	-- escapes control characters to ensure valid json
 	data = data:gsub("[\x00-\x1F]", function(c)
 		return string.format("\\u00%02X", string.byte(c))
 	end)

--- a/plugin/resurrect/test/text.lua
+++ b/plugin/resurrect/test/text.lua
@@ -1,7 +1,7 @@
 local wezterm = require("wezterm")
 local pub = {}
 
-function pub.write_all_bytes(pane)
+function pub.write_all_chars(pane)
 	-- ascii
 	for i = 1, 127 do
 		pane:inject_output(string.char(i))
@@ -16,11 +16,11 @@ function pub.write_and_save_current_window()
 	return wezterm.action_callback(function(win, pane)
 		local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm")
 		local mux_win = win:mux_window()
-		pub.write_all_bytes(pane)
-		mux_win:set_title("TEST_WRITING_BYTES")
+		pub.write_all_chars(pane)
+		mux_win:set_title("TEST_WRITING_CHARS")
 		local state = resurrect.window_state.get_window_state(mux_win)
 		resurrect.save_state(state)
-		wezterm.log_info("SAVED THE WINDOW AS TEST_WRITING_BYTES")
+		wezterm.log_info("SAVED THE WINDOW AS TEST_WRITING_CHARS")
 	end)
 end
 

--- a/plugin/resurrect/test/text.lua
+++ b/plugin/resurrect/test/text.lua
@@ -7,11 +7,7 @@ function pub.write_all_bytes(pane)
 		pane:inject_output(string.char(i))
 	end
 	--utf8
-	for i = 128, 55295 do
-		pane:inject_output(utf8.char(i))
-	end
-	local max = 5000 * 150 -- scrolback * some arbitrary number of chars per line
-	for i = 57344, max do
+	for i = 128, 31000 do
 		pane:inject_output(utf8.char(i))
 	end
 end

--- a/plugin/resurrect/test/text.lua
+++ b/plugin/resurrect/test/text.lua
@@ -1,0 +1,31 @@
+local wezterm = require("wezterm")
+local pub = {}
+
+function pub.write_all_bytes(pane)
+	-- ascii
+	for i = 1, 127 do
+		pane:inject_output(string.char(i))
+	end
+	--utf8
+	for i = 128, 55295 do
+		pane:inject_output(utf8.char(i))
+	end
+	local max = 5000 * 150 -- scrolback * some arbitrary number of chars per line
+	for i = 57344, max do
+		pane:inject_output(utf8.char(i))
+	end
+end
+
+function pub.write_and_save_current_window()
+	return wezterm.action_callback(function(win, pane)
+		local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm")
+		local mux_win = win:mux_window()
+		pub.write_all_bytes(pane)
+		mux_win:set_title("TEST_WRITING_BYTES")
+		local state = resurrect.window_state.get_window_state(mux_win)
+		resurrect.save_state(state)
+		wezterm.log_info("SAVED THE WINDOW AS TEST_WRITING_BYTES")
+	end)
+end
+
+return pub


### PR DESCRIPTION
This PR should simplify and ensure the correctness in saving/restoring text in panes. It does so by introducing `test/text.lua` which exposes a function to write a lot of different ascii and unicode characters. It also exposes a keybind to write this to the pane and save it as `TEST_WRITING_BYTES` window state.
This can then be loaded and thus it enables testing of saving/restoring text is correct.

I have used this to simplify and improve the current saving of the state to and have tested it works on Windows and Linux.