### PR TITLE
92 move file readwrite logic from initlua to seperate file

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -1,7 +1,5 @@
 local wezterm = require("wezterm")
 
----@class init_module
----@field encryption encryption_opts
 local pub = {}
 
 local plugin_dir
@@ -19,11 +17,15 @@ end
 
 --- Returns the name of the package, used when requiring modules
 --- @return string
-function pub.get_require_path()
+local function get_require_path()
 	local path1 = "httpssCssZssZsgithubsDscomsZsMLFlexersZsresurrectsDswezterm"
 	local path2 = "httpssCssZssZsgithubsDscomsZsMLFlexersZsresurrectsDsweztermsZs"
 	return directory_exists(path2) and path2 or path1
 end
+
+require("resurrect.state_manager").change_state_save_dir(
+	plugin_dir .. separator .. get_require_path() .. separator .. "state" .. separator
+)
 
 --- adds the wezterm plugin directory to the lua path
 local function enable_sub_modules()
@@ -32,7 +34,7 @@ local function enable_sub_modules()
 		.. ";"
 		.. plugin_dir
 		.. separator
-		.. pub.get_require_path()
+		.. get_require_path()
 		.. separator
 		.. "plugin"
 		.. separator
@@ -41,247 +43,11 @@ end
 
 enable_sub_modules()
 
----@param file_name string
----@param type string
----@param opt_name string?
----@return string
-local function get_file_path(file_name, type, opt_name)
-	if opt_name then
-		file_name = opt_name
-	end
-	return string.format("%s%s" .. separator .. "%s.json", pub.save_state_dir, type, file_name:gsub(separator, "+"))
-end
-
---- Sanitize the input by replacing control characters and invalid UTF-8 sequences with valid \uxxxx unicode
---- @param data string
---- @return string
-local function sanitize_json(data)
-	wezterm.emit("resurrect.sanitize_json.start", data)
-	-- escapes control characters to ensure valid json
-	data = data:gsub("[\x00-\x1F]", function(c)
-		return string.format("\\u00%02X", string.byte(c))
-	end)
-	wezterm.emit("resurrect.sanitize_json.finished")
-	return data
-end
-
----@param file_path string
----@param state table
----@param event_type "workspace" | "window" | "tab"
-local function write_state(file_path, state, event_type)
-	wezterm.emit("resurrect.save_state.start", file_path, event_type)
-	local json_state = wezterm.json_encode(state)
-	json_state = sanitize_json(json_state)
-	if pub.encryption.enable then
-		wezterm.emit("resurrect.encrypt.start", file_path)
-		local ok, err = pcall(function()
-			return pub.encryption.encrypt(file_path, json_state)
-		end)
-		if not ok then
-			wezterm.emit("resurrect.error", "Encryption failed: " .. tostring(err))
-			wezterm.log_error("Decryption failed: " .. tostring(err))
-		else
-			wezterm.emit("resurrect.encrypt.finished", file_path)
-		end
-	else
-		local ok, err = pcall(function()
-			local file = assert(io.open(file_path, "w"))
-			file:write(json_state)
-			file:close()
-		end)
-		if not ok then
-			wezterm.emit("resurrect.error", "Failed to write state: " .. err)
-			wezterm.log_error("Failed to write state: " .. err)
-		end
-	end
-	wezterm.emit("resurrect.save_state.finished", file_path, event_type)
-end
-
----@param file_path string
----@return table|nil
-local function load_json(file_path)
-	local json
-	if pub.encryption.enable then
-		wezterm.emit("resurrect.decrypt.start", file_path)
-		local ok, output = pcall(function()
-			return pub.encryption.decrypt(file_path)
-		end)
-		if not ok then
-			wezterm.emit("resurrect.error", "Decryption failed: " .. tostring(output))
-			wezterm.log_error("Decryption failed: " .. tostring(output))
-		else
-			json = output
-			wezterm.emit("resurrect.decrypt.finished", file_path)
-		end
-	else
-		local lines = {}
-		for line in io.lines(file_path) do
-			table.insert(lines, line)
-		end
-		json = table.concat(lines)
-	end
-	if not json then
-		return nil
-	end
-	json = sanitize_json(json)
-
-	return wezterm.json_parse(json)
-end
-
----save state to a file
----@param state workspace_state | window_state | tab_state
----@param opt_name? string
-function pub.save_state(state, opt_name)
-	if state.window_states then
-		write_state(get_file_path(state.workspace, "workspace", opt_name), state, "workspace")
-	elseif state.tabs then
-		write_state(get_file_path(state.title, "window", opt_name), state, "window")
-	elseif state.pane_tree then
-		write_state(get_file_path(state.title, "tab", opt_name), state, "tab")
-	end
-end
-
----Reads a file with the state
----@param name string
----@param type string
----@return table
-function pub.load_state(name, type)
-	wezterm.emit("resurrect.load_state.start", name, type)
-	local json = load_json(get_file_path(name, type))
-	if not json then
-		wezterm.emit("resurrect.error", "Invalid json: " .. get_file_path(name, type))
-		return {}
-	end
-	wezterm.emit("resurrect.load_state.finished", name, type)
-	return json
-end
-
----Saves the stater after interval in seconds
----@param opts? { interval_seconds: integer?, save_workspaces: boolean?, save_windows: boolean?, save_tabs: boolean? }
-function pub.periodic_save(opts)
-	if opts == nil then
-		opts = { save_workspaces = true }
-	end
-	if opts.interval_seconds == nil then
-		opts.interval_seconds = 60 * 15
-	end
-	wezterm.time.call_after(opts.interval_seconds, function()
-		wezterm.emit("resurrect.periodic_save", opts)
-		if opts.save_workspaces then
-			pub.save_state(pub.workspace_state.get_workspace_state())
-		end
-
-		if opts.save_windows then
-			for _, gui_win in ipairs(wezterm.gui.gui_windows()) do
-				local mux_win = gui_win:mux_window()
-				local title = mux_win:get_title()
-				if title ~= "" and title ~= nil then
-					pub.save_state(pub.window_state.get_window_state(mux_win))
-				end
-			end
-		end
-
-		if opts.save_tabs then
-			for _, gui_win in ipairs(wezterm.gui.gui_windows()) do
-				local mux_win = gui_win:mux_window()
-				for _, mux_tab in ipairs(mux_win:tabs()) do
-					local title = mux_tab:get_title()
-					if title ~= "" and title ~= nil then
-						pub.save_state(pub.tab_state.get_tab_state(mux_tab))
-					end
-				end
-			end
-		end
-
-		pub.periodic_save(opts)
-	end)
-end
-
----Writes the current state name and type
----@param name string
----@param type string
----@return boolean
----@return string|nil
-function pub.write_current_state(name, type)
-	local file_path = pub.save_state_dir .. separator .. "current_state"
-	local suc, err = pcall(function()
-		local file = io.open(file_path, "w+")
-		if not file then
-			error("Could not open file: " .. file_path)
-		end
-		file:write(string.format("%s\n%s", name, type))
-		file:flush()
-		file:close()
-	end)
-	return suc, err
-end
-
----callback for resurrecting workspaces on startup
----@return boolean
----@return string|nil
-function pub.resurrect_on_gui_startup()
-	local file_path = pub.save_state_dir .. separator .. "current_state"
-	local suc, err = pcall(function()
-		local file = io.open(file_path, "r")
-		if not file then
-			error("Could not open file: " .. file_path)
-		end
-		local name = file:read("*line")
-		local type = file:read("*line")
-		file:close()
-		if type == "workspace" then
-			pub.workspace_state.restore_workspace(pub.load_state(name, type), {
-				spawn_in_workspace = true,
-				relative = true,
-				restore_text = true,
-				on_pane_restore = pub.tab_state.default_on_pane_restore,
-			})
-			wezterm.mux.set_active_workspace(name)
-		end
-	end)
-	return suc, err
-end
-
----@param file_path string
-function pub.delete_state(file_path)
-	wezterm.emit("resurrect.delete_state.start", file_path)
-	local path = pub.save_state_dir .. file_path
-	local success = os.remove(path)
-	if not success then
-		wezterm.emit("resurrect.error", "Failed to delete state: " .. path)
-		wezterm.log_error("Failed to delete state: " .. path)
-	end
-	wezterm.emit("resurrect.delete_state.finished", file_path)
-end
-
---- Merges user-supplied options with default options
---- @param user_opts encryption_opts
-function pub.set_encryption(user_opts)
-	for k, v in pairs(user_opts) do
-		if v ~= nil then
-			pub.encryption[k] = v
-		end
-	end
-end
-
 -- Export submodules
 pub.workspace_state = require("resurrect.workspace_state")
 pub.window_state = require("resurrect.window_state")
 pub.tab_state = require("resurrect.tab_state")
 pub.fuzzy_loader = require("resurrect.fuzzy_loader")
-pub.encryption = require("resurrect.encryption")
-
----Changes the directory to save the state to
----@param directory string
-function pub.change_state_save_dir(directory)
-	pub.save_state_dir = directory
-	pub.fuzzy_loader.save_state_dir = directory
-end
-
-pub.change_state_save_dir(plugin_dir .. separator .. pub.get_require_path() .. separator .. "state" .. separator)
-
-function pub.set_max_nlines(max_nlines)
-	require("resurrect.pane_tree").max_nlines = max_nlines
-end
+pub.state_manager = require("resurrect.state_manager")
 
 return pub

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -23,10 +23,6 @@ local function get_require_path()
 	return directory_exists(path2) and path2 or path1
 end
 
-require("resurrect.state_manager").change_state_save_dir(
-	plugin_dir .. separator .. get_require_path() .. separator .. "state" .. separator
-)
-
 --- adds the wezterm plugin directory to the lua path
 local function enable_sub_modules()
 	plugin_dir = wezterm.plugin.list()[1].plugin_dir:gsub(separator .. "[^" .. separator .. "]*$", "")
@@ -41,7 +37,15 @@ local function enable_sub_modules()
 		.. "?.lua"
 end
 
-enable_sub_modules()
+local function init()
+	enable_sub_modules()
+
+	require("resurrect.state_manager").change_state_save_dir(
+		plugin_dir .. separator .. get_require_path() .. separator .. "state" .. separator
+	)
+end
+
+init()
 
 -- Export submodules
 pub.workspace_state = require("resurrect.workspace_state")

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -43,15 +43,15 @@ local function init()
 	require("resurrect.state_manager").change_state_save_dir(
 		plugin_dir .. separator .. get_require_path() .. separator .. "state" .. separator
 	)
+
+	-- Export submodules
+	pub.workspace_state = require("resurrect.workspace_state")
+	pub.window_state = require("resurrect.window_state")
+	pub.tab_state = require("resurrect.tab_state")
+	pub.fuzzy_loader = require("resurrect.fuzzy_loader")
+	pub.state_manager = require("resurrect.state_manager")
 end
 
 init()
-
--- Export submodules
-pub.workspace_state = require("resurrect.workspace_state")
-pub.window_state = require("resurrect.window_state")
-pub.tab_state = require("resurrect.tab_state")
-pub.fuzzy_loader = require("resurrect.fuzzy_loader")
-pub.state_manager = require("resurrect.state_manager")
 
 return pub

--- a/plugin/resurrect/file_io.lua
+++ b/plugin/resurrect/file_io.lua
@@ -1,0 +1,94 @@
+local wezterm = require("wezterm")
+
+local pub = {
+	encryption = { enable = false },
+}
+
+--- Merges user-supplied options with default options
+--- @param user_opts encryption_opts
+function pub.set_encryption(user_opts)
+	pub.encryption = require("resurrect.encryption")
+	for k, v in pairs(user_opts) do
+		if v ~= nil then
+			pub.encryption[k] = v
+		end
+	end
+end
+
+--- Sanitize the input by replacing control characters and invalid UTF-8 sequences with valid \uxxxx unicode
+--- @param data string
+--- @return string
+local function sanitize_json(data)
+	wezterm.emit("resurrect.sanitize_json.start", data)
+	-- escapes control characters to ensure valid json
+	data = data:gsub("[\x00-\x1F]", function(c)
+		return string.format("\\u00%02X", string.byte(c))
+	end)
+	wezterm.emit("resurrect.sanitize_json.finished")
+	return data
+end
+
+---@param file_path string
+---@param state table
+---@param event_type "workspace" | "window" | "tab"
+function pub.write_state(file_path, state, event_type)
+	wezterm.emit("resurrect.save_state.start", file_path, event_type)
+	local json_state = wezterm.json_encode(state)
+	json_state = sanitize_json(json_state)
+	if pub.encryption.enable then
+		wezterm.emit("resurrect.encrypt.start", file_path)
+		local ok, err = pcall(function()
+			return pub.encryption.encrypt(file_path, json_state)
+		end)
+		if not ok then
+			wezterm.emit("resurrect.error", "Encryption failed: " .. tostring(err))
+			wezterm.log_error("Decryption failed: " .. tostring(err))
+		else
+			wezterm.emit("resurrect.encrypt.finished", file_path)
+		end
+	else
+		local ok, err = pcall(function()
+			local file = assert(io.open(file_path, "w"))
+			file:write(json_state)
+			file:close()
+		end)
+		if not ok then
+			wezterm.emit("resurrect.error", "Failed to write state: " .. err)
+			wezterm.log_error("Failed to write state: " .. err)
+		end
+	end
+	wezterm.emit("resurrect.save_state.finished", file_path, event_type)
+end
+
+---@param file_path string
+---@return table|nil
+function pub.load_json(file_path)
+	local json
+	if pub.encryption.enable then
+		wezterm.emit("resurrect.decrypt.start", file_path)
+		local ok, output = pcall(function()
+			return pub.encryption.decrypt(file_path)
+		end)
+		if not ok then
+			wezterm.emit("resurrect.error", "Decryption failed: " .. tostring(output))
+			wezterm.log_error("Decryption failed: " .. tostring(output))
+		else
+			json = output
+			wezterm.emit("resurrect.decrypt.finished", file_path)
+		end
+	else
+		local lines = {}
+		for line in io.lines(file_path) do
+			table.insert(lines, line)
+		end
+		json = table.concat(lines)
+	end
+	if not json then
+		return nil
+	end
+	json = sanitize_json(json)
+
+	return wezterm.json_parse(json)
+end
+
+return pub

--- a/plugin/resurrect/file_io.lua
+++ b/plugin/resurrect/file_io.lua
@@ -19,12 +19,12 @@ end
 --- @param data string
 --- @return string
 local function sanitize_json(data)
-	wezterm.emit("resurrect.sanitize_json.start", data)
+	wezterm.emit("resurrect.file_io.sanitize_json.start", data)
 	-- escapes control characters to ensure valid json
 	data = data:gsub("[\x00-\x1F]", function(c)
 		return string.format("\\u00%02X", string.byte(c))
 	end)
-	wezterm.emit("resurrect.sanitize_json.finished")
+	wezterm.emit("resurrect.file_io.sanitize_json.finished")
 	return data
 end
 
@@ -32,11 +32,11 @@ end
 ---@param state table
 ---@param event_type "workspace" | "window" | "tab"
 function pub.write_state(file_path, state, event_type)
-	wezterm.emit("resurrect.save_state.start", file_path, event_type)
+	wezterm.emit("resurrect.file_io.save_state.start", file_path, event_type)
 	local json_state = wezterm.json_encode(state)
 	json_state = sanitize_json(json_state)
 	if pub.encryption.enable then
-		wezterm.emit("resurrect.encrypt.start", file_path)
+		wezterm.emit("resurrect.file_io.encrypt.start", file_path)
 		local ok, err = pcall(function()
 			return pub.encryption.encrypt(file_path, json_state)
 		end)
@@ -44,7 +44,7 @@ function pub.write_state(file_path, state, event_type)
 			wezterm.emit("resurrect.error", "Encryption failed: " .. tostring(err))
 			wezterm.log_error("Decryption failed: " .. tostring(err))
 		else
-			wezterm.emit("resurrect.encrypt.finished", file_path)
+			wezterm.emit("resurrect.file_io.encrypt.finished", file_path)
 		end
 	else
 		local ok, err = pcall(function()
@@ -57,7 +57,7 @@ function pub.write_state(file_path, state, event_type)
 			wezterm.log_error("Failed to write state: " .. err)
 		end
 	end
-	wezterm.emit("resurrect.save_state.finished", file_path, event_type)
+	wezterm.emit("resurrect.file_io.save_state.finished", file_path, event_type)
 end
 
 ---@param file_path string
@@ -65,7 +65,7 @@ end
 function pub.load_json(file_path)
 	local json
 	if pub.encryption.enable then
-		wezterm.emit("resurrect.decrypt.start", file_path)
+		wezterm.emit("resurrect.file_io.decrypt.start", file_path)
 		local ok, output = pcall(function()
 			return pub.encryption.decrypt(file_path)
 		end)
@@ -74,7 +74,7 @@ function pub.load_json(file_path)
 			wezterm.log_error("Decryption failed: " .. tostring(output))
 		else
 			json = output
-			wezterm.emit("resurrect.decrypt.finished", file_path)
+			wezterm.emit("resurrect.file_io.decrypt.finished", file_path)
 		end
 	else
 		local lines = {}

--- a/plugin/resurrect/fuzzy_loader.lua
+++ b/plugin/resurrect/fuzzy_loader.lua
@@ -58,7 +58,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 	end
 
 	local function insert_choices(type, fmt)
-		for _, file in ipairs(wezterm.glob("*", pub.save_state_dir .. "/" .. type)) do
+		for _, file in ipairs(wezterm.glob("*", require("resurrect.state_manager").save_state_dir .. "/" .. type)) do
 			local label
 			local id = type .. "/" .. file
 
@@ -87,7 +87,7 @@ function pub.fuzzy_load(window, pane, callback, opts)
 		wezterm.action.InputSelector({
 			action = wezterm.action_callback(function(_, _, id, label)
 				if id and label then
-					callback(id, label, pub.save_state_dir)
+					callback(id, label, require("resurrect.state_manager").save_state_dir)
 				end
 				wezterm.emit("resurrect.fuzzy_loader.fuzzy_load.finished", window, pane)
 			end),

--- a/plugin/resurrect/state_manager.lua
+++ b/plugin/resurrect/state_manager.lua
@@ -1,0 +1,163 @@
+local wezterm = require("wezterm")
+local file_io = require("resurrect.file_io")
+
+local pub = {}
+
+--- checks if the user is on windows
+local is_windows = wezterm.target_triple == "x86_64-pc-windows-msvc"
+local separator = is_windows and "\\" or "/"
+
+---@param file_name string
+---@param type string
+---@param opt_name string?
+---@return string
+local function get_file_path(file_name, type, opt_name)
+	if opt_name then
+		file_name = opt_name
+	end
+	return string.format("%s%s" .. separator .. "%s.json", pub.save_state_dir, type, file_name:gsub(separator, "+"))
+end
+
+---save state to a file
+---@param state workspace_state | window_state | tab_state
+---@param opt_name? string
+function pub.save_state(state, opt_name)
+	if state.window_states then
+		file_io.write_state(get_file_path(state.workspace, "workspace", opt_name), state, "workspace")
+	elseif state.tabs then
+		file_io.write_state(get_file_path(state.title, "window", opt_name), state, "window")
+	elseif state.pane_tree then
+		file_io.write_state(get_file_path(state.title, "tab", opt_name), state, "tab")
+	end
+end
+
+---Reads a file with the state
+---@param name string
+---@param type string
+---@return table
+function pub.load_state(name, type)
+	wezterm.emit("resurrect.load_state.start", name, type)
+	local json = file_io.load_json(get_file_path(name, type))
+	if not json then
+		wezterm.emit("resurrect.error", "Invalid json: " .. get_file_path(name, type))
+		return {}
+	end
+	wezterm.emit("resurrect.load_state.finished", name, type)
+	return json
+end
+
+---Saves the stater after interval in seconds
+---@param opts? { interval_seconds: integer?, save_workspaces: boolean?, save_windows: boolean?, save_tabs: boolean? }
+function pub.periodic_save(opts)
+	if opts == nil then
+		opts = { save_workspaces = true }
+	end
+	if opts.interval_seconds == nil then
+		opts.interval_seconds = 60 * 15
+	end
+	wezterm.time.call_after(opts.interval_seconds, function()
+		wezterm.emit("resurrect.periodic_save", opts)
+		if opts.save_workspaces then
+			pub.save_state(require("resurrect.workspace_state").get_workspace_state())
+		end
+
+		if opts.save_windows then
+			for _, gui_win in ipairs(wezterm.gui.gui_windows()) do
+				local mux_win = gui_win:mux_window()
+				local title = mux_win:get_title()
+				if title ~= "" and title ~= nil then
+					pub.save_state(require("resurrect.window_state").get_window_state(mux_win))
+				end
+			end
+		end
+
+		if opts.save_tabs then
+			for _, gui_win in ipairs(wezterm.gui.gui_windows()) do
+				local mux_win = gui_win:mux_window()
+				for _, mux_tab in ipairs(mux_win:tabs()) do
+					local title = mux_tab:get_title()
+					if title ~= "" and title ~= nil then
+						pub.save_state(require("resurrect.tab_state").get_tab_state(mux_tab))
+					end
+				end
+			end
+		end
+
+		pub.periodic_save(opts)
+	end)
+end
+
+---Writes the current state name and type
+---@param name string
+---@param type string
+---@return boolean
+---@return string|nil
+function pub.write_current_state(name, type)
+	local file_path = pub.save_state_dir .. separator .. "current_state"
+	local suc, err = pcall(function()
+		local file = io.open(file_path, "w+")
+		if not file then
+			error("Could not open file: " .. file_path)
+		end
+		file:write(string.format("%s\n%s", name, type))
+		file:flush()
+		file:close()
+	end)
+	return suc, err
+end
+
+---callback for resurrecting workspaces on startup
+---@return boolean
+---@return string|nil
+function pub.resurrect_on_gui_startup()
+	local file_path = pub.save_state_dir .. separator .. "current_state"
+	local suc, err = pcall(function()
+		local file = io.open(file_path, "r")
+		if not file then
+			error("Could not open file: " .. file_path)
+		end
+		local name = file:read("*line")
+		local type = file:read("*line")
+		file:close()
+		if type == "workspace" then
+			require("resurrect.workspace_state").restore_workspace(pub.load_state(name, type), {
+				spawn_in_workspace = true,
+				relative = true,
+				restore_text = true,
+				on_pane_restore = require("resurrect.tab_state").default_on_pane_restore,
+			})
+			wezterm.mux.set_active_workspace(name)
+		end
+	end)
+	return suc, err
+end
+
+---@param file_path string
+function pub.delete_state(file_path)
+	wezterm.emit("resurrect.delete_state.start", file_path)
+	local path = pub.save_state_dir .. file_path
+	local success = os.remove(path)
+	if not success then
+		wezterm.emit("resurrect.error", "Failed to delete state: " .. path)
+		wezterm.log_error("Failed to delete state: " .. path)
+	end
+	wezterm.emit("resurrect.delete_state.finished", file_path)
+end
+
+--- Merges user-supplied options with default options
+--- @param user_opts encryption_opts
+function pub.set_encryption(user_opts)
+	require("resurrect.file_io").set_encryption(user_opts)
+end
+
+---Changes the directory to save the state to
+---@param directory string
+function pub.change_state_save_dir(directory)
+	pub.save_state_dir = directory
+end
+
+function pub.set_max_nlines(max_nlines)
+	require("resurrect.pane_tree").max_nlines = max_nlines
+end
+
+return pub

--- a/plugin/resurrect/state_manager.lua
+++ b/plugin/resurrect/state_manager.lua
@@ -36,13 +36,13 @@ end
 ---@param type string
 ---@return table
 function pub.load_state(name, type)
-	wezterm.emit("resurrect.load_state.start", name, type)
+	wezterm.emit("resurrect.state_manager.load_state.start", name, type)
 	local json = file_io.load_json(get_file_path(name, type))
 	if not json then
 		wezterm.emit("resurrect.error", "Invalid json: " .. get_file_path(name, type))
 		return {}
 	end
-	wezterm.emit("resurrect.load_state.finished", name, type)
+	wezterm.emit("resurrect.state_manager.load_state.finished", name, type)
 	return json
 end
 
@@ -56,7 +56,7 @@ function pub.periodic_save(opts)
 		opts.interval_seconds = 60 * 15
 	end
 	wezterm.time.call_after(opts.interval_seconds, function()
-		wezterm.emit("resurrect.periodic_save", opts)
+		wezterm.emit("resurrect.state_manager.periodic_save", opts)
 		if opts.save_workspaces then
 			pub.save_state(require("resurrect.workspace_state").get_workspace_state())
 		end
@@ -134,14 +134,14 @@ end
 
 ---@param file_path string
 function pub.delete_state(file_path)
-	wezterm.emit("resurrect.delete_state.start", file_path)
+	wezterm.emit("resurrect.state_manager.delete_state.start", file_path)
 	local path = pub.save_state_dir .. file_path
 	local success = os.remove(path)
 	if not success then
 		wezterm.emit("resurrect.error", "Failed to delete state: " .. path)
 		wezterm.log_error("Failed to delete state: " .. path)
 	end
-	wezterm.emit("resurrect.delete_state.finished", file_path)
+	wezterm.emit("resurrect.state_manager.delete_state.finished", file_path)
 end
 
 --- Merges user-supplied options with default options


### PR DESCRIPTION
Adds 2 files `file_io.lua` and `state_manager.lua` which contains logic for reading/writing state.

This results in a lot of breaking changes...
### BREAKING CHANGES
The following functions and emits have changed scope:
#### Functions
```diff
- resurrect.save_state(state)
+ resurrect.state_manager.save_state(state)

- resurrect.load_state(name, type)
+ resurrect.state_manager.load_state(name, type)

- resurrect.delete_state(name)
+ resurrect.state_manager.delete_state(name)

- resurrect.set_encryption(encryption_opts)
+ resurrect.state_manager.set_encryption(encryption_opts)

- resurrect.periodic_save(opts?)
+ resurrect.state_manager.periodic_save(opts?)

- resurrect.resurrect_on_gui_startup()
+ resurrect.state_manager.resurrect_on_gui_startup()

- resurrect.write_current_state(name, type)
+ resurrect.state_manager.write_current_state(name, type)

- resurrect.set_max_nlines(number)
+ resurrect.state_manager.set_max_nlines(number)

- resurrect.change_state_save_dir(string)
+ resurrect.state_manager.change_state_save_dir(string)
```
#### Emits
```diff
- resurrect.decrypt.finished(file_path)
- resurrect.decrypt.start(file_path)
- resurrect.encrypt.finished(file_path)
- resurrect.encrypt.start(file_path)
- resurrect.sanitize_json.finished(data)
- resurrect.sanitize_json.start(data)
+ resurrect.file_io.decrypt.finished(file_path)
+ resurrect.file_io.decrypt.start(file_path)
+ resurrect.file_io.encrypt.finished(file_path)
+ resurrect.file_io.encrypt.start(file_path)
+ resurrect.file_io.sanitize_json.finished(data)
+ resurrect.file_io.sanitize_json.start(data)

- resurrect.fuzzy_load.finished(window, pane)
- resurrect.fuzzy_load.start(window, pane)
+ resurrect.fuzzy_loader.fuzzy_load.finished(window, pane)
+ resurrect.fuzzy_loader.fuzzy_load.start(window, pane)

- resurrect.delete_state.finished(file_path)
- resurrect.delete_state.start(file_path)
- resurrect.load_state.finished(name, type)
- resurrect.load_state.start(name, type)
- resurrect.periodic_save(opts)
- resurrect.save_state.finished(file_path, event_type)
- resurrect.save_state.start(file_path, event_type)
+ resurrect.state_manager.delete_state.finished(file_path)
+ resurrect.state_manager.delete_state.start(file_path)
+ resurrect.state_manager.load_state.finished(name, type)
+ resurrect.state_manager.load_state.start(name, type)
+ resurrect.state_manager.periodic_save(opts)
+ resurrect.state_manager.save_state.finished(file_path, event_type)
+ resurrect.state_manager.save_state.start(file_path, event_type)
```

To help convert config:
```sh
find ./ -type f -exec sed -i 's/resurrect.delete_state/resurrect.state_manager.delete_state/g' {} +
find ./ -type f -exec sed -i 's/resurrect.set_max_nlines/resurrect.state_manager.set_max_nlines/g' {} +
find ./ -type f -exec sed -i 's/resurrect.change_state_save_dir/resurrect.state_manager.change_state_save_dir/g' {} +
find ./ -type f -exec sed -i 's/resurrect.decrypt.finished/resurrect.file_io.decrypt.finished/g' {} +
find ./ -type f -exec sed -i 's/resurrect.decrypt.start/resurrect.file_io.decrypt.start/g' {} +
find ./ -type f -exec sed -i 's/resurrect.encrypt.finished/resurrect.file_io.encrypt.finished/g' {} +
find ./ -type f -exec sed -i 's/resurrect.encrypt.start/resurrect.file_io.encrypt.start/g' {} +
find ./ -type f -exec sed -i 's/resurrect.sanitize_json.finished/resurrect.file_io.sanitize_json.finished/g' {} +
find ./ -type f -exec sed -i 's/resurrect.sanitize_json.start/resurrect.file_io.sanitize_json.start/g' {} +
find ./ -type f -exec sed -i 's/resurrect.fuzzy_load.finished/resurrect.fuzzy_loader.fuzzy_load.finished/g' {} +
find ./ -type f -exec sed -i 's/resurrect.fuzzy_load.start/resurrect.fuzzy_loader.fuzzy_load.start/g' {} +
find ./ -type f -exec sed -i 's/resurrect.load_state/resurrect.state_manager.load_state/g' {} +
find ./ -type f -exec sed -i 's/resurrect.periodic_save/resurrect.state_manager.periodic_save/g' {} +
find ./ -type f -exec sed -i 's/resurrect.set_encryption/resurrect.state_manager.set_encryption/g' {} +
find ./ -type f -exec sed -i 's/resurrect.resurrect_on_gui_startup/resurrect.state_manager.resurrect_on_gui_startup/g' {} +
find ./ -type f -exec sed -i 's/resurrect.save_state/resurrect.state_manager.save_state/g' {} +
find ./ -type f -exec sed -i 's/resurrect.write_current_state/resurrect.state_manager.write_current_state/g' {} +
```