### PR TITLE
feat: 79 add option to add datetime to filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,10 +219,19 @@ This can improve performance when saving and loading state.
 
 ### save_state options
 
-`resurrect.save_state(state, opt_name?, date_fmt?)`, `resurrect.window_state.save_window_action(date_fmt?)` 
-and `resurrect.tab_state.save_tab_action(date_fmt?)` take optional string arguments:
-- `opt_name` which will rename the file to the name of the string.
-- `date_fmt` which will append the current local date/time to the file name according to the [Rust chrono strftime syntax specified](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+```lua
+---@param opts { name: string?, date_fmt: string? } | nil
+-- example with optional custom save_state options
+local save_state_opts = {
+  name = "custom_filename", -- rename the file to the name of the string
+  date_fmt = "%Y-%m-%d %H:%M:%S" -- append the current local datetime to the filename
+}
+-- usage
+resurrect.save_state(state, save_state_opts)
+resurrect.window_state.save_window_action(save_state_opts)
+resurrect.tab_state.save_tab_action(save_state_opts)
+```
+`date_fmt` should follow the [Rust chrono strftime syntax specified](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
 See [wezterm.strftime](https://wezfurlong.org/wezterm/config/lua/wezterm/strftime.html).
 
 ### fuzzy_load opts

--- a/README.md
+++ b/README.md
@@ -219,8 +219,11 @@ This can improve performance when saving and loading state.
 
 ### save_state options
 
-`resurrect.save_state(state, opt_name?)` takes an optional string argument,
-which will rename the file to the name of the string.
+`resurrect.save_state(state, opt_name?, date_fmt?)`, `resurrect.window_state.save_window_action(date_fmt?)` 
+and `resurrect.tab_state.save_tab_action(date_fmt?)` take optional string arguments:
+- `opt_name` which will rename the file to the name of the string.
+- `date_fmt` which will append the current local date/time to the file name according to the [Rust chrono strftime syntax specified](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+See [wezterm.strftime](https://wezfurlong.org/wezterm/config/lua/wezterm/strftime.html).
 
 ### fuzzy_load opts
 

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -58,9 +58,12 @@ local function get_file_path(file_name, type, opt_name, date_fmt)
 	if opt_name then
 		file_name = opt_name
 	end
-	date_fmt = date_fmt and " " .. wezterm.strftime(date_fmt) or ""
-	return string.format("%s%s" .. separator .. "%s%s.json", pub.save_state_dir, type, file_name:gsub(separator, "+"),
-		date_fmt)
+	if date_fmt then
+	    return string.format("%s%s" .. separator .. "%s %s.json", pub.save_state_dir, type, file_name:gsub(separator, "+"),
+		wezterm.strftime(date_fmt))
+	else
+		    return string.format("%s%s" .. separator .. "%s.json", pub.save_state_dir, type, file_name:gsub(separator, "+"))
+  end
 end
 
 ---executes cmd and passes input to stdin

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -52,12 +52,15 @@ end
 ---@param file_name string
 ---@param type string
 ---@param opt_name string?
+---@param date_fmt string?
 ---@return string
-local function get_file_path(file_name, type, opt_name)
+local function get_file_path(file_name, type, opt_name, date_fmt)
 	if opt_name then
 		file_name = opt_name
 	end
-	return string.format("%s%s" .. separator .. "%s.json", pub.save_state_dir, type, file_name:gsub(separator, "+"))
+	date_fmt = date_fmt and " " .. wezterm.strftime(date_fmt) or ""
+	return string.format("%s%s" .. separator .. "%s%s.json", pub.save_state_dir, type, file_name:gsub(separator, "+"),
+		date_fmt)
 end
 
 ---executes cmd and passes input to stdin
@@ -246,13 +249,14 @@ end
 ---save state to a file
 ---@param state workspace_state | window_state | tab_state
 ---@param opt_name? string
-function pub.save_state(state, opt_name)
+---@param date_fmt? string
+function pub.save_state(state, opt_name, date_fmt)
 	if state.window_states then
-		write_state(get_file_path(state.workspace, "workspace", opt_name), state)
+		write_state(get_file_path(state.workspace, "workspace", opt_name, date_fmt), state)
 	elseif state.tabs then
-		write_state(get_file_path(state.title, "window", opt_name), state)
+		write_state(get_file_path(state.title, "window", opt_name, date_fmt), state)
 	elseif state.pane_tree then
-		write_state(get_file_path(state.title, "tab", opt_name), state)
+		write_state(get_file_path(state.title, "tab", opt_name, date_fmt), state)
 	end
 end
 

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -98,7 +98,10 @@ function pub.restore_tab(tab, tab_state, opts)
 	wezterm.emit("resurrect.tab_state.restore_tab.finished")
 end
 
-function pub.save_tab_action()
+---@param opt_name? string
+---@param date_fmt? string
+function pub.save_tab_action(opt_name, date_fmt)
+	date_fmt = date_fmt and wezterm.strftime(date_fmt) or ""
 	return wezterm.action_callback(function(win, pane)
 		local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm")
 		local tab = pane:tab()
@@ -110,7 +113,7 @@ function pub.save_tab_action()
 						if title then
 							callback_pane:tab():set_title(title)
 							local state = pub.get_tab_state(tab)
-							resurrect.save_state(state)
+							resurrect.save_state(state, opt_name, date_fmt)
 						end
 					end),
 				}),
@@ -118,7 +121,7 @@ function pub.save_tab_action()
 			)
 		elseif tab:get_title() then
 			local state = pub.get_tab_state(tab)
-			resurrect.save_state(state)
+			resurrect.save_state(state, opt_name, date_fmt)
 		end
 	end)
 end

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -98,10 +98,8 @@ function pub.restore_tab(tab, tab_state, opts)
 	wezterm.emit("resurrect.tab_state.restore_tab.finished")
 end
 
----@param opt_name? string
----@param date_fmt? string
-function pub.save_tab_action(opt_name, date_fmt)
-	date_fmt = date_fmt and wezterm.strftime(date_fmt) or ""
+---@param opts { name: string?, date_fmt: string? } | nil
+function pub.save_tab_action(opts)
 	return wezterm.action_callback(function(win, pane)
 		local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm")
 		local tab = pane:tab()
@@ -113,7 +111,7 @@ function pub.save_tab_action(opt_name, date_fmt)
 						if title then
 							callback_pane:tab():set_title(title)
 							local state = pub.get_tab_state(tab)
-							resurrect.save_state(state, opt_name, date_fmt)
+							resurrect.save_state(state, opts)
 						end
 					end),
 				}),
@@ -121,7 +119,7 @@ function pub.save_tab_action(opt_name, date_fmt)
 			)
 		elseif tab:get_title() then
 			local state = pub.get_tab_state(tab)
-			resurrect.save_state(state, opt_name, date_fmt)
+			resurrect.save_state(state, opts)
 		end
 	end)
 end

--- a/plugin/resurrect/window_state.lua
+++ b/plugin/resurrect/window_state.lua
@@ -66,7 +66,10 @@ function pub.restore_window(window, window_state, opts)
 	wezterm.emit("resurrect.window_state.restore_window.finished")
 end
 
-function pub.save_window_action()
+---@param opt_name? string
+---@param date_fmt? string
+function pub.save_window_action(opt_name, date_fmt)
+	date_fmt = date_fmt and wezterm.strftime(date_fmt) or ""
 	return wezterm.action_callback(function(win, pane)
 		local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm")
 		local mux_win = win:mux_window()
@@ -78,7 +81,7 @@ function pub.save_window_action()
 						if title then
 							window:mux_window():set_title(title)
 							local state = pub.get_window_state(mux_win)
-							resurrect.save_state(state)
+							resurrect.save_state(state, opt_name, date_fmt)
 						end
 					end),
 				}),
@@ -86,7 +89,7 @@ function pub.save_window_action()
 			)
 		elseif mux_win:get_title() then
 			local state = pub.get_window_state(mux_win)
-			resurrect.save_state(state)
+			resurrect.save_state(state, opt_name, date_fmt)
 		end
 	end)
 end

--- a/plugin/resurrect/window_state.lua
+++ b/plugin/resurrect/window_state.lua
@@ -66,10 +66,8 @@ function pub.restore_window(window, window_state, opts)
 	wezterm.emit("resurrect.window_state.restore_window.finished")
 end
 
----@param opt_name? string
----@param date_fmt? string
-function pub.save_window_action(opt_name, date_fmt)
-	date_fmt = date_fmt and wezterm.strftime(date_fmt) or ""
+---@param opts { name: string?, date_fmt: string? } | nil
+function pub.save_window_action(opts)
 	return wezterm.action_callback(function(win, pane)
 		local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm")
 		local mux_win = win:mux_window()
@@ -81,7 +79,7 @@ function pub.save_window_action(opt_name, date_fmt)
 						if title then
 							window:mux_window():set_title(title)
 							local state = pub.get_window_state(mux_win)
-							resurrect.save_state(state, opt_name, date_fmt)
+							resurrect.save_state(state, opts)
 						end
 					end),
 				}),
@@ -89,7 +87,7 @@ function pub.save_window_action(opt_name, date_fmt)
 			)
 		elseif mux_win:get_title() then
 			local state = pub.get_window_state(mux_win)
-			resurrect.save_state(state, opt_name, date_fmt)
+			resurrect.save_state(state, opts)
 		end
 	end)
 end


### PR DESCRIPTION
Responds to [issue: #79 ](https://github.com/MLFlexer/resurrect.wezterm/issues/79).

The user can provide an optional `date_fmt` string in the strftime syntax interpreted by [wezterm.strftime()](https://wezfurlong.org/wezterm/config/lua/wezterm/strftime.html). If this opt is provided, the current local datetime will be appended to the saved filename for the state and visible in the fuzzy picker when restoring or deleting it.

 ```lua
--- e.g.
      action = wezterm.action_callback(function(win, pane)
        resurrect.save_state(resurrect.workspace_state.get_workspace_state(), nil, "%Y-%m-%d %H:%M:%S")
      end),
---
      action = resurrect.window_state.save_window_action(nil, "%Y-%m-%d %H:%M:%S"),
---
      action = resurrect.tab_state.save_tab_action(nil, "%Y-%m-%d %H:%M:%S"),
```

I added the optional `opt_name` param to the `save_window_action` and `save_tab_action` functions to make them consistent with the `resurrect.save_state` args.