### PR TITLE
fix(pane_tree): prevent nil pane access in symmetric layouts

### DIFF
--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -75,6 +75,13 @@ local function insert_panes(root, panes)
 		return nil
 	end
 
+	-- Guard against duplicate processing in symmetric layouts
+	-- In a perfect cross layout, a pane can appear in both right and bottom branches
+	-- If already processed by another branch, skip to avoid nil pane access
+	if root.pane == nil then
+		return root
+	end
+
 	local domain = root.pane:get_domain_name()
 	if not wezterm.mux.get_domain(domain):is_spawnable() then
 		wezterm.log_warn("Domain " .. domain .. " is not spawnable")


### PR DESCRIPTION
## Summary
Fixes #98 - Resolves nil pane access error that occurs during workspace switching with symmetric pane layouts

## Problem
When saving workspace state with symmetric pane layouts (e.g., 2x2 grid or perfect cross layout), the following error occurs:

attempt to index a nil value (field 'pane')
at pane_tree.lua:85 in root.pane:get_domain_name()

### Root Cause
In the recursive `insert_panes()` function, symmetric pane layouts can cause the same pane node to be encountered multiple times through different branches:

1. A pane is processed through one branch (e.g., right branch)
2. After processing, `root.pane` is set to `nil` (line 122) to avoid memory leaks
3. The same pane node is encountered again through another branch (e.g., bottom branch)
4. Attempting to call `root.pane:get_domain_name()` on the already-nil pane causes the crash

This happens because in symmetric layouts, a pane can satisfy both `is_right()` and `is_bottom()` conditions from the same parent node, causing it to appear in both branch collections.