### PR TITLE
fix: restore same window would create new root pane on "close_open_panes"

### DIFF
--- a/plugin/resurrect/workspace_state.lua
+++ b/plugin/resurrect/workspace_state.lua
@@ -22,7 +22,9 @@ function pub.restore_workspace(workspace_state, opts)
 				opts.window:gui_window():set_inner_size(window_state.size.pixel_width, window_state.size.pixel_height)
 			end
 			opts.tab = opts.window:active_tab()
-			opts.pane = opts.window:active_pane()
+			if not opts.close_open_panes then
+				opts.pane = opts.window:active_pane()
+			end
 		else
 			local spawn_window_args = {
 				width = window_state.size.cols,


### PR DESCRIPTION
## What
Currently on restoring workspace on same windows & close open panes, the current active pane wouldn't spawn correctly with previous state. This PR would un-assign the current active pane from opts on restoring and let tab state handles the pane split.

## Example
On previous behaviour, when I save a workspace with a tab and 2 panels side by side, restoring workspace wouldn't restore the left side pane if it is currently the active ones.