### PR TITLE
90 move fuzzy finding logic from initlua into own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ config.keys = {
     key = "r",
     mods = "ALT",
     action = wezterm.action_callback(function(win, pane)
-      resurrect.fuzzy_load(win, pane, function(id, label)
+      resurrect.fuzzy_loader.fuzzy_load(win, pane, function(id, label)
         local type = string.match(id, "^([^/]+)") -- match before '/'
         id = string.match(id, "([^/]+)$") -- match after '/'
         id = string.match(id, "(.+)%..+$") -- remove file extention
@@ -282,7 +282,7 @@ the tabs in the window, such that only the restored tabs are visible after resto
 
 ### fuzzy_load opts
 
-the `resurrect.fuzzy_load(window, pane, callback, opts?)` function takes an
+the `resurrect.fuzzy_loader.fuzzy_load(window, pane, callback, opts?)` function takes an
 optional `opts` argument, which has the following types:
 
 ```lua
@@ -319,8 +319,8 @@ This plugin emits the following events that you can use for your own callback fu
 - `resurrect.delete_state.finished(file_path)`
 - `resurrect.encrypt.start(file_path)`
 - `resurrect.encrypt.finished(file_path)`
-- `resurrect.fuzzy_load.start(window, pane)`
-- `resurrect.fuzzy_load.finished(window, pane)`
+- `resurrect.fuzzy_loader.fuzzy_load.start(window, pane)`
+- `resurrect.fuzzy_loader.fuzzy_load.finished(window, pane)`
 - `resurrect.error(err)`
 - `resurrect.load_state.start(name, type)`
 - `resurrect.load_state.finished(name, type)`
@@ -421,7 +421,7 @@ config.keys = {
     key = "d",
     mods = "ALT",
     action = wezterm.action_callback(function(win, pane)
-      resurrect.fuzzy_load(win, pane, function(id)
+      resurrect.fuzzy_loader.fuzzy_load(win, pane, function(id)
           resurrect.delete_state(id)
         end,
         {

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -358,106 +358,6 @@ function pub.resurrect_on_gui_startup()
 	return suc, err
 end
 
----@alias fmt_fun fun(label: string): string
----@alias fuzzy_load_opts {title: string, description: string, fuzzy_description: string, is_fuzzy: boolean, ignore_workspaces: boolean, ignore_tabs: boolean, ignore_windows: boolean, fmt_window: fmt_fun, fmt_workspace: fmt_fun, fmt_tab: fmt_fun }
-
----Returns default fuzzy loading options
----@return fuzzy_load_opts
-function pub.get_default_fuzzy_load_opts()
-	return {
-		title = "Load State",
-		description = "Select State to Load and press Enter = accept, Esc = cancel, / = filter",
-		fuzzy_description = "Search State to Load: ",
-		is_fuzzy = true,
-		ignore_workspaces = false,
-		ignore_windows = false,
-		ignore_tabs = false,
-		fmt_workspace = function(label)
-			return wezterm.format({
-				{ Foreground = { AnsiColor = "Green" } },
-				{ Text = "󱂬 : " .. label:gsub("%.json$", "") },
-			})
-		end,
-		fmt_window = function(label)
-			return wezterm.format({
-				{ Foreground = { AnsiColor = "Yellow" } },
-				{ Text = " : " .. label:gsub("%.json$", "") },
-			})
-		end,
-		fmt_tab = function(label)
-			return wezterm.format({
-				{ Foreground = { AnsiColor = "Red" } },
-				{ Text = "󰓩 : " .. label:gsub("%.json$", "") },
-			})
-		end,
-	}
-end
-
----A fuzzy finder to restore saved state
----@param window MuxWindow
----@param pane Pane
----@param callback fun(id: string, label: string, save_state_dir: string)
----@param opts fuzzy_load_opts?
-function pub.fuzzy_load(window, pane, callback, opts)
-	wezterm.emit("resurrect.fuzzy_load.start", window, pane)
-	local state_files = {}
-
-	if opts == nil then
-		opts = pub.get_default_fuzzy_load_opts()
-	else
-		-- Merge user opts with defaults
-		local default_opts = pub.get_default_fuzzy_load_opts()
-		for k, v in pairs(default_opts) do
-			if opts[k] == nil then
-				opts[k] = v
-			end
-		end
-	end
-
-	local function insert_choices(type, fmt)
-		for _, file in ipairs(wezterm.glob("*", pub.save_state_dir .. "/" .. type)) do
-			local label
-			local id = type .. "/" .. file
-
-			if fmt then
-				label = fmt(file)
-			else
-				label = file
-			end
-			table.insert(state_files, { id = id, label = label })
-		end
-	end
-
-	if not opts.ignore_workspaces then
-		insert_choices("workspace", opts.fmt_workspace)
-	end
-
-	if not opts.ignore_windows then
-		insert_choices("window", opts.fmt_window)
-	end
-
-	if not opts.ignore_tabs then
-		insert_choices("tab", opts.fmt_tab)
-	end
-
-	window:perform_action(
-		wezterm.action.InputSelector({
-			action = wezterm.action_callback(function(_, _, id, label)
-				if id and label then
-					callback(id, label, pub.save_state_dir)
-				end
-				wezterm.emit("resurrect.fuzzy_load.finished", window, pane)
-			end),
-			title = opts.title,
-			description = opts.description,
-			fuzzy_description = opts.fuzzy_description,
-			choices = state_files,
-			fuzzy = opts.is_fuzzy,
-		}),
-		pane
-	)
-end
-
 ---@param file_path string
 function pub.delete_state(file_path)
 	wezterm.emit("resurrect.delete_state.start", file_path)
@@ -471,12 +371,10 @@ function pub.delete_state(file_path)
 end
 
 -- Export submodules
-local workspace_state = require("resurrect.workspace_state")
-pub.workspace_state = workspace_state
-local window_state = require("resurrect.window_state")
-pub.window_state = window_state
-local tab_state = require("resurrect.tab_state")
-pub.tab_state = tab_state
+pub.workspace_state = require("resurrect.workspace_state")
+pub.window_state = require("resurrect.window_state")
+pub.tab_state = require("resurrect.tab_state")
+pub.fuzzy_loader = require("resurrect.fuzzy_loader")
 
 function pub.set_max_nlines(max_nlines)
 	require("resurrect.pane_tree").max_nlines = max_nlines

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -41,14 +41,14 @@ end
 
 enable_sub_modules()
 
-pub.save_state_dir = plugin_dir .. separator .. pub.get_require_path() .. separator .. "state" .. separator
-
 ---Changes the directory to save the state to
 ---@param directory string
 function pub.change_state_save_dir(directory)
 	pub.save_state_dir = directory
 	pub.fuzzy_loader.save_state_dir = directory
 end
+
+pub.change_state_save_dir(plugin_dir .. separator .. pub.get_require_path() .. separator .. "state" .. separator)
 
 ---@param file_name string
 ---@param type string

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -41,15 +41,6 @@ end
 
 enable_sub_modules()
 
----Changes the directory to save the state to
----@param directory string
-function pub.change_state_save_dir(directory)
-	pub.save_state_dir = directory
-	pub.fuzzy_loader.save_state_dir = directory
-end
-
-pub.change_state_save_dir(plugin_dir .. separator .. pub.get_require_path() .. separator .. "state" .. separator)
-
 ---@param file_name string
 ---@param type string
 ---@param opt_name string?
@@ -376,7 +367,15 @@ pub.workspace_state = require("resurrect.workspace_state")
 pub.window_state = require("resurrect.window_state")
 pub.tab_state = require("resurrect.tab_state")
 pub.fuzzy_loader = require("resurrect.fuzzy_loader")
-pub.fuzzy_loader.save_state_dir = pub.save_state_dir
+
+---Changes the directory to save the state to
+---@param directory string
+function pub.change_state_save_dir(directory)
+	pub.save_state_dir = directory
+	pub.fuzzy_loader.save_state_dir = directory
+end
+
+pub.change_state_save_dir(plugin_dir .. separator .. pub.get_require_path() .. separator .. "state" .. separator)
 
 function pub.set_max_nlines(max_nlines)
 	require("resurrect.pane_tree").max_nlines = max_nlines

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -47,6 +47,7 @@ pub.save_state_dir = plugin_dir .. separator .. pub.get_require_path() .. separa
 ---@param directory string
 function pub.change_state_save_dir(directory)
 	pub.save_state_dir = directory
+	pub.fuzzy_loader.save_state_dir = directory
 end
 
 ---@param file_name string
@@ -375,6 +376,7 @@ pub.workspace_state = require("resurrect.workspace_state")
 pub.window_state = require("resurrect.window_state")
 pub.tab_state = require("resurrect.tab_state")
 pub.fuzzy_loader = require("resurrect.fuzzy_loader")
+pub.fuzzy_loader.save_state_dir = pub.save_state_dir
 
 function pub.set_max_nlines(max_nlines)
 	require("resurrect.pane_tree").max_nlines = max_nlines

--- a/plugin/resurrect/fuzzy_loader.lua
+++ b/plugin/resurrect/fuzzy_loader.lua
@@ -1,0 +1,105 @@
+local wezterm = require("wezterm")
+local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm")
+local pub = {}
+
+---@alias fmt_fun fun(label: string): string
+---@alias fuzzy_load_opts {title: string, description: string, fuzzy_description: string, is_fuzzy: boolean, ignore_workspaces: boolean, ignore_tabs: boolean, ignore_windows: boolean, fmt_window: fmt_fun, fmt_workspace: fmt_fun, fmt_tab: fmt_fun }
+
+---Returns default fuzzy loading options
+---@return fuzzy_load_opts
+function pub.get_default_fuzzy_load_opts()
+	return {
+		title = "Load State",
+		description = "Select State to Load and press Enter = accept, Esc = cancel, / = filter",
+		fuzzy_description = "Search State to Load: ",
+		is_fuzzy = true,
+		ignore_workspaces = false,
+		ignore_windows = false,
+		ignore_tabs = false,
+		fmt_workspace = function(label)
+			return wezterm.format({
+				{ Foreground = { AnsiColor = "Green" } },
+				{ Text = "󱂬 : " .. label:gsub("%.json$", "") },
+			})
+		end,
+		fmt_window = function(label)
+			return wezterm.format({
+				{ Foreground = { AnsiColor = "Yellow" } },
+				{ Text = " : " .. label:gsub("%.json$", "") },
+			})
+		end,
+		fmt_tab = function(label)
+			return wezterm.format({
+				{ Foreground = { AnsiColor = "Red" } },
+				{ Text = "󰓩 : " .. label:gsub("%.json$", "") },
+			})
+		end,
+	}
+end
+
+---A fuzzy finder to restore saved state
+---@param window MuxWindow
+---@param pane Pane
+---@param callback fun(id: string, label: string, save_state_dir: string)
+---@param opts fuzzy_load_opts?
+function pub.fuzzy_load(window, pane, callback, opts)
+	wezterm.emit("resurrect.fuzzy_loader.fuzzy_load.start", window, pane)
+	local state_files = {}
+
+	if opts == nil then
+		opts = pub.get_default_fuzzy_load_opts()
+	else
+		-- Merge user opts with defaults
+		local default_opts = pub.get_default_fuzzy_load_opts()
+		for k, v in pairs(default_opts) do
+			if opts[k] == nil then
+				opts[k] = v
+			end
+		end
+	end
+
+	local function insert_choices(type, fmt)
+		for _, file in ipairs(wezterm.glob("*", resurrect.save_state_dir .. "/" .. type)) do
+			local label
+			local id = type .. "/" .. file
+
+			if fmt then
+				label = fmt(file)
+			else
+				label = file
+			end
+			table.insert(state_files, { id = id, label = label })
+		end
+	end
+
+	if not opts.ignore_workspaces then
+		insert_choices("workspace", opts.fmt_workspace)
+	end
+
+	if not opts.ignore_windows then
+		insert_choices("window", opts.fmt_window)
+	end
+
+	if not opts.ignore_tabs then
+		insert_choices("tab", opts.fmt_tab)
+	end
+
+	window:perform_action(
+		wezterm.action.InputSelector({
+			action = wezterm.action_callback(function(_, _, id, label)
+				if id and label then
+					callback(id, label, resurrect.save_state_dir)
+				end
+				wezterm.emit("resurrect.fuzzy_loader.fuzzy_load.finished", window, pane)
+			end),
+			title = opts.title,
+			description = opts.description,
+			fuzzy_description = opts.fuzzy_description,
+			choices = state_files,
+			fuzzy = opts.is_fuzzy,
+		}),
+		pane
+	)
+end
+
+return pub

--- a/plugin/resurrect/fuzzy_loader.lua
+++ b/plugin/resurrect/fuzzy_loader.lua
@@ -1,5 +1,4 @@
 local wezterm = require("wezterm")
-local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.wezterm")
 local pub = {}
 
 ---@alias fmt_fun fun(label: string): string
@@ -59,7 +58,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 	end
 
 	local function insert_choices(type, fmt)
-		for _, file in ipairs(wezterm.glob("*", resurrect.save_state_dir .. "/" .. type)) do
+		for _, file in ipairs(wezterm.glob("*", pub.save_state_dir .. "/" .. type)) do
 			local label
 			local id = type .. "/" .. file
 
@@ -88,7 +87,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 		wezterm.action.InputSelector({
 			action = wezterm.action_callback(function(_, _, id, label)
 				if id and label then
-					callback(id, label, resurrect.save_state_dir)
+					callback(id, label, pub.save_state_dir)
 				end
 				wezterm.emit("resurrect.fuzzy_loader.fuzzy_load.finished", window, pane)
 			end),


### PR DESCRIPTION
Moved fuzzy finder into fuzzy_loader.lua

### BREAKING CHANGES:
`fuzzy_load` has been placed into a submodule of resurrect, thus the function and the events now has the `fuzzy_loader.` prefix. 
```diff
- resurrect.fuzzy_load(window, pane, callback, opts)
+ resurrect.fuzzy_loader.fuzzy_load(window, pane, callback, opts)

- resurrect.fuzzy_load.start(window, pane)
+ resurrect.fuzzy_loader.fuzzy_load.start(window, pane)

- resurrect.fuzzy_load.finished(window, pane)
+ resurrect.fuzzy_loader.fuzzy_load.finished(window, pane)
```

To fix config on linux, you can run the following in your wezterm config directory:
```sh
find ./ -type f -exec sed -i 's/resurrect.fuzzy_load/resurrect.fuzzy_loader.fuzzy_load/g' {} +
find ./ -type f -exec sed -i 's/resurrect.start/resurrect.fuzzy_loader.start/g' {} +
find ./ -type f -exec sed -i 's/resurrect.finished/resurrect.fuzzy_loader.finished/g' {} +
```