### PR TITLE
Fix/module resurrect not found

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -11,7 +11,7 @@ local function init()
 	-- enable_sub_modules()
 	local opts = {
 		auto = true,
-		keywords = { "github", "MLFlexer", "resurrect", "wezterm" },
+		keywords = { "github", "userux", "resurrect", "wezterm" },
 	}
 	local plugin_path = dev.setup(opts)
 

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -11,7 +11,7 @@ local function init()
 	-- enable_sub_modules()
 	local opts = {
 		auto = true,
-		keywords = { "github", "userux", "resurrect", "wezterm" },
+		keywords = { "github", "MLFlexer", "resurrect", "wezterm" },
 	}
 	local plugin_path = dev.setup(opts)
 

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -1,5 +1,6 @@
 local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
 local pane_tree_mod = require("resurrect.pane_tree")
+local state_manager_mod = require("resurrect.state_manager")
 local pub = {}
 
 ---Function used to split panes when mapping over the pane_tree
@@ -121,7 +122,6 @@ end
 
 function pub.save_tab_action()
 	return wezterm.action_callback(function(win, pane)
-		local resurrect = require("resurrect")
 		local tab = pane:tab()
 		if tab:get_title() == "" then
 			win:perform_action(
@@ -131,7 +131,7 @@ function pub.save_tab_action()
 						if title then
 							callback_pane:tab():set_title(title)
 							local state = pub.get_tab_state(tab)
-							resurrect.save_state(state)
+							state_manager_mod.save_state(state)
 						end
 					end),
 				}),
@@ -139,7 +139,7 @@ function pub.save_tab_action()
 			)
 		elseif tab:get_title() then
 			local state = pub.get_tab_state(tab)
-			resurrect.state_manager.save_state(state)
+			state_manager_mod.save_state(state)
 		end
 	end)
 end

--- a/plugin/resurrect/window_state.lua
+++ b/plugin/resurrect/window_state.lua
@@ -1,6 +1,8 @@
 local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
 local tab_state_mod = require("resurrect.tab_state")
+local state_manager_mod = require("resurrect.state_manager")
 local pub = {}
+
 
 ---Returns the state of the window
 ---@param window MuxWindow
@@ -95,7 +97,7 @@ function pub.save_window_action()
 						if title then
 							window:mux_window():set_title(title)
 							local state = pub.get_window_state(mux_win)
-							resurrect.save_state(state)
+							state_manager_mod.save_state(state)
 						end
 					end),
 				}),
@@ -103,7 +105,7 @@ function pub.save_window_action()
 			)
 		elseif mux_win:get_title() then
 			local state = pub.get_window_state(mux_win)
-			resurrect.save_state(state)
+			state_manager_mod.save_state(state)
 		end
 	end)
 end


### PR DESCRIPTION
local resurrect = require("resurrect") in plugin/resurrect/state_manager.lua not importing correct module. 
I changed it to local state_manager_mod = require("resurrect.state_manager").

should fix #117 and #119