### PR TITLE
Feature: Delete state file

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ config.keys = {
         end,
         {
           title = "Delete State",
-          description = "Choose State to Delete: ",
+          description = "Select State to Delete and press Enter = accept, Esc = cancel, / = filter",
           fuzzy_description = "Search State to Delete: ",
           is_fuzzy = true,
         })

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ which has the following types:
 
 ```lua
 ---@alias fmt_fun fun(label: string): string
----@alias fuzzy_load_opts {title: string, is_fuzzy: boolean, ignore_workspaces: boolean, ignore_tabs: boolean, ignore_windows: boolean, fmt_window: fmt_fun, fmt_workspace: fmt_fun, fmt_tab: fmt_fun }
+---@alias fuzzy_load_opts {title: string, description: string, fuzzy_description: string, is_fuzzy: boolean, ignore_workspaces: boolean, ignore_tabs: boolean, ignore_windows: boolean, fmt_window: fmt_fun, fmt_workspace: fmt_fun, fmt_tab: fmt_fun }
 ```
 
 This is used to format labels, ignore saved state, change the title and change the behaviour of the fuzzy finder.

--- a/README.md
+++ b/README.md
@@ -91,10 +91,34 @@ config.keys = {
 }
 ```
 
-4. Optional, enable encryption (recommended):
+4. Delete a saved state file via. fuzzy finder:
+
+```lua
+local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm")
+
+config.keys = {
+  -- ...
+  {
+    key = "d",
+    mods = "ALT",
+    action = wezterm.action_callback(function(win, pane)
+      resurrect.fuzzy_load(win, pane, function(id)
+          resurrect.delete_state(id)
+        end,
+        {
+          title = "Delete State",
+          description = "Choose State to Delete: ",
+          fuzzy_description = "Search State to Delete: ",
+          is_fuzzy = true,
+        })
+    end),
+  },
+}
+```
+5. Optional, enable encryption (recommended):
    You can optionally configure the plugin to encrypt and decrypt the saved state. [age](https://github.com/FiloSottile/age) is the default encryption provider. [Rage](https://github.com/str4d/rage) and [GnuPG](https://gnupg.org/) encryption are also supported.
 
-4.1. Install `age` and generate a key with:
+5.1. Install `age` and generate a key with:
 
 ```sh
 $ age-keygen -o key.txt
@@ -105,7 +129,7 @@ Public key: age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
 > If you prefer to use [GnuPG](https://gnupg.org/), generate a key pair: `gpg --full-generate-key`. Get the public key with `gpg --armor --export your_email@example.com`.
 > The private key is your email or key ID associated with the gpg key.
 
-4.2. Enable encryption in your Wezterm config:
+5.2. Enable encryption in your Wezterm config:
 
 ```lua
 local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm")
@@ -254,6 +278,8 @@ This plugin emits the following events that you can use for your own callback fu
 
 - `resurrect.decrypt.start(file_path)`
 - `resurrect.decrypt.finished(file_path)`
+- `resurrect.delete_state.start(file_path)`
+- `resurrect.delete_state.finished(file_path)`
 - `resurrect.encrypt.start(file_path)`
 - `resurrect.encrypt.finished(file_path)`
 - `resurrect.error(err)`

--- a/README.md
+++ b/README.md
@@ -91,34 +91,10 @@ config.keys = {
 }
 ```
 
-4. Delete a saved state file via. fuzzy finder:
-
-```lua
-local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm")
-
-config.keys = {
-  -- ...
-  {
-    key = "d",
-    mods = "ALT",
-    action = wezterm.action_callback(function(win, pane)
-      resurrect.fuzzy_load(win, pane, function(id)
-          resurrect.delete_state(id)
-        end,
-        {
-          title = "Delete State",
-          description = "Select State to Delete and press Enter = accept, Esc = cancel, / = filter",
-          fuzzy_description = "Search State to Delete: ",
-          is_fuzzy = true,
-        })
-    end),
-  },
-}
-```
-5. Optional, enable encryption (recommended):
+4. Optional, enable encryption (recommended):
    You can optionally configure the plugin to encrypt and decrypt the saved state. [age](https://github.com/FiloSottile/age) is the default encryption provider. [Rage](https://github.com/str4d/rage) and [GnuPG](https://gnupg.org/) encryption are also supported.
 
-5.1. Install `age` and generate a key with:
+4.1. Install `age` and generate a key with:
 
 ```sh
 $ age-keygen -o key.txt
@@ -129,7 +105,7 @@ Public key: age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
 > If you prefer to use [GnuPG](https://gnupg.org/), generate a key pair: `gpg --full-generate-key`. Get the public key with `gpg --armor --export your_email@example.com`.
 > The private key is your email or key ID associated with the gpg key.
 
-5.2. Enable encryption in your Wezterm config:
+4.2. Enable encryption in your Wezterm config:
 
 ```lua
 local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm")
@@ -346,7 +322,7 @@ Here is an example of a json file:
                "is_active":true,
                "pane_tree":{
                   "cwd":"/home/user/",
-                  "domain": "SSHMUX:domain", -- key only exists if attached to remote domain
+                  "domain": "SSHMUX:domain",
                   "height":50,
                   "index":0,
                   "is_active":true,
@@ -366,6 +342,33 @@ Here is an example of a json file:
       }
    ],
    "workspace":"workspace_name"
+}
+```
+
+### Delete a saved state file via. fuzzy finder
+
+You can use the fuzzy finder to delete a saved state file by adding a keybind to your config:
+
+```lua
+local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm")
+
+config.keys = {
+  -- ...
+  {
+    key = "d",
+    mods = "ALT",
+    action = wezterm.action_callback(function(win, pane)
+      resurrect.fuzzy_load(win, pane, function(id)
+          resurrect.delete_state(id)
+        end,
+        {
+          title = "Delete State",
+          description = "Select State to Delete and press Enter = accept, Esc = cancel, / = filter",
+          fuzzy_description = "Search State to Delete: ",
+          is_fuzzy = true,
+        })
+    end),
+  },
 }
 ```
 

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -308,7 +308,7 @@ end
 function pub.get_default_fuzzy_load_opts()
 	return {
 		title = "Load State",
-		description = "Select State to Load: ",
+		description = "Select State to Load and press Enter = accept, Esc = cancel, / = filter",
 		fuzzy_description = "Search State to Load: ",
 		is_fuzzy = true,
 		ignore_workspaces = false,

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -398,6 +398,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 	)
 end
 
+---@param file_path string
 function pub.delete_state(file_path)
 	wezterm.emit("resurrect.delete_state.start", file_path)
 	local path = pub.save_state_dir .. file_path

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -301,13 +301,15 @@ function pub.periodic_save(opts)
 end
 
 ---@alias fmt_fun fun(label: string): string
----@alias fuzzy_load_opts {title: string, is_fuzzy: boolean, ignore_workspaces: boolean, ignore_tabs: boolean, ignore_windows: boolean, fmt_window: fmt_fun, fmt_workspace: fmt_fun, fmt_tab: fmt_fun }
+---@alias fuzzy_load_opts {title: string, description: string, fuzzy_description: string, is_fuzzy: boolean, ignore_workspaces: boolean, ignore_tabs: boolean, ignore_windows: boolean, fmt_window: fmt_fun, fmt_workspace: fmt_fun, fmt_tab: fmt_fun }
 
 ---Returns default fuzzy loading options
 ---@return fuzzy_load_opts
 function pub.get_default_fuzzy_load_opts()
 	return {
-		title = "Choose State to Load",
+		title = "Load State",
+		description = "Select State to Load: ",
+		fuzzy_description = "Search State to Load: ",
 		is_fuzzy = true,
 		ignore_workspaces = false,
 		ignore_windows = false,
@@ -343,6 +345,14 @@ function pub.fuzzy_load(window, pane, callback, opts)
 
 	if opts == nil then
 		opts = pub.get_default_fuzzy_load_opts()
+	else
+		-- Merge user opts with defaults
+		local default_opts = pub.get_default_fuzzy_load_opts()
+		for k, v in pairs(default_opts) do
+			if opts[k] == nil then
+				opts[k] = v
+			end
+		end
 	end
 
 	local function insert_choices(type, fmt)
@@ -379,11 +389,24 @@ function pub.fuzzy_load(window, pane, callback, opts)
 				end
 			end),
 			title = opts.title,
+			description = opts.description,
+			fuzzy_description = opts.fuzzy_description,
 			choices = state_files,
 			fuzzy = opts.is_fuzzy,
 		}),
 		pane
 	)
+end
+
+function pub.delete_state(file_path)
+	wezterm.emit("resurrect.delete_state.start", file_path)
+	local path = pub.save_state_dir .. file_path
+	local success = os.remove(path)
+	if not success then
+		wezterm.emit("resurrect.error", "Failed to delete state: " .. path)
+		wezterm.log_error("Failed to delete state: " .. path)
+	end
+	wezterm.emit("resurrect.delete_state.finished", file_path)
 end
 
 -- Export submodules


### PR DESCRIPTION
This PR allows you to use the fuzzy picker to select a state file to delete. While testing the other PRs, I ended up with some stale state files. Rather than trying to find the file in the plugin directory I figured we could reuse the fuzzy picker for deleting state files that are no longer wanted.

1) I added a couple "description" opts to the default fuzzy load opts. Now you get a descriptive message at the top of the window instead of the Wezterm default "Fuzzy matching: "

2) In `pub.fuzzy_load` if there are user supplied ops, it will now merge them with default opts. This should make it a bit simpler for users since you only need to overwrite keys you want to change from the default opts. It also enabled me to reuse the `pub.fuzzy_load` function for a `resurrect.delete_state` function while keeping the settings and formatting the same.

3) The new `resurrect.delete_state` function is pretty small and simple:
```lua
---@param file_path string
function pub.delete_state(file_path)
	wezterm.emit("resurrect.delete_state.start", file_path)
	local path = pub.save_state_dir .. file_path
	local success = os.remove(path)
	if not success then
		wezterm.emit("resurrect.error", "Failed to delete state: " .. path)
		wezterm.log_error("Failed to delete state: " .. path)
	end
	wezterm.emit("resurrect.delete_state.finished", file_path)
end
```

It accepts a `file_path` and will remove the file. It has start, finished and error emitters. It works well in combination with the file picker. I added an example keybind to the `README`:
```lua
  {
    key = "d",
    mods = "ALT",
    action = wezterm.action_callback(function(win, pane)
      resurrect.fuzzy_load(win, pane, function(id)
          resurrect.delete_state(id)
        end,
        {
          title = "Delete State",
          description = "Select State to Delete and press Enter = accept, Esc = cancel, / = filter",
          fuzzy_description = "Search State to Delete: ",
          is_fuzzy = true,
        })
    end),
  },
```