### PR TITLE
Feature: add the state's last modified date/time in the fuzzy search dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,11 @@ config.keys = {
           local state = resurrect.load_state(id, "tab")
           resurrect.tab_state.restore_tab(pane:tab(), state, opts)
         end
-      end)
+      end,
+        { -- optional part (* see explanations in fuzzy_load opts)
+          show_state_with_date = true,
+          date_format = "%d-%b-%Y %H:%M",
+        })
     end),
   },
 }
@@ -143,7 +147,7 @@ resurrect.set_encryption({
       pub.encryption.public_key,
       file_path:gsub(" ", "\\ ")
     )
-    
+
     local success, output = execute_cmd_with_stdin(cmd, lines)
     if not success then
       error("Encryption failed:" .. output)
@@ -152,12 +156,12 @@ resurrect.set_encryption({
   decrypt = function(file_path)
     -- substitute for your decryption command
     local cmd = { pub.encryption.method, "-d", "-i", pub.encryption.private_key, file_path }
-    
+
     local success, stdout, stderr = wezterm.run_child_process(cmd)
     if not success then
       error("Decryption failed: " .. stderr)
     end
-    
+
     return stdout
   end,
 })
@@ -178,7 +182,7 @@ I have added the following to my configuration to be able to do this whenever I 
 -- loads the state whenever I create a new workspace
 wezterm.on("smart_workspace_switcher.workspace_switcher.created", function(window, path, label)
   local workspace_state = resurrect.workspace_state
-  
+
   workspace_state.restore_workspace(resurrect.load_state(label, "workspace"), {
     window = window,
     relative = true,
@@ -229,16 +233,18 @@ which has the following types:
 
 ```lua
 ---@alias fmt_fun fun(label: string): string
----@alias fuzzy_load_opts {title: string, description: string, fuzzy_description: string, is_fuzzy: boolean, ignore_workspaces: boolean, ignore_tabs: boolean, ignore_windows: boolean, fmt_window: fmt_fun, fmt_workspace: fmt_fun, fmt_tab: fmt_fun }
+---@alias fuzzy_load_opts {title: string, description: string, fuzzy_description: string, is_fuzzy: boolean, ignore_workspaces: boolean, ignore_tabs: boolean, ignore_windows: boolean, date_format: string, show_state_with_date: boolean, fmt_window: fmt_fun, fmt_workspace: fmt_fun, fmt_tab: fmt_fun }
 ```
 
-This is used to format labels, ignore saved state, change the title and change the behaviour of the fuzzy finder.
+This is used to format labels, ignore saved state, change the title and change the behaviour of the fuzzy finder. The option `show_state_with_date`, by default `false`, is used such that the date/time of the last change of the state file can be shown in the list. Additionally `date_format`, by default `%d-%m-%Y %H:%M:%S`, is used to format the date if shown, the format follows [`strftime`](https://strftime.org).
 
 ### Change the directory to store the saved state
 
 ```lua
 resurrect.change_state_save_dir("/some/other/directory")
 ```
+
+When changing the directory, resurrect will create the necessary subfolders _workspace_, _window_, and _tab_ if they don't exist already.
 
 > [!WARNING]
 > FOR WINDOWS USERS

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -457,7 +457,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 	end
 
 	if not opts.ignore_windows then
-		insert_choices("window") --, opts.fmt_window)
+		insert_choices("window")
 	end
 
 	if not opts.ignore_tabs then

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -435,7 +435,8 @@ function pub.fuzzy_load(window, pane, callback, opts)
 		-- Execute the command and capture stdout
 		local handle = io.popen(cmd)
 		if not handle then
-			return -- Return an empty table if the command fails
+      wezterm.emit("resurrect.error", "Could not open process: " .. cmd)
+			return {} -- Return an empty table if the command fails
 		end
 
 		local stdout = handle:read("*a")

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -453,7 +453,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 	end
 
 	if not opts.ignore_workspaces then
-		insert_choices("workspace") --, opts.fmt_workspace)
+		insert_choices("workspace")
 	end
 
 	if not opts.ignore_windows then

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -1,4 +1,4 @@
-local wezterm = require("wezterm")
+local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
 
 ---@class init_module
 ---@field encryption encryption_opts
@@ -8,6 +8,7 @@ local plugin_dir
 
 --- checks if the user is on windows
 local is_windows = wezterm.target_triple == "x86_64-pc-windows-msvc"
+local is_mac = (wezterm.target_triple == "x86_64-apple-darwin" or wezterm.target_triple == "aarch64-apple-darwin")
 local separator = is_windows and "\\" or "/"
 
 --- Checks if the plugin directory exists
@@ -342,29 +343,52 @@ function pub.get_default_fuzzy_load_opts()
 		ignore_workspaces = false,
 		ignore_windows = false,
 		ignore_tabs = false,
-		fmt_workspace = function(label, date)
-			return wezterm.format({
-				{ Foreground = { AnsiColor = "Green" } },
-				{ Text = "󱂬 : " .. label:gsub("%.json", "") .. " " },
-				{ Foreground = { AnsiColor = "White" } },
-				{ Text = date },
-			})
+		date_format = "%d-%m-%Y %H:%M:%S",
+		show_state_with_date = false,
+		fmt_workspace = function(label, date, opts)
+			if opts.show_state_with_date then
+				return wezterm.format({
+					{ Foreground = { AnsiColor = "Green" } },
+					{ Text = "󱂬 : " .. label:gsub("%.json", "") .. " " },
+					{ Foreground = { AnsiColor = "White" } },
+					{ Text = date },
+				})
+			else
+				return wezterm.format({
+					{ Foreground = { AnsiColor = "Green" } },
+					{ Text = "󱂬 : " .. label:gsub("%.json", "") },
+				})
+			end
 		end,
-		fmt_window = function(label, date)
-			return wezterm.format({
-				{ Foreground = { AnsiColor = "Yellow" } },
-				{ Text = " : " .. label:gsub("%.json", "") .. " " },
-				{ Foreground = { AnsiColor = "White" } },
-				{ Text = date },
-			})
+		fmt_window = function(label, date, show_state_with_date, opts)
+			if opts.show_state_with_date then
+				return wezterm.format({
+					{ Foreground = { AnsiColor = "Yellow" } },
+					{ Text = " : " .. label:gsub("%.json", "") .. " " },
+					{ Foreground = { AnsiColor = "White" } },
+					{ Text = date },
+				})
+			else
+				return wezterm.format({
+					{ Foreground = { AnsiColor = "Yellow" } },
+					{ Text = " : " .. label:gsub("%.json", "") },
+				})
+			end
 		end,
-		fmt_tab = function(label, date)
-			return wezterm.format({
-				{ Foreground = { AnsiColor = "Red" } },
-				{ Text = "󰓩 : " .. label:gsub("%.json", "") .. " " },
-				{ Foreground = { AnsiColor = "White" } },
-				{ Text = date },
-			})
+		fmt_tab = function(label, date, opts)
+			if opts.show_state_with_date then
+				return wezterm.format({
+					{ Foreground = { AnsiColor = "Red" } },
+					{ Text = "󰓩 : " .. label:gsub("%.json", "") .. " " },
+					{ Foreground = { AnsiColor = "White" } },
+					{ Text = date },
+				})
+			else
+				return wezterm.format({
+					{ Foreground = { AnsiColor = "Red" } },
+					{ Text = "󰓩 : " .. label:gsub("%.json", "") },
+				})
+			end
 		end,
 	}
 end
@@ -390,65 +414,51 @@ function pub.fuzzy_load(window, pane, callback, opts)
 			end
 		end
 	end
+	print(opts)
 
-	local function file_datetime(folder, file)
-		-- Month names
-		local months = {
-			"Jan",
-			"Feb",
-			"Mar",
-			"Apr",
-			"May",
-			"Jun",
-			"Jul",
-			"Aug",
-			"Sep",
-			"Oct",
-			"Nov",
-			"Dec",
-		}
-		local result = ""
-		if is_windows then
-			local handle = io.popen("wmic datafile where name='" .. folder .. separator .. file .. "' get LastModified")
-			if handle then
-				local stdout = handle:read("*a")
-				handle:close()
-
-				-- Convert the date format into "dd-mmm-yyyy HH:MM"
-
-				local year = stdout:sub(1, 4)
-				local month = stdout:sub(5, 6)
-				local day = stdout:sub(7, 8)
-				local hour = stdout:sub(9, 10)
-				local minute = stdout:sub(11, 12)
-
-				-- Format into "dd-mmm-yyyy hh:mm"
-				result = string.format(
-					"%02d-%s-%04d %02d:%02d",
-					tonumber(day),
-					months[tonumber(month)],
-					tonumber(year),
-					tonumber(hour),
-					tonumber(minute)
-				)
-			end
-		else
-			local handle = io.popen("date -r '" .. folder .. separator .. file .. "' +'%d-%b-%Y %H:%M'")
-			if handle then
-				result = handle:read("*a")
-				handle:close()
-			end
-		end
-		return result
-	end
+	local max_length = 0
 
 	local function insert_choices(type)
-		local folder = pub.save_state_dir .. separator .. type
-		for _, file in ipairs(wezterm.glob("*", folder)) do
-			local id = type .. "/" .. file
-			local date = file_datetime(folder, file)
+		local folder = pub.save_state_dir .. type
 
-			table.insert(state_files, { id = id, file = file, date = date, type = type })
+		-- Command-line recipe based on OS
+		local cmd
+		if is_windows then
+			cmd = "powershell -Command \"Get-ChildItem -Path '"
+				.. folder
+				.. '\' | ForEach-Object { "$($_.LastWriteTime.ToFileTimeUtc()) $($_.Name)" }"'
+		elseif is_mac then
+			cmd = 'stat -f "%m %N" ' .. folder .. "/*"
+		else
+			cmd = 'ls -l --time-style=+"%s" ' .. folder .. " | awk '{print $6,$7,$9}'"
+		end
+
+		-- Execute the command and capture stdout
+		local handle = io.popen(cmd)
+		if not handle then
+			return -- Return an empty table if the command fails
+		end
+
+		local stdout = handle:read("*a")
+		handle:close()
+
+		if not stdout or stdout == "" then
+			return {} -- Return an empty table if no output is returned
+		end
+
+		-- Parse the stdout and construct the table
+		for line in stdout:gmatch("[^\n]+") do
+			local epoch, file = line:match("(%d+)%s+(.+)")
+			if epoch and file then
+				local formatted_date = os.date(opts.date_format, tonumber(epoch))
+				max_length = math.max(max_length, file:len())
+				table.insert(state_files, {
+					id = type .. "/" .. file,
+					file = file,
+					date = formatted_date,
+					type = type,
+				})
+			end
 		end
 	end
 
@@ -464,12 +474,6 @@ function pub.fuzzy_load(window, pane, callback, opts)
 		insert_choices("tab")
 	end
 
-	-- look for the longest file name in the list
-	local max_length = 0
-	for _, items in ipairs(state_files) do
-		max_length = math.max(max_length, items["file"]:len())
-	end
-
 	-- build the final list
 	for _, items in ipairs(state_files) do
 		local label = ""
@@ -477,14 +481,18 @@ function pub.fuzzy_load(window, pane, callback, opts)
 			label = items["file"]
 		else
 			local padding = max_length - items["file"]:len()
-			label = items["file"] .. " " .. string.rep(".", padding - 1)
+			if opts.show_state_with_date then
+				label = items["file"] .. " " .. string.rep(".", padding - 1)
+			else
+				label = items["file"]
+			end
 		end
 		if items["type"] == "workspace" then
-			label = opts.fmt_workspace(label, items["date"]) or label
+			label = opts.fmt_workspace(label, items["date"], opts) or label
 		elseif items[type] == "window" then
-			label = opts.fmt_window(label, items["date"]) or label
+			label = opts.fmt_window(label, items["date"], opts) or label
 		else
-			label = opts.fmt_tab(label, items["date"]) or label
+			label = opts.fmt_tab(label, items["date"], opts) or label
 		end
 		table.insert(state_fmted_files, { id = items.id, label = label })
 	end

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -47,6 +47,11 @@ pub.save_state_dir = plugin_dir .. separator .. pub.get_require_path() .. separa
 ---@param directory string
 function pub.change_state_save_dir(directory)
 	pub.save_state_dir = directory
+	-- ensure that subfolders exist
+	dirname = pub.save_state_dir .. separator .. "state"
+	os.execute("mkdir -p " .. dirname .. separator .. "tab")
+	os.execute("mkdir -p " .. dirname .. separator .. "window")
+	os.execute("mkdir -p " .. dirname .. separator .. "workspace")
 end
 
 ---@param file_name string

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -49,13 +49,19 @@ function pub.change_state_save_dir(directory)
 	pub.save_state_dir = string.gsub(
 		string.gsub(directory, "%s+", ""), -- trim any trailing space
 		"[\\/]$",
-		""
-	) -- remove any trailing \ or /
-	print(pub.save_state_dir)
+		"" -- remove any trailing \ or /
+	) .. separator -- add a trailing separator
 	-- ensure that subfolders exist
-	os.execute("mkdir -p " .. directory .. separator .. "tab")
-	os.execute("mkdir -p " .. directory .. separator .. "window")
-	os.execute("mkdir -p " .. directory .. separator .. "workspace")
+
+	if is_windows then
+		os.execute("mkdir " .. pub.save_state_dir .. "tab")
+		os.execute("mkdir " .. pub.save_state_dir .. "window")
+		os.execute("mkdir " .. pub.save_state_dir .. "workspace")
+	else
+		os.execute("mkdir -p " .. pub.save_state_dir .. "tab")
+		os.execute("mkdir -p " .. pub.save_state_dir .. "window")
+		os.execute("mkdir -p " .. pub.save_state_dir .. "workspace")
+	end
 end
 
 ---@param file_name string
@@ -335,22 +341,28 @@ function pub.get_default_fuzzy_load_opts()
 		ignore_workspaces = false,
 		ignore_windows = false,
 		ignore_tabs = false,
-		fmt_workspace = function(label)
+		fmt_workspace = function(label, date)
 			return wezterm.format({
 				{ Foreground = { AnsiColor = "Green" } },
-				{ Text = "󱂬 : " .. label:gsub("%.json$", "") },
+				{ Text = "󱂬 : " .. label:gsub("%.json", "") .. " " },
+				{ Foreground = { AnsiColor = "White" } },
+				{ Text = date },
 			})
 		end,
-		fmt_window = function(label)
+		fmt_window = function(label, date)
 			return wezterm.format({
 				{ Foreground = { AnsiColor = "Yellow" } },
-				{ Text = " : " .. label:gsub("%.json$", "") },
+				{ Text = " : " .. label:gsub("%.json", "") .. " " },
+				{ Foreground = { AnsiColor = "White" } },
+				{ Text = date },
 			})
 		end,
-		fmt_tab = function(label)
+		fmt_tab = function(label, date)
 			return wezterm.format({
 				{ Foreground = { AnsiColor = "Red" } },
-				{ Text = "󰓩 : " .. label:gsub("%.json$", "") },
+				{ Text = "󰓩 : " .. label:gsub("%.json", "") .. " " },
+				{ Foreground = { AnsiColor = "White" } },
+				{ Text = date },
 			})
 		end,
 	}
@@ -364,6 +376,7 @@ end
 function pub.fuzzy_load(window, pane, callback, opts)
 	wezterm.emit("resurrect.fuzzy_load.start", window, pane)
 	local state_files = {}
+	local state_fmted_files = {}
 
 	if opts == nil then
 		opts = pub.get_default_fuzzy_load_opts()
@@ -377,30 +390,102 @@ function pub.fuzzy_load(window, pane, callback, opts)
 		end
 	end
 
-	local function insert_choices(type, fmt)
-		for _, file in ipairs(wezterm.glob("*", pub.save_state_dir .. "/" .. type)) do
-			local label
-			local id = type .. "/" .. file
+	local function file_datetime(folder, file)
+		-- Month names
+		local months = {
+			"Jan",
+			"Feb",
+			"Mar",
+			"Apr",
+			"May",
+			"Jun",
+			"Jul",
+			"Aug",
+			"Sep",
+			"Oct",
+			"Nov",
+			"Dec",
+		}
+		local result = ""
+		if is_windows then
+			local handle = io.popen("wmic datafile where name='" .. folder .. separator .. file("' get LastModified"))
+			if handle then
+				local stdout = handle:read("*a")
+				handle:close()
 
-			if fmt then
-				label = fmt(file)
-			else
-				label = file
+				-- Convert the date format into "dd-mmm-yyyy HH:MM"
+
+				local year = stdout:sub(1, 4)
+				local month = stdout:sub(5, 6)
+				local day = stdout:sub(7, 8)
+				local hour = stdout:sub(9, 10)
+				local minute = stdout:sub(11, 12)
+
+				-- Format into "dd-mmm-yyyy hh:mm"
+				result = string.format(
+					"%02d-%s-%04d %02d:%02d",
+					tonumber(day),
+					months[tonumber(month)],
+					tonumber(year),
+					tonumber(hour),
+					tonumber(minute)
+				)
 			end
-			table.insert(state_files, { id = id, label = label })
+		else
+			local handle = io.popen("date -r '" .. folder .. "' +'%d-%b-%Y %H:%M'")
+			if handle then
+				result = handle:read("*a")
+				handle:close()
+			end
+		end
+		return result
+	end
+
+	local function insert_choices(type)
+		local folder = pub.save_state_dir .. separator .. type
+		for _, file in ipairs(wezterm.glob("*", folder)) do
+			local id = type .. "/" .. file
+			local date = file_datetime(folder, file)
+
+			table.insert(state_files, { id = id, file = file, date = date, type = type })
 		end
 	end
 
 	if not opts.ignore_workspaces then
-		insert_choices("workspace", opts.fmt_workspace)
+		insert_choices("workspace") --, opts.fmt_workspace)
 	end
 
 	if not opts.ignore_windows then
-		insert_choices("window", opts.fmt_window)
+		insert_choices("window") --, opts.fmt_window)
 	end
 
 	if not opts.ignore_tabs then
-		insert_choices("tab", opts.fmt_tab)
+		insert_choices("tab") --, opts.fmt_tab)
+	end
+
+	-- look for the longest file name in the list
+	local max_length = 0
+	for _, items in ipairs(state_files) do
+		max_length = math.max(max_length, items["file"]:len())
+	end
+
+	-- build the final list
+	for _, items in ipairs(state_files) do
+		local label = ""
+		if items["file"]:len() == max_length then
+			label = items["file"]
+		else
+			local padding = max_length - items["file"]:len()
+			label = items["file"] .. " " .. string.rep(".", padding - 1)
+		end
+		if items["type"] == "workspace" then
+			label = opts.fmt_workspace(label, items["date"]) or label
+		elseif items[type] == "window" then
+			label = opts.fmt_window(label, items["date"]) or label
+		else
+			label = opts.fmt_tab(label, items["date"]) or label
+		end
+		table.insert(state_fmted_files, { id = items.id, label = label })
 	end
 
 	window:perform_action(
@@ -414,7 +499,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 			title = opts.title,
 			description = opts.description,
 			fuzzy_description = opts.fuzzy_description,
-			choices = state_files,
+			choices = state_fmted_files,
 			fuzzy = opts.is_fuzzy,
 		}),
 		pane

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -433,7 +433,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 				)
 			end
 		else
-			local handle = io.popen("date -r '" .. folder .. "' +'%d-%b-%Y %H:%M'")
+			local handle = io.popen("date -r '" .. folder .. seperator .. file .. "' +'%d-%b-%Y %H:%M'")
 			if handle then
 				result = handle:read("*a")
 				handle:close()

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -414,7 +414,6 @@ function pub.fuzzy_load(window, pane, callback, opts)
 			end
 		end
 	end
-	print(opts)
 
 	local max_length = 0
 

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -443,6 +443,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 		handle:close()
 
 		if not stdout or stdout == "" then
+      wezterm.emit("resurrect.error", "No output when running: " .. cmd)
 			return {} -- Return an empty table if no output is returned
 		end
 

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -461,7 +461,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 	end
 
 	if not opts.ignore_tabs then
-		insert_choices("tab") --, opts.fmt_tab)
+		insert_choices("tab")
 	end
 
 	-- look for the longest file name in the list

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -433,7 +433,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 				)
 			end
 		else
-			local handle = io.popen("date -r '" .. folder .. seperator .. file .. "' +'%d-%b-%Y %H:%M'")
+			local handle = io.popen("date -r '" .. folder .. separator .. file .. "' +'%d-%b-%Y %H:%M'")
 			if handle then
 				result = handle:read("*a")
 				handle:close()

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -46,12 +46,16 @@ pub.save_state_dir = plugin_dir .. separator .. pub.get_require_path() .. separa
 ---Changes the directory to save the state to
 ---@param directory string
 function pub.change_state_save_dir(directory)
-	pub.save_state_dir = directory
+	pub.save_state_dir = string.gsub(
+		string.gsub(directory, "%s+", ""), -- trim any trailing space
+		"[\\/]$",
+		""
+	) -- remove any trailing \ or /
+	print(pub.save_state_dir)
 	-- ensure that subfolders exist
-	dirname = pub.save_state_dir .. separator .. "state"
-	os.execute("mkdir -p " .. dirname .. separator .. "tab")
-	os.execute("mkdir -p " .. dirname .. separator .. "window")
-	os.execute("mkdir -p " .. dirname .. separator .. "workspace")
+	os.execute("mkdir -p " .. directory .. separator .. "tab")
+	os.execute("mkdir -p " .. directory .. separator .. "window")
+	os.execute("mkdir -p " .. directory .. separator .. "workspace")
 end
 
 ---@param file_name string

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -409,7 +409,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 		}
 		local result = ""
 		if is_windows then
-			local handle = io.popen("wmic datafile where name='" .. folder .. separator .. file("' get LastModified"))
+			local handle = io.popen("wmic datafile where name='" .. folder .. separator .. file .. "' get LastModified")
 			if handle then
 				local stdout = handle:read("*a")
 				handle:close()

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -79,8 +79,7 @@ end
 ---executes cmd and passes input to stdin
 ---@param cmd string command to be run
 ---@param input string input to stdin
----@return boolean
----@return string
+---@return boolean, string
 local function execute_cmd_with_stdin(cmd, input)
 	if is_windows and #input < 32000 then -- Check if input is larger than max cmd length on Windows
 		cmd = string.format("%s | %s", wezterm.shell_join_args({ "Write-Output", "-NoEnumerate", input }), cmd)
@@ -435,7 +434,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 		-- Execute the command and capture stdout
 		local handle = io.popen(cmd)
 		if not handle then
-      wezterm.emit("resurrect.error", "Could not open process: " .. cmd)
+			wezterm.emit("resurrect.error", "Could not open process: " .. cmd)
 			return {} -- Return an empty table if the command fails
 		end
 
@@ -443,7 +442,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 		handle:close()
 
 		if not stdout or stdout == "" then
-      wezterm.emit("resurrect.error", "No output when running: " .. cmd)
+			wezterm.emit("resurrect.error", "No output when running: " .. cmd)
 			return {} -- Return an empty table if no output is returned
 		end
 
@@ -451,11 +450,12 @@ function pub.fuzzy_load(window, pane, callback, opts)
 		for line in stdout:gmatch("[^\n]+") do
 			local epoch, file = line:match("(%d+)%s+(.+)")
 			if epoch and file then
+				local filename, _ = file:match("^.*" .. separator .. "(.+)%.(.*)$")
 				local formatted_date = os.date(opts.date_format, tonumber(epoch))
-				max_length = math.max(max_length, file:len())
+				max_length = math.max(max_length, filename:len())
 				table.insert(state_files, {
 					id = type .. "/" .. file,
-					file = file,
+					file = filename,
 					date = formatted_date,
 					type = type,
 				})


### PR DESCRIPTION
1. The modified code adds a new date/time column within the label field passed to the fuzzy dialog. After the glob is retrieved by wezterm, the last change of each file is retrieved. The maximum length is derived from the list of filenames such that a proper column is formatted with a padding of '.' so it is easy to read. The format functions have been modified to display the date/time in white, leaving the color focus on the name of the state.
2. I've noticed that when changing the `state_save_dir`, the proper subfolders (tab, workspace, window) are expected to be created as well, which is non-intuitive, in my opinion. Thus, I have modified the code such that when the folder is changed, the plugin ensures that the necessary folders are present and, if needed, creates them.

I've attempted to write the changes for Windows and Mac/Linux, but I wasn't able to test thoroughly for Windows.

This PR closes issue #80 