### PR TITLE
Fix workspace name when restoring a workspace

### DIFF
--- a/plugin/resurrect/workspace_state.lua
+++ b/plugin/resurrect/workspace_state.lua
@@ -42,6 +42,11 @@ function pub.restore_workspace(workspace_state, opts)
 
 		window_state_mod.restore_window(opts.window, window_state, opts)
 	end
+	if opts.spawn_in_workspace then
+		wezterm.mux.set_active_workspace(workspace_state.workspace)
+	else
+		wezterm.mux.rename_workspace(wezterm.mux.get_active_workspace(), workspace_state.workspace)
+	end
 	wezterm.emit("resurrect.workspace_state.restore_workspace.finished")
 end
 


### PR DESCRIPTION
Hello and thanks for this plugin !

Currently when restoring a workspace, it restores the state (tabs/panes/processes) without restoring the workspace name ( hence we are still on default workspace and in the spawned window, no traces of the name of restored worspace)

This PR shall fix this:
- When opts.spawn_in_workspace is true -> add the restored workspace to the current instance of wezterm and switch to it
- When opts.spawn_in_workspace is false -> spawn a new instance with the restored workspace's state + rename it accordingly so we can continue editing the same workspace (instead of manually renaming it).



Fixes #114 