### PR TITLE
99 tab staterestore tab is not restoring all the splits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+state/current_state.txt
 # Compiled Lua sources
 luac.out
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Options for restoring state:
 relative: boolean?, -- Use relative size when restoring panes
 absolute: boolean?, -- Use absolute size when restoring panes
 close_open_tabs: boolean?, -- Closes all tabs which are open in the window, only restored tabs are left
+close_open_panes: boolean?, -- Closes all panes which are open in the tab, only keeping the panes to be restored
 pane: Pane?, -- Restore in this window
 tab: MuxTab?, -- Restore in this window
 window: MuxWindow, -- Restore in this window

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -77,6 +77,20 @@ function pub.get_tab_state(tab)
 	return tab_state
 end
 
+---Force closes all other tabs in the window but one
+---@param tab MuxTab
+---@param pane_to_keep Pane
+local function close_all_other_panes(tab, pane_to_keep)
+	for _, pane in ipairs(tab:panes()) do
+		if pane:pane_id() ~= pane_to_keep:pane_id() then
+			pane:activate()
+			tab:window()
+				:gui_window()
+				:perform_action(wezterm.action.CloseCurrentPane({ confirm = false }), pane)
+		end
+	end
+end
+
 ---restore a tab
 ---@param tab MuxTab
 ---@param tab_state tab_state
@@ -86,7 +100,16 @@ function pub.restore_tab(tab, tab_state, opts)
 	if opts.pane then
 		tab_state.pane_tree.pane = opts.pane
 	else
-		tab_state.pane_tree.pane = tab:active_pane()
+		local split_args = { cwd = tab_state.pane_tree.cwd }
+		if tab_state.pane_tree.domain then
+				split_args.domain = { DomainName = tab_state.pane_tree.domain }
+			end
+			local new_pane = tab:active_pane():split(split_args)
+			tab_state.pane_tree.pane = new_pane
+	end
+
+	if opts.close_open_panes then
+			close_all_other_panes(tab, tab_state.pane_tree.pane)
 	end
 
 	if tab_state.title then

--- a/plugin/types.lua
+++ b/plugin/types.lua
@@ -5,4 +5,4 @@
 ---@alias MuxTab any
 ---@alias MuxWindow any
 
----@alias restore_opts {spawn_in_workspace: boolean?, relative: boolean?, absolute: boolean?, close_open_tabs: boolean?, pane: Pane?, tab: MuxTab?, window: MuxWindow, resize_window: boolean?, on_pane_restore: fun(pane_tree: pane_tree)}
+---@alias restore_opts {spawn_in_workspace: boolean?, relative: boolean?, absolute: boolean?, close_open_tabs: boolean?, close_open_panes: boolean?, pane: Pane?, tab: MuxTab?, window: MuxWindow, resize_window: boolean?, on_pane_restore: fun(pane_tree: pane_tree)}


### PR DESCRIPTION
adds option to close all other panes in the tab, before restoring. This will ensure that only the panes related to the restoring state of the tabs will be visible with the correct cwd for all panes.