### PR TITLE
Fix first tab on window not setting its cwd

### DIFF
--- a/plugin/resurrect/workspace_state.lua
+++ b/plugin/resurrect/workspace_state.lua
@@ -22,9 +22,11 @@ function pub.restore_workspace(workspace_state, opts)
 			if opts.resize_window == true or opts.resize_window == nil then
 				opts.window:gui_window():set_inner_size(window_state.size.pixel_width, window_state.size.pixel_height)
 			end
-			opts.tab = opts.window:active_tab()
-			if not opts.close_open_panes then
-				opts.pane = opts.window:active_pane()
+			if not opts.close_open_tabs then
+				opts.tab = opts.window:active_tab()
+				if not opts.close_open_panes then
+					opts.pane = opts.window:active_pane()
+				end
 			end
 		else
 			local spawn_window_args = {


### PR DESCRIPTION
As I understood it, the plugin saves the active pane only if the close_open_panes option is set, but it saves the active tab even if close_open_tabs is set, so that when the tabs are restored it remains open, which made it keep its working directory. This change makes it open a new tab and then close the current one if close_open_tabs is set because then opts.tab will not be set.

Sorry for the first PR, I used the wrong branch.