### PR TITLE
Emit opts along with the periodic_save event

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ This plugin emits the following events that you can use for your own callback fu
 - `resurrect.error(err)`
 - `resurrect.load_state.start(name, type)`
 - `resurrect.load_state.finished(name, type)`
-- `resurrect.periodic_save`
+- `resurrect.periodic_save(opts)`
 - `resurrect.sanitize_json.start(data)`
 - `resurrect.sanitize_json.finished(data)`
 - `resurrect.save_state.start(file_path)`

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -281,7 +281,7 @@ function pub.periodic_save(opts)
 		opts.interval_seconds = 60 * 15
 	end
 	wezterm.time.call_after(opts.interval_seconds, function()
-		wezterm.emit("resurrect.periodic_save")
+		wezterm.emit("resurrect.periodic_save", opts)
 		if opts.save_workspaces then
 			pub.save_state(pub.workspace_state.get_workspace_state())
 		end


### PR DESCRIPTION
Addresses an issue with `tabline.wez` where the status wouldn't be cleared after a delay due to no window object. See https://github.com/michaelbrusegard/tabline.wez/pull/8.