### PR TITLE
Fix #125

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -11,7 +11,7 @@ local function init()
 	-- enable_sub_modules()
 	local opts = {
 		auto = true,
-		keywords = { "github", "MLFlexer", "resurrect", "wezterm" },
+		keywords = { "resurrect", "wezterm" },
 	}
 	local plugin_path = dev.setup(opts)
 


### PR DESCRIPTION
Replacing `utils.ensure_folder_exists` with a version not using `os.execute` but `io.open` and `os.remove` on a tmp file as suggested by https://github.com/azinsharaf in https://github.com/MLFlexer/resurrect.wezterm/issues/125#issuecomment-3503894459 hopefully fixing https://github.com/MLFlexer/resurrect.wezterm/issues/125 for all.

To get it working in a local dev env I had to also remove `"github"` hostname and user from `plugin/init.lua` `keywords` in `opts` for call to plugin dev.wezterm's `dev.setup(opts)` - cf https://github.com/ChrisGVE/dev.wezterm/issues/1 . If you want to me to keep that commit out of this PR let me know and I'll remove it.