### PR TITLE
add fuzzy load event emitters

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ This plugin emits the following events that you can use for your own callback fu
 - `resurrect.decrypt.finished(file_path)`
 - `resurrect.encrypt.start(file_path)`
 - `resurrect.encrypt.finished(file_path)`
+- `resurrect.fuzzy_load.start(window, pane)`
+- `resurrect.fuzzy_load.finished(window, pane)`
 - `resurrect.error(err)`
 - `resurrect.load_state.start(name, type)`
 - `resurrect.load_state.finished(name, type)`

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -339,6 +339,7 @@ end
 ---@param callback fun(id: string, label: string, save_state_dir: string)
 ---@param opts fuzzy_load_opts?
 function pub.fuzzy_load(window, pane, callback, opts)
+	wezterm.emit("resurrect.fuzzy_load.start", window, pane)
 	local state_files = {}
 
 	if opts == nil then
@@ -377,6 +378,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 				if id and label then
 					callback(id, label, pub.save_state_dir)
 				end
+				wezterm.emit("resurrect.fuzzy_load.finished", window, pane)
 			end),
 			title = opts.title,
 			choices = state_files,


### PR DESCRIPTION
Addresses https://github.com/MLFlexer/resurrect.wezterm/issues/58

Add emitters for:
`resurrect.fuzzy_load.start(window, pane)`
`resurrect.fuzzy_load.finished(window, pane)`