### PR TITLE
feat(shell): add api.lua module for WezTerm data extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ luac.out
 *.x86_64
 *.hex
 
+.lua-check-logs/

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,45 @@
+-- Luacheck configuration
+globals = {
+    "describe",
+    "it",
+    "before",
+    "after",
+    "expect",
+    "wezterm",
+    "mux",
+    "_",  -- Lua convention for unused loop variable
+}
+
+-- Ignore certain warnings globally
+ignore = {
+    "212",  -- unused argument
+}
+
+max_line_length = 120
+
+-- Type definition files are stubs that define types for LuaLS
+-- The variables are used as type annotations, not accessed at runtime
+files["**/types/*.lua"] = {
+    ignore = {
+        "311",  -- value assigned is overwritten
+        "211",  -- unused variable (type stubs)
+    },
+}
+
+-- Test spec files can have unused variables for setup
+files["**/spec/*.lua"] = {
+    ignore = { "211" },  -- unused variable
+}
+
+-- Test fakes may have variables used for state tracking
+files["**/fakes/*.lua"] = {
+    ignore = {
+        "311",  -- value assigned is overwritten
+        "211",  -- unused variable
+    },
+}
+
+-- Test utility files
+files["**/test_*.lua"] = {
+    ignore = { "211" },  -- unused variable
+}

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,10 +1,20 @@
 {
-  "Lua": {
-    "runtime": {
-      "version": "Lua 5.4"
-    },
-    "workspace": {
-      "checkThirdParty": false
-    }
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+  "runtime": {
+    "version": "Lua 5.4",
+    "path": ["?.lua", "?/init.lua", "plugin/?.lua", "plugin/?/init.lua"]
+  },
+  "workspace": {
+    "library": ["plugin/resurrect/types"],
+    "checkThirdParty": false,
+    "ignoreDir": ["test", "**/test", "**/test/**", "plugin/resurrect/test"]
+  },
+  "diagnostics": {
+    "globals": [],
+    "disable": ["lowercase-global", "need-check-nil"],
+    "ignoredFiles": "Opened"
+  },
+  "type": {
+    "castNumberToInteger": true
   }
 }

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,9 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Tabs"
+indent_width = 4
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"
+
+[sort_requires]
+enabled = false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-verbose check lint all clean help
+.PHONY: test test-verbose check lint fix all clean help
 
 help:
 	@echo "Available targets:"
@@ -6,7 +6,8 @@ help:
 	@echo "  make test-verbose - Run tests with verbose output"
 	@echo "  make check        - Run type check with LuaLS"
 	@echo "  make lint         - Run linter with luacheck"
-	@echo "  make all          - Run all checks (lint, check, test)"
+	@echo "  make fix          - Format code with stylua"
+	@echo "  make all          - Run all checks (fix, lint, check, test)"
 	@echo "  make clean        - Clean generated files"
 	@echo "  make help         - Show this help"
 
@@ -26,11 +27,17 @@ check:
 # Lint with luacheck
 lint:
 	@echo "Running linter..."
-	@luacheck plugin/resurrect --no-unused-args --max-line-length=120
+	@luacheck plugin/resurrect --no-unused-args --max-line-length=120 --exclude-files="**/test/lib/**" --exclude-files="**/types/**"
 	@echo "Lint passed"
 
+# Format with stylua
+fix:
+	@echo "Formatting code..."
+	@stylua plugin/ -g "*.lua" -g "!**/test/lib/**"
+	@echo "Formatting complete"
+
 # Run all checks
-all: lint check test
+all: fix lint check test
 	@echo "All checks passed"
 
 # Clean generated files

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,38 @@
-.PHONY: test test-verbose help
+.PHONY: test test-verbose check lint all clean help
 
 help:
 	@echo "Available targets:"
 	@echo "  make test         - Run all tests"
 	@echo "  make test-verbose - Run tests with verbose output"
+	@echo "  make check        - Run type check with LuaLS"
+	@echo "  make lint         - Run linter with luacheck"
+	@echo "  make all          - Run all checks (lint, check, test)"
+	@echo "  make clean        - Clean generated files"
 	@echo "  make help         - Show this help"
 
+# Run tests
 test:
 	@lua plugin/resurrect/test/init.lua
 
 test-verbose:
 	@lua plugin/resurrect/test/init.lua --verbose
+
+# Type check with LuaLS (excluding test directory)
+check:
+	@echo "Running type check..."
+	@lua-language-server --check . --checklevel=Warning --logpath=.lua-check-logs
+	@echo "Type check passed"
+
+# Lint with luacheck
+lint:
+	@echo "Running linter..."
+	@luacheck plugin/resurrect --no-unused-args --max-line-length=120
+	@echo "Lint passed"
+
+# Run all checks
+all: lint check test
+	@echo "All checks passed"
+
+# Clean generated files
+clean:
+	@rm -rf .lua-check-logs

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: test test-verbose help
+
+help:
+	@echo "Available targets:"
+	@echo "  make test         - Run all tests"
+	@echo "  make test-verbose - Run tests with verbose output"
+	@echo "  make help         - Show this help"
+
+test:
+	@lua plugin/resurrect/test/init.lua
+
+test-verbose:
+	@lua plugin/resurrect/test/init.lua --verbose

--- a/REFACTORING_PLAN.md
+++ b/REFACTORING_PLAN.md
@@ -1,0 +1,475 @@
+# Resurrect.wezterm Refactoring Plan
+
+## Goal
+Separate **functional core** (pure, testable) from **imperative shell** (I/O, WezTerm API).
+
+## Constraints
+
+- **Pure refactor**: No functionality changes
+- **Preserve events**: They are documented public API
+- **Tests must pass**: All 151 tests + type checks + lint at each step
+- **Type safety**: Maintain strict LuaLS type annotations
+
+---
+
+## Current Infrastructure
+
+### Quality Gates (must pass at each step)
+```bash
+make all  # Runs: fix → lint → check → test
+```
+
+| Gate | Tool | Config |
+|------|------|--------|
+| Format | stylua | Default |
+| Lint | luacheck | `.luacheckrc` |
+| Types | lua-language-server | `.luarc.json` |
+| Tests | lust | `make test` |
+
+### Type Definitions
+```
+plugin/resurrect/types/
+├── wezterm.lua    # WezTerm API stubs (Pane, MuxTab, MuxWindow, etc.)
+├── mux.lua        # Mux domain types
+└── resurrect.lua  # Internal types (WorkspaceState, PaneTree, RestoreOptions, etc.)
+```
+
+Key types already defined:
+- `WorkspaceState`, `WindowState`, `TabState`, `PaneTree`
+- `RestoreOptions`, `SplitCommand`
+- `RawPaneData` (for extracted pane data - ready for Phase 2)
+
+---
+
+## Current Architecture (Problem)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Everything mixed: API calls + logic + I/O + events in same fn  │
+│                                                                 │
+│  workspace_state ──► window_state ──► tab_state ──► pane_tree  │
+│       ↓                   ↓              ↓             ↓        │
+│   wezterm.mux        wezterm.mux    wezterm.mux   pane:get_*()  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Current Pure vs Impure Analysis
+
+| File | Pure Functions | Impure (WezTerm API) |
+|------|---------------|---------------------|
+| `pane_tree.lua` | `compare_pane_by_coord`, `is_right`, `is_bottom`, `pop_connected_*`, `map`, `fold` | `insert_panes` (main problem) |
+| `state_manager.lua` | `sanitize_filename` ✓ | `save_state`, `load_state`, `periodic_save` |
+| `tab_state.lua` | `make_splits` (partial) | `get_tab_state`, `restore_tab` |
+| `window_state.lua` | - | All impure |
+| `workspace_state.lua` | - | All impure |
+| `file_io.lua` | `sanitize_json` | `write_file`, `read_file`, `load_json` |
+
+---
+
+## Target Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      IMPERATIVE SHELL                            │
+│            (WezTerm API, File I/O, Events, UI)                  │
+├─────────────────────────────────────────────────────────────────┤
+│  ┌─────────────┐    ┌──────────────────────────────────────┐    │
+│  │  init.lua   │    │  shell/api.lua                       │    │
+│  │  (entry)    │    │  - extract_pane(), extract_tab()     │    │
+│  └─────────────┘    │  - extract_window(), get_workspace() │    │
+│                     └──────────────────────────────────────┘    │
+│                                    │                            │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │  shell/io.lua                                            │   │
+│  │  - Workflow orchestration (capture → save, load → restore)│  │
+│  │  - File I/O, Event emission, Fuzzy loader UI             │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                                    │                            │
+└────────────────────────────────────┼────────────────────────────┘
+                                     │
+                                     ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                      FUNCTIONAL CORE                             │
+│         (Pure functions, no side effects, no wezterm require)   │
+├─────────────────────────────────────────────────────────────────┤
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │  core/pane_tree.lua                                      │   │
+│  │  - build(raw_panes) → tree, warnings                     │   │
+│  │  - map(tree, fn), fold(tree, init, fn)                   │   │
+│  │  - plan_splits(tree) → SplitCommand[]                    │   │
+│  │  - sanitize_filename(name) → safe_name                   │   │
+│  │  - build_workspace/window/tab(raw_data) → state          │   │
+│  └──────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Refactoring Phases
+
+### Phase 1: Create `shell/api.lua` (HIGHEST PRIORITY)
+
+**Goal**: Extract WezTerm API calls from tree building.
+
+**Create** `plugin/resurrect/shell/api.lua`:
+```lua
+local wezterm = require("wezterm")
+
+---@class ShellApi
+local M = {}
+
+---Extract raw data from a WezTerm pane (IMPURE - all API calls here)
+---@param pane Pane
+---@param max_lines number
+---@return RawPaneData
+function M.extract_pane(pane, max_lines)
+    local domain = pane:get_domain_name()
+    local cwd_obj = pane:get_current_working_dir()
+    return {
+        left = pane.left,
+        top = pane.top,
+        width = pane.width,
+        height = pane.height,
+        domain = domain,
+        is_spawnable = wezterm.mux.get_domain(domain):is_spawnable(),
+        cwd = cwd_obj and cwd_obj.file_path or "",
+        text = pane:get_lines_as_escapes(max_lines or 2000),
+        process = pane:get_foreground_process_info(),
+        is_active = pane.is_active,
+        is_zoomed = pane.is_zoomed,
+        alt_screen_active = pane:is_alt_screen_active(),
+    }
+end
+
+---Extract panes from tab
+---@param pane_infos PaneInformation[]
+---@param max_lines number
+---@return RawPaneData[]
+function M.extract_panes(pane_infos, max_lines)
+    local result = {}
+    for _, info in ipairs(pane_infos) do
+        local raw = M.extract_pane(info.pane, max_lines)
+        raw.left = info.left
+        raw.top = info.top
+        raw.width = info.width
+        raw.height = info.height
+        raw.is_active = info.is_active
+        raw.is_zoomed = info.is_zoomed
+        result[#result + 1] = raw
+    end
+    return result
+end
+
+---@param mux_tab MuxTab
+---@param max_lines number
+---@return {title: string, panes: RawPaneData[], is_active: boolean, is_zoomed: boolean}
+function M.extract_tab(mux_tab, max_lines)
+    return {
+        title = mux_tab:get_title(),
+        panes = M.extract_panes(mux_tab:panes_with_info(), max_lines),
+        is_active = false,  -- Set by caller
+        is_zoomed = false,  -- Set by caller
+    }
+end
+
+---@param mux_win MuxWindow
+---@param max_lines number
+---@return {title: string, tabs: table[], size: TabSize}
+function M.extract_window(mux_win, max_lines)
+    local tabs = {}
+    for _, tab_info in ipairs(mux_win:tabs_with_info()) do
+        local tab = M.extract_tab(tab_info.tab, max_lines)
+        tab.is_active = tab_info.is_active
+        tabs[#tabs + 1] = tab
+    end
+    return {
+        title = mux_win:get_title(),
+        tabs = tabs,
+        size = tabs[1] and tabs[1].panes[1] and {
+            cols = 0, rows = 0,  -- Computed from panes
+            pixel_width = 0, pixel_height = 0, dpi = 96
+        } or nil
+    }
+end
+
+return M
+```
+
+**Type additions** to `plugin/resurrect/types/resurrect.lua`:
+```lua
+---@class ShellApi
+---@field extract_pane fun(pane: Pane, max_lines: number): RawPaneData
+---@field extract_panes fun(pane_infos: PaneInformation[], max_lines: number): RawPaneData[]
+---@field extract_tab fun(mux_tab: MuxTab, max_lines: number): table
+---@field extract_window fun(mux_win: MuxWindow, max_lines: number): table
+```
+
+**Validation**:
+```bash
+make all  # Must pass
+```
+
+---
+
+### Phase 2: Create `core/pane_tree.lua` (Pure Logic)
+
+**Goal**: Pure tree building with no WezTerm dependency.
+
+**Create** `plugin/resurrect/core/pane_tree.lua`:
+```lua
+-- NO wezterm require allowed!
+
+---@class CorePaneTree
+local M = {}
+
+---Build pane tree from raw extracted data (PURE)
+---@param panes RawPaneData[]
+---@return PaneTree?, string[]
+function M.build(panes)
+    if not panes or #panes == 0 then
+        return nil, {}
+    end
+
+    local warnings = {}
+    table.sort(panes, M.compare_by_coord)
+
+    local root = table.remove(panes, 1)
+    if not root.is_spawnable then
+        warnings[#warnings + 1] = "Domain " .. (root.domain or "unknown") .. " not spawnable"
+    end
+
+    return M.insert(root, panes, warnings), warnings
+end
+
+-- Move existing pure functions here:
+-- compare_pane_by_coord, is_right, is_bottom, pop_connected_*, insert, map, fold
+
+---Plan splits needed to restore pane tree (PURE)
+---@param tree PaneTree
+---@param opts {relative: boolean}
+---@return SplitCommand[]
+function M.plan_splits(tree, opts)
+    local commands = {}
+    M.fold(tree, nil, function(_, node)
+        if node.right then
+            commands[#commands + 1] = {
+                direction = "Right",
+                cwd = node.right.cwd,
+                text = node.right.text,
+                domain = node.right.domain,
+                size = opts.relative and node.right.width / (node.width + node.right.width) or nil,
+            }
+        end
+        if node.bottom then
+            commands[#commands + 1] = {
+                direction = "Bottom",
+                cwd = node.bottom.cwd,
+                text = node.bottom.text,
+                domain = node.bottom.domain,
+                size = opts.relative and node.bottom.height / (node.height + node.bottom.height) or nil,
+            }
+        end
+    end)
+    return commands
+end
+
+---Sanitize string for use as filename (PURE)
+---@param name string?
+---@return string
+function M.sanitize_filename(name)
+    -- Move from state_manager.lua
+end
+
+return M
+```
+
+**Add tests** `plugin/resurrect/test/spec/core_spec.lua`:
+- Test `build()` with raw data fixtures (no mocks!)
+- Test `plan_splits()` with various layouts
+- Test pure functions directly
+
+---
+
+### Phase 3: Create `shell/io.lua` (Orchestration)
+
+**Goal**: Single orchestrator for workflows.
+
+**Create** `plugin/resurrect/shell/io.lua`:
+```lua
+local wezterm = require("wezterm")
+local api = require("resurrect.shell.api")
+local core = require("resurrect.core.pane_tree")
+
+---@class ShellIO
+local M = {}
+
+M.state_dir = wezterm.config_dir .. "/resurrect/"
+M.max_nlines = 2000
+
+---Capture current workspace state
+---@return WorkspaceState
+function M.capture_workspace()
+    local workspace = wezterm.mux.get_active_workspace()
+    local raw_windows = {}
+    for _, win in ipairs(wezterm.mux.all_windows()) do
+        if win:get_workspace() == workspace then
+            raw_windows[#raw_windows + 1] = api.extract_window(win, M.max_nlines)
+        end
+    end
+    return core.build_workspace(workspace, raw_windows)
+end
+
+---Save state to file
+---@param state WorkspaceState|WindowState|TabState
+---@param name string?
+---@param state_type "workspace"|"window"|"tab"
+---@return boolean
+function M.save(state, name, state_type)
+    local filename = core.sanitize_filename(name or state.workspace or state.title)
+    local path = M.state_dir .. state_type .. "/" .. filename .. ".json"
+
+    wezterm.emit("resurrect.save.start", path)
+
+    local file = io.open(path, "w")
+    if not file then
+        wezterm.emit("resurrect.error", "Failed to open: " .. path)
+        return false
+    end
+
+    file:write(wezterm.json_encode(state))
+    file:close()
+
+    wezterm.emit("resurrect.save.finished", path)
+    return true
+end
+
+-- ... load, restore_workspace, execute_splits, etc.
+
+return M
+```
+
+---
+
+### Phase 4: Update Existing Modules
+
+**Goal**: Delegate to new modules, keep backward compatibility.
+
+1. **`pane_tree.lua`**: Delegate to `core/pane_tree.lua` + `shell/api.lua`
+2. **`tab_state.lua`**: Use `core.plan_splits()` in `make_splits()`
+3. **`state_manager.lua`**: Delegate to `shell/io.lua`
+4. **`init.lua`**: Keep unchanged (public API)
+
+---
+
+## File Structure After Refactoring
+
+```
+plugin/
+├── init.lua                    # Entry point (unchanged public API)
+└── resurrect/
+    ├── core/
+    │   └── pane_tree.lua       # ALL pure logic
+    │
+    ├── shell/
+    │   ├── api.lua             # WezTerm data extraction
+    │   └── io.lua              # File I/O, orchestration, events
+    │
+    ├── types/
+    │   ├── wezterm.lua         # WezTerm API type stubs
+    │   ├── mux.lua             # Mux types
+    │   └── resurrect.lua       # Internal types
+    │
+    ├── test/
+    │   ├── spec/
+    │   │   ├── capture_spec.lua
+    │   │   ├── restore_spec.lua
+    │   │   ├── persistence_spec.lua
+    │   │   ├── events_spec.lua
+    │   │   └── core_spec.lua   # NEW: Pure function tests
+    │   ├── fakes/
+    │   └── fixtures/
+    │
+    └── [legacy modules - thin wrappers for compatibility]
+        ├── pane_tree.lua
+        ├── tab_state.lua
+        ├── window_state.lua
+        ├── workspace_state.lua
+        ├── state_manager.lua
+        └── file_io.lua
+```
+
+---
+
+## Implementation Checklist
+
+### Phase 1: shell/api.lua
+- [ ] Create `plugin/resurrect/shell/api.lua`
+- [ ] Add `ShellApi` type to `types/resurrect.lua`
+- [ ] Add `plugin/resurrect/test/spec/api_spec.lua`
+- [ ] Run `make all` - must pass
+
+### Phase 2: core/pane_tree.lua
+- [ ] Create `plugin/resurrect/core/pane_tree.lua`
+- [ ] Move pure functions from `pane_tree.lua`
+- [ ] Implement `build(raw_panes)` with warnings return
+- [ ] Implement `plan_splits(tree, opts)`
+- [ ] Move `sanitize_filename` from `state_manager.lua`
+- [ ] Add `plugin/resurrect/test/spec/core_spec.lua`
+- [ ] Run `make all` - must pass
+
+### Phase 3: shell/io.lua
+- [ ] Create `plugin/resurrect/shell/io.lua`
+- [ ] Implement capture/save/load/restore workflows
+- [ ] Preserve all event emissions
+- [ ] Run `make all` - must pass
+
+### Phase 4: Integration
+- [ ] Update `pane_tree.lua` to delegate to core + shell
+- [ ] Update `tab_state.lua` to use `plan_splits()`
+- [ ] Update `state_manager.lua` to delegate to `shell/io.lua`
+- [ ] Run `make all` - must pass
+- [ ] Manual smoke test with complex layouts
+
+---
+
+## Type Checking Guidelines
+
+1. **All new functions must have type annotations**:
+   ```lua
+   ---@param panes RawPaneData[]
+   ---@return PaneTree?, string[]
+   function M.build(panes)
+   ```
+
+2. **Add types to `types/resurrect.lua`** for any new classes/interfaces
+
+3. **Run `make check`** after each file change
+
+4. **Core module must not require wezterm** - LuaLS will catch this
+
+5. **Use existing types**: `RawPaneData`, `SplitCommand`, `PaneTree`, etc.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Public API breakage | Keep `init.lua` unchanged |
+| Layout regressions | 151 tests cover many scenarios |
+| Type errors | `make check` at each step |
+| Windows path issues | Keep existing fix in `shell/api.lua` |
+| Module load order | Core never requires shell |
+
+---
+
+## Estimated Effort
+
+| Phase | Effort | Risk |
+|-------|--------|------|
+| Phase 1: shell/api.lua | ~4 hours | Medium |
+| Phase 2: core/pane_tree.lua | ~3 hours | Low |
+| Phase 3: shell/io.lua | ~4 hours | Medium |
+| Phase 4: Integration | ~2 hours | Low |
+
+**Total: ~13 hours / 2 days**

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -1,4 +1,5 @@
-local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
+---@type Wezterm
+local wezterm = require("wezterm")
 local dev = wezterm.plugin.require("https://github.com/chrisgve/dev.wezterm")
 
 local pub = {}

--- a/plugin/resurrect/encryption.lua
+++ b/plugin/resurrect/encryption.lua
@@ -1,6 +1,8 @@
 ---@type Wezterm
 local wezterm = require("wezterm")
----@alias encryption_opts {enable: boolean, method: string, private_key: string?, public_key: string?, encrypt: fun(file_path: string, lines: string), decrypt: fun(file_path: string): string}
+---@alias encryption_opts {enable: boolean, method: string, private_key: string?,
+---public_key: string?, encrypt: fun(file_path: string, lines: string),
+---decrypt: fun(file_path: string): string}
 
 local utils = require("resurrect.utils")
 

--- a/plugin/resurrect/encryption.lua
+++ b/plugin/resurrect/encryption.lua
@@ -1,4 +1,5 @@
-local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
+---@type Wezterm
+local wezterm = require("wezterm")
 ---@alias encryption_opts {enable: boolean, method: string, private_key: string?, public_key: string?, encrypt: fun(file_path: string, lines: string), decrypt: fun(file_path: string): string}
 
 local utils = require("resurrect.utils")

--- a/plugin/resurrect/file_io.lua
+++ b/plugin/resurrect/file_io.lua
@@ -1,4 +1,5 @@
-local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
+---@type Wezterm
+local wezterm = require("wezterm")
 
 local pub = {
 	encryption = { enable = false },

--- a/plugin/resurrect/fuzzy_loader.lua
+++ b/plugin/resurrect/fuzzy_loader.lua
@@ -1,4 +1,5 @@
-local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
+---@type Wezterm
+local wezterm = require("wezterm")
 local utils = require("resurrect.utils")
 local file_io = require("resurrect.file_io")
 local pub = {}
@@ -311,14 +312,14 @@ local function insert_choices(stdout, opts)
 end
 
 ---A fuzzy finder to restore saved state
----@param window MuxWindow
+---@param window GuiWindow
 ---@param pane Pane
 ---@param callback fun(id: string, label: string, save_state_dir: string)
 ---@param opts fuzzy_load_opts?
 function pub.fuzzy_load(window, pane, callback, opts)
 	wezterm.emit("resurrect.fuzzy_loader.fuzzy_load.start", window, pane)
 
-	opts = utils.tbl_deep_extend("force", pub.default_fuzzy_load_opts, opts or {})
+	opts = utils.tbl_deep_extend("force", pub.default_fuzzy_load_opts, opts or {}) --[[@as fuzzy_load_opts]]
 
 	local folder = require("resurrect.state_manager").save_state_dir
 

--- a/plugin/resurrect/fuzzy_loader.lua
+++ b/plugin/resurrect/fuzzy_loader.lua
@@ -5,9 +5,10 @@ local file_io = require("resurrect.file_io")
 local pub = {}
 
 ---@alias fmt_fun fun(label: string): string
----@alias fuzzy_load_opts {title: string, description: string, fuzzy_description: string, is_fuzzy: boolean,
----ignore_workspaces: boolean, ignore_tabs: boolean, ignore_windows: boolean, fmt_window: fmt_fun, fmt_workspace: fmt_fun,
----fmt_tab: fmt_fun, fmt_date: fmt_fun, show_state_with_date: boolean, date_format: string, ignore_screen_width: boolean,
+---@alias fuzzy_load_opts {title: string, description: string, fuzzy_description: string,
+---is_fuzzy: boolean, ignore_workspaces: boolean, ignore_tabs: boolean, ignore_windows: boolean,
+---fmt_window: fmt_fun, fmt_workspace: fmt_fun, fmt_tab: fmt_fun, fmt_date: fmt_fun,
+---show_state_with_date: boolean, date_format: string, ignore_screen_width: boolean,
 ---name_truncature: string, min_filename_size: number}
 
 ---Default fuzzy loading options
@@ -68,14 +69,14 @@ local function find_json_files_recursive(base_path)
 			[[
                 Set fso = CreateObject("Scripting.FileSystemObject")
                 Set outFile = fso.CreateTextFile("%s", True)
-                
+
                 Sub ProcessFolder(folderPath)
                     On Error Resume Next
                     Set folder = fso.GetFolder(folderPath)
                     If Err.Number <> 0 Then
                         Exit Sub
                     End If
-                    
+
                     ' Process files in current folder
                     For Each file in folder.Files
                         If LCase(fso.GetExtensionName(file.Name)) = "json" Then
@@ -83,13 +84,13 @@ local function find_json_files_recursive(base_path)
                             outFile.WriteLine(epoch & " " & file.Path)
                         End If
                     Next
-                    
+
                     ' Process subfolders recursively
                     For Each subFolder in folder.SubFolders
                         ProcessFolder(subFolder.Path)
                     Next
                 End Sub
-                
+
                 ProcessFolder("%s")
                 outFile.Close
             ]],

--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -75,6 +75,13 @@ local function insert_panes(root, panes)
 		return nil
 	end
 
+	-- Guard against processing the same pane twice (can happen in grid layouts
+	-- where a pane is both right-of and below the root, causing it to appear
+	-- in multiple recursive paths)
+	if root.pane == nil then
+		return nil
+	end
+
 	local domain = root.pane:get_domain_name()
 	if not wezterm.mux.get_domain(domain):is_spawnable() then
 		wezterm.log_warn("Domain " .. domain .. " is not spawnable")

--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -8,7 +8,10 @@ local pub = {}
 pub.max_nlines = 3500
 
 ---@alias PaneInformation {left: integer, top: integer, height: integer, width: integer, pane: Pane?}
----@alias pane_tree {left: integer, top: integer, height: integer, width: integer, bottom: pane_tree?, right: pane_tree?, text: string, cwd: string, domain?: string, process?: local_process_info?, pane: Pane?, is_active: boolean, is_zoomed: boolean, alt_screen_active: boolean}
+---@alias pane_tree {left: integer, top: integer, height: integer, width: integer,
+---bottom: pane_tree?, right: pane_tree?, text: string, cwd: string, domain?: string,
+---process?: local_process_info?, pane: Pane?, is_active: boolean, is_zoomed: boolean,
+---alt_screen_active: boolean}
 ---@alias local_process_info {name: string, argv: string[], cwd: string, executable: string}
 
 ---compare function returns true if a is more left than b

--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -1,4 +1,5 @@
-local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
+---@type Wezterm
+local wezterm = require("wezterm")
 local utils = require("resurrect.utils")
 
 ---@class pane_tree_module
@@ -6,8 +7,7 @@ local utils = require("resurrect.utils")
 local pub = {}
 pub.max_nlines = 3500
 
----@alias Pane any
----@alias PaneInformation {left: integer, top: integer, height: integer, width: integer}
+---@alias PaneInformation {left: integer, top: integer, height: integer, width: integer, pane: Pane?}
 ---@alias pane_tree {left: integer, top: integer, height: integer, width: integer, bottom: pane_tree?, right: pane_tree?, text: string, cwd: string, domain?: string, process?: local_process_info?, pane: Pane?, is_active: boolean, is_zoomed: boolean, alt_screen_active: boolean}
 ---@alias local_process_info {name: string, argv: string[], cwd: string, executable: string}
 

--- a/plugin/resurrect/shell/api.lua
+++ b/plugin/resurrect/shell/api.lua
@@ -1,0 +1,176 @@
+---@type Wezterm
+local wezterm = require("wezterm")
+local utils = require("resurrect.utils")
+
+---@class ShellApi
+---Module for extracting raw data from WezTerm pane/tab/window objects.
+---All WezTerm API calls that extract data for state capture are centralized here.
+local M = {}
+
+--------------------------------------------------------------------------------
+-- Pane Data Extraction
+--------------------------------------------------------------------------------
+
+---Extract raw data from a WezTerm pane (IMPURE - all API calls here)
+---@param pane Pane
+---@param max_lines number
+---@return RawPaneData
+function M.extract_pane(pane, max_lines)
+	local domain = pane:get_domain_name()
+	local is_spawnable = wezterm.mux.get_domain(domain):is_spawnable()
+
+	-- Handle CWD with Windows path fix
+	local cwd = ""
+	local cwd_obj = pane:get_current_working_dir()
+	if cwd_obj then
+		cwd = cwd_obj.file_path
+		if utils.is_windows then
+			cwd = cwd:gsub("^/([a-zA-Z]):", "%1:")
+		end
+	end
+
+	-- Extract process info or scrollback based on alt screen state
+	local text = ""
+	local process = nil
+	local alt_screen_active = pane:is_alt_screen_active()
+
+	-- Only extract scrollback/process for local domain
+	-- pane:inject_output() is unavailable for non-local domains
+	-- See: https://github.com/MLFlexer/resurrect.wezterm/issues/41
+	if is_spawnable and domain == "local" then
+		if alt_screen_active then
+			local process_info = pane:get_foreground_process_info()
+			if process_info then
+				-- Clear transient fields that shouldn't be persisted
+				process_info.children = nil
+				process_info.pid = nil
+				process_info.ppid = nil
+				process = process_info
+			end
+		else
+			local nlines = pane:get_dimensions().scrollback_rows
+			if nlines > max_lines then
+				nlines = max_lines
+			end
+			text = pane:get_lines_as_escapes(nlines)
+		end
+	end
+
+	return {
+		left = 0, -- Set by caller from PaneInfo
+		top = 0,
+		width = 0,
+		height = 0,
+		cwd = cwd,
+		domain = domain,
+		is_spawnable = is_spawnable,
+		text = text,
+		process = process,
+		is_active = false, -- Set by caller
+		is_zoomed = false, -- Set by caller
+		alt_screen_active = alt_screen_active,
+	}
+end
+
+---Extract pane data from PaneInfo list
+---@param pane_infos PaneInfo[]
+---@param max_lines number
+---@return RawPaneData[]
+function M.extract_panes(pane_infos, max_lines)
+	local result = {}
+	for _, info in ipairs(pane_infos) do
+		-- Guard: skip if pane is nil (can happen with invalid state)
+		if info.pane then
+			local raw = M.extract_pane(info.pane, max_lines)
+			-- Overlay geometry from PaneInfo
+			raw.left = info.left
+			raw.top = info.top
+			raw.width = info.width
+			raw.height = info.height
+			raw.is_active = info.is_active or false
+			raw.is_zoomed = info.is_zoomed or false
+			result[#result + 1] = raw
+		end
+	end
+	return result
+end
+
+--------------------------------------------------------------------------------
+-- Tab Data Extraction
+--------------------------------------------------------------------------------
+
+---Extract raw tab data from a MuxTab
+---@param mux_tab MuxTab
+---@param max_lines number
+---@return RawTabData
+function M.extract_tab(mux_tab, max_lines)
+	local panes_info = mux_tab:panes_with_info()
+	local panes = M.extract_panes(panes_info, max_lines)
+
+	-- Check if any pane is zoomed
+	local is_zoomed = false
+	for _, pane in ipairs(panes) do
+		if pane.is_zoomed then
+			is_zoomed = true
+			break
+		end
+	end
+
+	return {
+		title = mux_tab:get_title(),
+		panes = panes,
+		is_active = false, -- Set by caller
+		is_zoomed = is_zoomed,
+	}
+end
+
+--------------------------------------------------------------------------------
+-- Window Data Extraction
+--------------------------------------------------------------------------------
+
+---Extract raw window data from a MuxWindow
+---@param mux_win MuxWindow
+---@param max_lines number
+---@return RawWindowData
+function M.extract_window(mux_win, max_lines)
+	local tabs = {}
+	for _, tab_info in ipairs(mux_win:tabs_with_info()) do
+		local tab = M.extract_tab(tab_info.tab, max_lines)
+		tab.is_active = tab_info.is_active or false
+		tabs[#tabs + 1] = tab
+	end
+
+	-- Compute size from active tab
+	local size = nil
+	local active_tab = mux_win:active_tab()
+	if active_tab then
+		local tab_size = active_tab:get_size()
+		if tab_size then
+			size = {
+				cols = tab_size.cols or 0,
+				rows = tab_size.rows or 0,
+				pixel_width = tab_size.pixel_width or 0,
+				pixel_height = tab_size.pixel_height or 0,
+			}
+		end
+	end
+
+	return {
+		title = mux_win:get_title(),
+		tabs = tabs,
+		size = size,
+	}
+end
+
+--------------------------------------------------------------------------------
+-- Domain Spawnability Warning
+--------------------------------------------------------------------------------
+
+---Log warning and emit error event for non-spawnable domain
+---@param domain string
+function M.warn_not_spawnable(domain)
+	wezterm.log_warn("Domain " .. domain .. " is not spawnable")
+	wezterm.emit("resurrect.error", "Domain " .. domain .. " is not spawnable")
+end
+
+return M

--- a/plugin/resurrect/state_manager.lua
+++ b/plugin/resurrect/state_manager.lua
@@ -1,4 +1,5 @@
-local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
+---@type Wezterm
+local wezterm = require("wezterm")
 local file_io = require("resurrect.file_io")
 local utils = require("resurrect.utils")
 
@@ -69,9 +70,10 @@ function pub.load_state(name, type)
 	return json
 end
 
+local save_in_progress = false
+
 ---Saves the state after interval in seconds
 ---@param opts? { interval_seconds: integer?, save_workspaces: boolean?, save_windows: boolean?, save_tabs: boolean? }
-local save_in_progress = false
 function pub.periodic_save(opts)
 	-- Default options with ternary idiom
 	opts = opts or { save_workspaces = true }

--- a/plugin/resurrect/state_manager.lua
+++ b/plugin/resurrect/state_manager.lua
@@ -10,14 +10,16 @@ local pub = {}
 ---@param name string? The input string to sanitize
 ---@return string The sanitized filename-safe string
 function pub.sanitize_filename(name)
-	if not name then return "_unnamed_" end
+	if not name then
+		return "_unnamed_"
+	end
 
 	local result = name
-		:gsub("[/\\]", "+")            -- path separators -> + (preserves structure)
-		:gsub("%.%.", "_")             -- .. -> _ (prevent path traversal confusion)
-		:gsub('[<>:"|%?%*]', "_")      -- Windows-invalid chars -> _
-		:gsub("[\x00-\x1f\x7f]", "_")  -- control characters -> _
-		:gsub("[%. ]+$", "")           -- trim trailing dots/spaces (Windows)
+		:gsub("[/\\]", "+") -- path separators -> + (preserves structure)
+		:gsub("%.%.", "_") -- .. -> _ (prevent path traversal confusion)
+		:gsub('[<>:"|%?%*]', "_") -- Windows-invalid chars -> _
+		:gsub("[\x00-\x1f\x7f]", "_") -- control characters -> _
+		:gsub("[%. ]+$", "") -- trim trailing dots/spaces (Windows)
 
 	return result ~= "" and result or "_unnamed_"
 end
@@ -39,8 +41,8 @@ function pub.save_state(state, opt_name)
 	-- State type detection: maps state field to (type_name, name_field) pair
 	local state_types = {
 		{ field = "window_states", type = "workspace", name = state.workspace },
-		{ field = "tabs",          type = "window",    name = state.title },
-		{ field = "pane_tree",     type = "tab",       name = state.title },
+		{ field = "tabs", type = "window", name = state.title },
+		{ field = "pane_tree", type = "tab", name = state.title },
 	}
 	-- Find matching state type and write
 	for _, st in ipairs(state_types) do
@@ -82,7 +84,7 @@ function pub.periodic_save(opts)
 	wezterm.time.call_after(opts.interval_seconds, function()
 		-- Guard: skip if previous save still running (prevents overlap)
 		if save_in_progress then
-			pub.periodic_save(opts)  -- reschedule and check again later
+			pub.periodic_save(opts) -- reschedule and check again later
 			return
 		end
 		save_in_progress = true
@@ -90,7 +92,9 @@ function pub.periodic_save(opts)
 		wezterm.emit("resurrect.state_manager.periodic_save.start", opts)
 
 		-- Helper: check if title is non-empty
-		local function has_title(title) return title and title ~= "" end
+		local function has_title(title)
+			return title and title ~= ""
+		end
 
 		if opts.save_workspaces then
 			pub.save_state(require("resurrect.workspace_state").get_workspace_state())

--- a/plugin/resurrect/state_manager.lua
+++ b/plugin/resurrect/state_manager.lua
@@ -4,32 +4,49 @@ local utils = require("resurrect.utils")
 
 local pub = {}
 
+--- Sanitizes a string to be safe for use as a filename on all platforms.
+--- Pure function: no side effects, deterministic output.
+---@param name string? The input string to sanitize
+---@return string The sanitized filename-safe string
+function pub.sanitize_filename(name)
+	if not name then return "_unnamed_" end
+
+	local result = name
+		:gsub("[/\\]", "+")            -- path separators -> + (preserves structure)
+		:gsub("%.%.", "_")             -- .. -> _ (prevent path traversal confusion)
+		:gsub('[<>:"|%?%*]', "_")      -- Windows-invalid chars -> _
+		:gsub("[\x00-\x1f\x7f]", "_")  -- control characters -> _
+		:gsub("[%. ]+$", "")           -- trim trailing dots/spaces (Windows)
+
+	return result ~= "" and result or "_unnamed_"
+end
+
 ---@param file_name string
 ---@param type string
 ---@param opt_name string?
 ---@return string
 local function get_file_path(file_name, type, opt_name)
-	if opt_name then
-		file_name = opt_name
-	end
-	return string.format(
-		"%s%s" .. utils.separator .. "%s.json",
-		pub.save_state_dir,
-		type,
-		file_name:gsub(utils.separator, "+")
-	)
+	-- Use opt_name if provided, otherwise use file_name
+	local sanitized_name = pub.sanitize_filename(opt_name or file_name)
+	return string.format("%s%s" .. utils.separator .. "%s.json", pub.save_state_dir, type, sanitized_name)
 end
 
 ---save state to a file
 ---@param state workspace_state | window_state | tab_state
 ---@param opt_name? string
 function pub.save_state(state, opt_name)
-	if state.window_states then
-		file_io.write_state(get_file_path(state.workspace, "workspace", opt_name), state, "workspace")
-	elseif state.tabs then
-		file_io.write_state(get_file_path(state.title, "window", opt_name), state, "window")
-	elseif state.pane_tree then
-		file_io.write_state(get_file_path(state.title, "tab", opt_name), state, "tab")
+	-- State type detection: maps state field to (type_name, name_field) pair
+	local state_types = {
+		{ field = "window_states", type = "workspace", name = state.workspace },
+		{ field = "tabs",          type = "window",    name = state.title },
+		{ field = "pane_tree",     type = "tab",       name = state.title },
+	}
+	-- Find matching state type and write
+	for _, st in ipairs(state_types) do
+		if state[st.field] then
+			file_io.write_state(get_file_path(st.name, st.type, opt_name), state, st.type)
+			return
+		end
 	end
 end
 
@@ -39,26 +56,40 @@ end
 ---@return table
 function pub.load_state(name, type)
 	wezterm.emit("resurrect.state_manager.load_state.start", name, type)
-	local json = file_io.load_json(get_file_path(name, type))
+	local file_path = get_file_path(name, type)
+	local json = file_io.load_json(file_path)
+
+	-- Guard: invalid json returns empty table with error event
 	if not json then
-		wezterm.emit("resurrect.error", "Invalid json: " .. get_file_path(name, type))
+		wezterm.emit("resurrect.error", "Invalid json: " .. file_path)
 		return {}
 	end
+
 	wezterm.emit("resurrect.state_manager.load_state.finished", name, type)
 	return json
 end
 
----Saves the stater after interval in seconds
+---Saves the state after interval in seconds
 ---@param opts? { interval_seconds: integer?, save_workspaces: boolean?, save_windows: boolean?, save_tabs: boolean? }
+local save_in_progress = false
 function pub.periodic_save(opts)
-	if opts == nil then
-		opts = { save_workspaces = true }
-	end
-	if opts.interval_seconds == nil then
-		opts.interval_seconds = 60 * 15
-	end
+	-- Default options with ternary idiom
+	opts = opts or { save_workspaces = true }
+	opts.interval_seconds = opts.interval_seconds or (60 * 15)
+
 	wezterm.time.call_after(opts.interval_seconds, function()
+		-- Guard: skip if previous save still running (prevents overlap)
+		if save_in_progress then
+			pub.periodic_save(opts)  -- reschedule and check again later
+			return
+		end
+		save_in_progress = true
+
 		wezterm.emit("resurrect.state_manager.periodic_save.start", opts)
+
+		-- Helper: check if title is non-empty
+		local function has_title(title) return title and title ~= "" end
+
 		if opts.save_workspaces then
 			pub.save_state(require("resurrect.workspace_state").get_workspace_state())
 		end
@@ -66,8 +97,7 @@ function pub.periodic_save(opts)
 		if opts.save_windows then
 			for _, gui_win in ipairs(wezterm.gui.gui_windows()) do
 				local mux_win = gui_win:mux_window()
-				local title = mux_win:get_title()
-				if title ~= "" and title ~= nil then
+				if has_title(mux_win:get_title()) then
 					pub.save_state(require("resurrect.window_state").get_window_state(mux_win))
 				end
 			end
@@ -75,10 +105,8 @@ function pub.periodic_save(opts)
 
 		if opts.save_tabs then
 			for _, gui_win in ipairs(wezterm.gui.gui_windows()) do
-				local mux_win = gui_win:mux_window()
-				for _, mux_tab in ipairs(mux_win:tabs()) do
-					local title = mux_tab:get_title()
-					if title ~= "" and title ~= nil then
+				for _, mux_tab in ipairs(gui_win:mux_window():tabs()) do
+					if has_title(mux_tab:get_title()) then
 						pub.save_state(require("resurrect.tab_state").get_tab_state(mux_tab))
 					end
 				end
@@ -86,6 +114,7 @@ function pub.periodic_save(opts)
 		end
 
 		wezterm.emit("resurrect.state_manager.periodic_save.finished", opts)
+		save_in_progress = false
 		pub.periodic_save(opts)
 	end)
 end

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -5,7 +5,8 @@ local pub = {}
 
 ---Function used to split panes when mapping over the pane_tree
 ---@param opts restore_opts
----@return fun(acc: {active_pane: Pane, is_zoomed: boolean}, pane_tree: pane_tree): {active_pane: Pane, is_zoomed: boolean}
+---@return fun(acc: {active_pane: Pane, is_zoomed: boolean}, pane_tree: pane_tree):
+---{active_pane: Pane, is_zoomed: boolean}
 local function make_splits(opts)
 	if opts == nil then
 		opts = {}

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -1,4 +1,5 @@
-local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
+---@type Wezterm
+local wezterm = require("wezterm")
 local pane_tree_mod = require("resurrect.pane_tree")
 local pub = {}
 

--- a/plugin/resurrect/test/fakes/fs.lua
+++ b/plugin/resurrect/test/fakes/fs.lua
@@ -3,120 +3,126 @@ local fs = {}
 
 -- Cross-platform temp directory detection
 local function get_temp_base()
-    return os.getenv("TMPDIR")  -- macOS
-        or os.getenv("TEMP")     -- Windows
-        or os.getenv("TMP")      -- Windows alt
-        or "/tmp"                -- Linux/fallback
+	return os.getenv("TMPDIR") -- macOS
+		or os.getenv("TEMP") -- Windows
+		or os.getenv("TMP") -- Windows alt
+		or "/tmp" -- Linux/fallback
 end
 
 -- Platform detection
-local is_windows = package.config:sub(1,1) == '\\'
+local is_windows = package.config:sub(1, 1) == "\\"
 
 -- State
 local test_root = nil
 
 --- Create a unique test directory
 function fs.setup()
-    local base = get_temp_base()
-    test_root = base .. (is_windows and "\\" or "/") .. "resurrect-test-" .. os.time() .. "-" .. math.random(10000)
+	local base = get_temp_base()
+	test_root = base .. (is_windows and "\\" or "/") .. "resurrect-test-" .. os.time() .. "-" .. math.random(10000)
 
-    if is_windows then
-        os.execute('mkdir "' .. test_root .. '"')
-    else
-        os.execute("mkdir -p '" .. test_root .. "'")
-    end
+	if is_windows then
+		os.execute('mkdir "' .. test_root .. '"')
+	else
+		os.execute("mkdir -p '" .. test_root .. "'")
+	end
 
-    return test_root
+	return test_root
 end
 
 --- Clean up test directory
 function fs.teardown()
-    if not test_root then return end
+	if not test_root then
+		return
+	end
 
-    if is_windows then
-        os.execute('rmdir /s /q "' .. test_root .. '" 2>nul')
-    else
-        os.execute("rm -rf '" .. test_root .. "' 2>/dev/null")
-    end
+	if is_windows then
+		os.execute('rmdir /s /q "' .. test_root .. '" 2>nul')
+	else
+		os.execute("rm -rf '" .. test_root .. "' 2>/dev/null")
+	end
 
-    test_root = nil
+	test_root = nil
 end
 
 --- Get the test root directory
 function fs.get_root()
-    return test_root
+	return test_root
 end
 
 --- Ensure a directory exists (creates parent dirs)
 function fs.mkdir(path)
-    if is_windows then
-        os.execute('mkdir "' .. path .. '" 2>nul')
-    else
-        os.execute("mkdir -p '" .. path .. "'")
-    end
+	if is_windows then
+		os.execute('mkdir "' .. path .. '" 2>nul')
+	else
+		os.execute("mkdir -p '" .. path .. "'")
+	end
 end
 
 --- Write content to a file
 function fs.write(path, content)
-    local file = io.open(path, "w")
-    if not file then
-        fs.mkdir(path:match("(.+)[/\\][^/\\]+$"))  -- create parent dir
-        file = io.open(path, "w")
-    end
-    if not file then return false end
-    file:write(content)
-    file:close()
-    return true
+	local file = io.open(path, "w")
+	if not file then
+		fs.mkdir(path:match("(.+)[/\\][^/\\]+$")) -- create parent dir
+		file = io.open(path, "w")
+	end
+	if not file then
+		return false
+	end
+	file:write(content)
+	file:close()
+	return true
 end
 
 --- Read content from a file
 function fs.read(path)
-    local file = io.open(path, "r")
-    if not file then return nil end
-    local content = file:read("*a")
-    file:close()
-    return content
+	local file = io.open(path, "r")
+	if not file then
+		return nil
+	end
+	local content = file:read("*a")
+	file:close()
+	return content
 end
 
 --- Check if path exists
 function fs.exists(path)
-    local file = io.open(path, "r")
-    if file then
-        file:close()
-        return true
-    end
-    return false
+	local file = io.open(path, "r")
+	if file then
+		file:close()
+		return true
+	end
+	return false
 end
 
 --- Delete a file
 function fs.delete(path)
-    return os.remove(path)
+	return os.remove(path)
 end
 
 --- List files in directory (returns iterator or table)
 function fs.list(dir)
-    local files = {}
-    local cmd
-    if is_windows then
-        cmd = 'dir /b "' .. dir .. '" 2>nul'
-    else
-        cmd = "ls -1 '" .. dir .. "' 2>/dev/null"
-    end
+	local files = {}
+	local cmd
+	if is_windows then
+		cmd = 'dir /b "' .. dir .. '" 2>nul'
+	else
+		cmd = "ls -1 '" .. dir .. "' 2>/dev/null"
+	end
 
-    local handle = io.popen(cmd)
-    if handle then
-        for line in handle:lines() do
-            table.insert(files, line)
-        end
-        handle:close()
-    end
-    return files
+	local handle = io.popen(cmd)
+	if handle then
+		for line in handle:lines() do
+			table.insert(files, line)
+		end
+		handle:close()
+	end
+	return files
 end
 
 --- Reset (alias for teardown + setup)
 function fs.reset()
-    fs.teardown()
-    return fs.setup()
+	fs.teardown()
+	return fs.setup()
 end
 
 return fs

--- a/plugin/resurrect/test/fakes/fs.lua
+++ b/plugin/resurrect/test/fakes/fs.lua
@@ -1,0 +1,122 @@
+---Virtual filesystem for tests using real temp directory
+local fs = {}
+
+-- Cross-platform temp directory detection
+local function get_temp_base()
+    return os.getenv("TMPDIR")  -- macOS
+        or os.getenv("TEMP")     -- Windows
+        or os.getenv("TMP")      -- Windows alt
+        or "/tmp"                -- Linux/fallback
+end
+
+-- Platform detection
+local is_windows = package.config:sub(1,1) == '\\'
+
+-- State
+local test_root = nil
+
+--- Create a unique test directory
+function fs.setup()
+    local base = get_temp_base()
+    test_root = base .. (is_windows and "\\" or "/") .. "resurrect-test-" .. os.time() .. "-" .. math.random(10000)
+
+    if is_windows then
+        os.execute('mkdir "' .. test_root .. '"')
+    else
+        os.execute("mkdir -p '" .. test_root .. "'")
+    end
+
+    return test_root
+end
+
+--- Clean up test directory
+function fs.teardown()
+    if not test_root then return end
+
+    if is_windows then
+        os.execute('rmdir /s /q "' .. test_root .. '" 2>nul')
+    else
+        os.execute("rm -rf '" .. test_root .. "' 2>/dev/null")
+    end
+
+    test_root = nil
+end
+
+--- Get the test root directory
+function fs.get_root()
+    return test_root
+end
+
+--- Ensure a directory exists (creates parent dirs)
+function fs.mkdir(path)
+    if is_windows then
+        os.execute('mkdir "' .. path .. '" 2>nul')
+    else
+        os.execute("mkdir -p '" .. path .. "'")
+    end
+end
+
+--- Write content to a file
+function fs.write(path, content)
+    local file = io.open(path, "w")
+    if not file then
+        fs.mkdir(path:match("(.+)[/\\][^/\\]+$"))  -- create parent dir
+        file = io.open(path, "w")
+    end
+    if not file then return false end
+    file:write(content)
+    file:close()
+    return true
+end
+
+--- Read content from a file
+function fs.read(path)
+    local file = io.open(path, "r")
+    if not file then return nil end
+    local content = file:read("*a")
+    file:close()
+    return content
+end
+
+--- Check if path exists
+function fs.exists(path)
+    local file = io.open(path, "r")
+    if file then
+        file:close()
+        return true
+    end
+    return false
+end
+
+--- Delete a file
+function fs.delete(path)
+    return os.remove(path)
+end
+
+--- List files in directory (returns iterator or table)
+function fs.list(dir)
+    local files = {}
+    local cmd
+    if is_windows then
+        cmd = 'dir /b "' .. dir .. '" 2>nul'
+    else
+        cmd = "ls -1 '" .. dir .. "' 2>/dev/null"
+    end
+
+    local handle = io.popen(cmd)
+    if handle then
+        for line in handle:lines() do
+            table.insert(files, line)
+        end
+        handle:close()
+    end
+    return files
+end
+
+--- Reset (alias for teardown + setup)
+function fs.reset()
+    fs.teardown()
+    return fs.setup()
+end
+
+return fs

--- a/plugin/resurrect/test/fakes/mux.lua
+++ b/plugin/resurrect/test/fakes/mux.lua
@@ -1,0 +1,724 @@
+-- Fake Mux API for testing
+-- Provides behavioral fakes with builder pattern for workspace/window/tab/pane
+
+local mux = {}
+
+--------------------------------------------------------------------------------
+-- Internal ID generators
+--------------------------------------------------------------------------------
+
+local next_pane_id = 1
+local next_tab_id = 1
+local next_window_id = 1
+
+local function gen_pane_id()
+    local id = next_pane_id
+    next_pane_id = next_pane_id + 1
+    return id
+end
+
+local function gen_tab_id()
+    local id = next_tab_id
+    next_tab_id = next_tab_id + 1
+    return id
+end
+
+local function gen_window_id()
+    local id = next_window_id
+    next_window_id = next_window_id + 1
+    return id
+end
+
+--------------------------------------------------------------------------------
+-- Domain Registry
+--------------------------------------------------------------------------------
+
+local domains = {
+    ["local"] = { name = "local", spawnable = true },
+}
+
+function mux.get_domain(name)
+    local domain = domains[name]
+    if domain then
+        return {
+            name = domain.name,
+            is_spawnable = function() return domain.spawnable end,
+        }
+    end
+    -- Default: unknown domains are spawnable
+    return {
+        name = name,
+        is_spawnable = function() return true end,
+    }
+end
+
+function mux.set_domain_spawnable(name, spawnable)
+    domains[name] = { name = name, spawnable = spawnable }
+end
+
+--------------------------------------------------------------------------------
+-- FakePane
+--------------------------------------------------------------------------------
+
+---@class FakePane
+---@field _id number
+---@field left number
+---@field top number
+---@field width number
+---@field height number
+---@field cwd string
+---@field domain string
+---@field text string[]
+---@field is_active boolean
+---@field is_zoomed boolean
+---@field _process table?
+---@field _alt_screen boolean
+---@field _splits FakePane[]
+---@field _tab FakeTab?
+local FakePane = {}
+FakePane.__index = FakePane
+
+function FakePane.new(opts)
+    opts = opts or {}
+    local self = setmetatable({}, FakePane)
+    self._id = gen_pane_id()
+    self.left = opts.left or 0
+    self.top = opts.top or 0
+    self.width = opts.width or 160
+    self.height = opts.height or 48
+    self.cwd = opts.cwd or "/home/user"
+    self.domain = opts.domain or "local"
+    self.text = opts.text and { opts.text } or {}
+    self.is_active = opts.is_active or false
+    self.is_zoomed = opts.is_zoomed or false
+    self._process = opts.process or nil
+    self._alt_screen = opts.alt_screen or false
+    self._splits = {}
+    self._tab = nil
+    return self
+end
+
+function FakePane:pane_id()
+    return self._id
+end
+
+function FakePane:get_domain_name()
+    return self.domain
+end
+
+function FakePane:get_current_working_dir()
+    if not self.cwd or self.cwd == "" then
+        return nil
+    end
+    return { file_path = self.cwd }
+end
+
+function FakePane:get_lines_as_escapes(nlines)
+    -- Return scrollback as escape sequences
+    local lines = {}
+    for i = 1, math.min(nlines or #self.text, #self.text) do
+        lines[#lines + 1] = self.text[i]
+    end
+    return table.concat(lines, "\r\n")
+end
+
+function FakePane:is_alt_screen_active()
+    return self._alt_screen
+end
+
+function FakePane:get_foreground_process_info()
+    return self._process
+end
+
+function FakePane:get_dimensions()
+    return { scrollback_rows = #self.text, cols = self.width, rows = self.height }
+end
+
+-- Split creates a new pane and tracks it
+function FakePane:split(args)
+    args = args or {}
+    local direction = args.direction or "Right"
+    local size = args.size
+
+    local new_pane = FakePane.new({
+        cwd = args.cwd or self.cwd,
+        domain = args.domain and args.domain.DomainName or self.domain,
+    })
+
+    -- Calculate geometry based on split direction
+    if direction == "Right" then
+        -- Horizontal split: new pane to the right
+        local split_width = size and math.floor(self.width * size) or math.floor(self.width / 2)
+        new_pane.left = self.left + self.width - split_width + 1
+        new_pane.top = self.top
+        new_pane.width = split_width
+        new_pane.height = self.height
+        self.width = self.width - split_width - 1
+    elseif direction == "Bottom" then
+        -- Vertical split: new pane below
+        local split_height = size and math.floor(self.height * size) or math.floor(self.height / 2)
+        new_pane.left = self.left
+        new_pane.top = self.top + self.height - split_height + 1
+        new_pane.width = self.width
+        new_pane.height = split_height
+        self.height = self.height - split_height - 1
+    end
+
+    table.insert(self._splits, new_pane)
+
+    -- Add to tab's pane list if we have a reference
+    if self._tab then
+        new_pane._tab = self._tab
+        table.insert(self._tab._panes, new_pane)
+    end
+
+    return new_pane
+end
+
+function FakePane:send_text(text)
+    table.insert(self.text, text)
+end
+
+function FakePane:inject_output(text)
+    table.insert(self.text, text)
+end
+
+function FakePane:activate()
+    -- Deactivate other panes in the same tab
+    if self._tab then
+        for _, pane in ipairs(self._tab._panes) do
+            pane.is_active = false
+        end
+    end
+    self.is_active = true
+end
+
+function FakePane:tab()
+    return self._tab
+end
+
+function FakePane:get_lines()
+    return table.concat(self.text, "\n")
+end
+
+--------------------------------------------------------------------------------
+-- FakeTab
+--------------------------------------------------------------------------------
+
+---@class FakeTab
+---@field _id number
+---@field _title string
+---@field _panes FakePane[]
+---@field _active_pane FakePane?
+---@field _window FakeWindow?
+---@field _is_zoomed boolean
+local FakeTab = {}
+FakeTab.__index = FakeTab
+
+function FakeTab.new(opts)
+    opts = opts or {}
+    local self = setmetatable({}, FakeTab)
+    self._id = gen_tab_id()
+    self._title = opts.title or ""
+    self._panes = {}
+    self._active_pane = nil
+    self._window = nil
+    self._is_zoomed = false
+    return self
+end
+
+function FakeTab:tab_id()
+    return self._id
+end
+
+function FakeTab:get_title()
+    return self._title
+end
+
+function FakeTab:set_title(title)
+    self._title = title
+end
+
+function FakeTab:panes()
+    return self._panes
+end
+
+function FakeTab:panes_with_info()
+    local result = {}
+    for _, pane in ipairs(self._panes) do
+        result[#result + 1] = {
+            pane = pane, is_active = pane == self._active_pane or pane.is_active, is_zoomed = pane.is_zoomed,
+            left = pane.left, top = pane.top, width = pane.width, height = pane.height,
+        }
+    end
+    return result
+end
+
+function FakeTab:active_pane()
+    return self._active_pane or self._panes[1]
+end
+
+function FakeTab:get_size()
+    -- Compute from pane dimensions
+    local max_width, max_height = 0, 0
+    for _, p in ipairs(self._panes) do
+        max_width = math.max(max_width, p.left + p.width)
+        max_height = math.max(max_height, p.top + p.height)
+    end
+    return { cols = max_width, rows = max_height, pixel_width = max_width * 10, pixel_height = max_height * 20 }
+end
+
+function FakeTab:window()
+    return self._window
+end
+
+function FakeTab:activate()
+    if self._window then
+        self._window._active_tab = self
+    end
+end
+
+function FakeTab:set_zoomed(zoomed)
+    self._is_zoomed = zoomed
+    -- Set zoomed on active pane
+    if self._active_pane then
+        self._active_pane.is_zoomed = zoomed
+    end
+end
+
+-- Internal: add a pane to the tab
+function FakeTab:_add_pane(pane)
+    pane._tab = self
+    table.insert(self._panes, pane)
+    if not self._active_pane then
+        self._active_pane = pane
+        pane.is_active = true
+    end
+end
+
+--------------------------------------------------------------------------------
+-- FakeWindow
+--------------------------------------------------------------------------------
+
+---@class FakeWindow
+---@field _id number
+---@field _title string
+---@field _workspace string
+---@field _tabs FakeTab[]
+---@field _active_tab FakeTab?
+---@field _gui_window FakeGuiWindow?
+local FakeWindow = {}
+FakeWindow.__index = FakeWindow
+
+function FakeWindow.new(opts)
+    opts = opts or {}
+    local self = setmetatable({}, FakeWindow)
+    self._id = gen_window_id()
+    self._title = opts.title or ""
+    self._workspace = opts.workspace or "default"
+    self._tabs = {}
+    self._active_tab = nil
+    self._gui_window = nil
+    return self
+end
+
+function FakeWindow:window_id()
+    return self._id
+end
+
+function FakeWindow:get_title()
+    return self._title
+end
+
+function FakeWindow:set_title(title)
+    self._title = title
+end
+
+function FakeWindow:get_workspace()
+    return self._workspace
+end
+
+function FakeWindow:tabs()
+    return self._tabs
+end
+
+function FakeWindow:tabs_with_info()
+    local result = {}
+    for _, tab in ipairs(self._tabs) do
+        result[#result + 1] = { tab = tab, is_active = tab == self._active_tab }
+    end
+    return result
+end
+
+function FakeWindow:active_tab()
+    return self._active_tab or self._tabs[1]
+end
+
+function FakeWindow:active_pane()
+    local tab = self:active_tab()
+    return tab and tab:active_pane()
+end
+
+function FakeWindow:spawn_tab(args)
+    args = args or {}
+    local tab = FakeTab.new({ title = args.title or "" })
+    local pane = FakePane.new({
+        cwd = args.cwd,
+        domain = args.domain and args.domain.DomainName or "local",
+    })
+    tab:_add_pane(pane)
+    tab._window = self
+    table.insert(self._tabs, tab)
+    if not self._active_tab then
+        self._active_tab = tab
+    end
+    return tab, pane, self
+end
+
+function FakeWindow:gui_window()
+    if not self._gui_window then
+        self._gui_window = FakeGuiWindow.new(self)
+    end
+    return self._gui_window
+end
+
+-- Internal: add a tab to the window
+function FakeWindow:_add_tab(tab)
+    tab._window = self
+    table.insert(self._tabs, tab)
+    if not self._active_tab then
+        self._active_tab = tab
+    end
+end
+
+--------------------------------------------------------------------------------
+-- FakeGuiWindow (for perform_action and set_inner_size)
+--------------------------------------------------------------------------------
+
+---@class FakeGuiWindow
+---@field _mux_window FakeWindow
+---@field _inner_width number
+---@field _inner_height number
+---@field _performed_actions table[]
+local FakeGuiWindow = {}
+FakeGuiWindow.__index = FakeGuiWindow
+
+function FakeGuiWindow.new(mux_window)
+    local self = setmetatable({}, FakeGuiWindow)
+    self._mux_window = mux_window
+    self._inner_width = 1600
+    self._inner_height = 960
+    self._performed_actions = {}
+    return self
+end
+
+function FakeGuiWindow:set_inner_size(width, height)
+    self._inner_width = width
+    self._inner_height = height
+end
+
+function FakeGuiWindow:perform_action(action, pane)
+    table.insert(self._performed_actions, { action = action, pane = pane })
+end
+
+function FakeGuiWindow:is_focused()
+    return true
+end
+
+--------------------------------------------------------------------------------
+-- Builder Pattern
+--------------------------------------------------------------------------------
+
+---@class WorkspaceBuilder
+---@field _name string
+---@field _windows WindowBuilder[]
+---@field _current_window WindowBuilder?
+local WorkspaceBuilder = {}
+WorkspaceBuilder.__index = WorkspaceBuilder
+
+---@class WindowBuilder
+---@field _title string
+---@field _tabs TabBuilder[]
+---@field _current_tab TabBuilder?
+---@field _workspace_builder WorkspaceBuilder
+local WindowBuilder = {}
+WindowBuilder.__index = WindowBuilder
+
+---@class TabBuilder
+---@field _title string
+---@field _panes PaneConfig[]
+---@field _window_builder WindowBuilder
+local TabBuilder = {}
+TabBuilder.__index = TabBuilder
+
+---@alias PaneConfig {left: number, top: number, width: number, height: number, cwd: string, domain: string?, text: string?, is_active: boolean?, is_zoomed: boolean?, process: table?, alt_screen: boolean?}
+
+-- WorkspaceBuilder methods
+
+function WorkspaceBuilder.new(name)
+    local self = setmetatable({}, WorkspaceBuilder)
+    self._name = name or "default"
+    self._windows = {}
+    self._current_window = nil
+    return self
+end
+
+function WorkspaceBuilder:window(title)
+    local win_builder = WindowBuilder.new(title, self)
+    table.insert(self._windows, win_builder)
+    self._current_window = win_builder
+    return win_builder
+end
+
+function WorkspaceBuilder:build()
+    local windows = {}
+    for _, win_builder in ipairs(self._windows) do
+        local window = win_builder:_build(self._name)
+        table.insert(windows, window)
+    end
+    return {
+        name = self._name,
+        windows = windows,
+    }
+end
+
+-- WindowBuilder methods
+
+function WindowBuilder.new(title, workspace_builder)
+    local self = setmetatable({}, WindowBuilder)
+    self._title = title or ""
+    self._tabs = {}
+    self._current_tab = nil
+    self._workspace_builder = workspace_builder
+    return self
+end
+
+function WindowBuilder:tab(title)
+    local tab_builder = TabBuilder.new(title, self)
+    table.insert(self._tabs, tab_builder)
+    self._current_tab = tab_builder
+    return tab_builder
+end
+
+function WindowBuilder:window(title)
+    -- Delegate to workspace builder to add another window
+    return self._workspace_builder:window(title)
+end
+
+function WindowBuilder:build()
+    return self._workspace_builder:build()
+end
+
+function WindowBuilder:_build(workspace_name)
+    local window = FakeWindow.new({
+        title = self._title,
+        workspace = workspace_name,
+    })
+
+    for _, tab_builder in ipairs(self._tabs) do
+        local tab = tab_builder:_build()
+        window:_add_tab(tab)
+    end
+
+    return window
+end
+
+-- TabBuilder methods
+
+function TabBuilder.new(title, window_builder)
+    local self = setmetatable({}, TabBuilder)
+    self._title = title or ""
+    self._panes = {}
+    self._window_builder = window_builder
+    return self
+end
+
+function TabBuilder:pane(config)
+    config = config or {}
+    config.is_first = #self._panes == 0
+    table.insert(self._panes, { type = "pane", config = config })
+    return self
+end
+
+function TabBuilder:hsplit(config)
+    config = config or {}
+    config.split_direction = "Right"
+    table.insert(self._panes, { type = "split", config = config })
+    return self
+end
+
+function TabBuilder:vsplit(config)
+    config = config or {}
+    config.split_direction = "Bottom"
+    table.insert(self._panes, { type = "split", config = config })
+    return self
+end
+
+function TabBuilder:tab(title)
+    return self._window_builder:tab(title)
+end
+
+function TabBuilder:window(title)
+    return self._window_builder:window(title)
+end
+
+function TabBuilder:build()
+    return self._window_builder:build()
+end
+
+function TabBuilder:_build()
+    local tab = FakeTab.new({ title = self._title })
+    local active_pane = nil
+
+    for _, pane_spec in ipairs(self._panes) do
+        local config = pane_spec.config
+        local pane
+
+        if pane_spec.type == "pane" or pane_spec.config.is_first then
+            -- Create initial pane with explicit geometry
+            pane = FakePane.new({
+                left = config.left or 0,
+                top = config.top or 0,
+                width = config.width or 160,
+                height = config.height or 48,
+                cwd = config.cwd or "/home/user",
+                domain = config.domain or "local",
+                text = config.text,
+                is_active = config.is_active,
+                is_zoomed = config.is_zoomed,
+                process = config.process,
+                alt_screen = config.alt_screen,
+            })
+            tab:_add_pane(pane)
+        else
+            -- Split from the last pane in the tab
+            local parent = tab._panes[#tab._panes]
+            pane = FakePane.new({
+                left = config.left or 0,
+                top = config.top or 0,
+                width = config.width or 80,
+                height = config.height or 48,
+                cwd = config.cwd or parent.cwd,
+                domain = config.domain or parent.domain,
+                text = config.text,
+                is_active = config.is_active,
+                is_zoomed = config.is_zoomed,
+                process = config.process,
+                alt_screen = config.alt_screen,
+            })
+            pane._tab = tab
+            table.insert(tab._panes, pane)
+        end
+
+        if config.is_active then
+            active_pane = pane
+        end
+    end
+
+    -- Set active pane
+    if active_pane then
+        tab._active_pane = active_pane
+    elseif #tab._panes > 0 then
+        tab._active_pane = tab._panes[1]
+        tab._panes[1].is_active = true
+    end
+
+    return tab
+end
+
+--------------------------------------------------------------------------------
+-- Mux State Management
+--------------------------------------------------------------------------------
+
+local active_workspace = "default"
+local workspaces = {}
+local all_windows = {}
+
+function mux.reset()
+    active_workspace = "default"
+    workspaces = {}
+    all_windows = {}
+    domains = {
+        ["local"] = { name = "local", spawnable = true },
+    }
+    -- Reset ID generators
+    next_pane_id = 1
+    next_tab_id = 1
+    next_window_id = 1
+end
+
+function mux.get_active_workspace()
+    return active_workspace
+end
+
+function mux.set_active(workspace_data)
+    if type(workspace_data) == "string" then
+        active_workspace = workspace_data
+    elseif workspace_data and workspace_data.name then
+        active_workspace = workspace_data.name
+        workspaces[workspace_data.name] = workspace_data
+        -- Add windows to all_windows
+        for _, win in ipairs(workspace_data.windows or {}) do
+            all_windows[#all_windows + 1] = win
+        end
+    end
+end
+
+function mux.all_windows()
+    return all_windows
+end
+
+function mux.spawn_window(args)
+    args = args or {}
+    local workspace_name = args.workspace or active_workspace
+
+    local window = FakeWindow.new({
+        workspace = workspace_name,
+    })
+
+    local tab = FakeTab.new({})
+    local pane = FakePane.new({
+        cwd = args.cwd,
+        width = args.width or 160,
+        height = args.height or 48,
+    })
+    tab:_add_pane(pane)
+    window:_add_tab(tab)
+
+    all_windows[#all_windows + 1] = window
+
+    return tab, pane, window
+end
+
+--------------------------------------------------------------------------------
+-- Builder Entry Point
+--------------------------------------------------------------------------------
+
+function mux.workspace(name)
+    return WorkspaceBuilder.new(name)
+end
+
+-- Create workspace from fixture data
+function mux.from_fixture(fixture)
+    -- Simple fixture format: just panes with geometry
+    local builder = mux.workspace("fixture")
+        :window("main")
+            :tab("tab")
+
+    for i, pane_config in ipairs(fixture.panes or {}) do
+        if i == 1 then
+            builder:pane(pane_config)
+        else
+            -- Determine split direction based on position
+            if pane_config.left > 0 and pane_config.top == 0 then
+                builder:hsplit(pane_config)
+            else
+                builder:vsplit(pane_config)
+            end
+        end
+    end
+
+    return builder:build()
+end
+
+return mux

--- a/plugin/resurrect/test/fakes/mux.lua
+++ b/plugin/resurrect/test/fakes/mux.lua
@@ -12,21 +12,21 @@ local next_tab_id = 1
 local next_window_id = 1
 
 local function gen_pane_id()
-    local id = next_pane_id
-    next_pane_id = next_pane_id + 1
-    return id
+	local id = next_pane_id
+	next_pane_id = next_pane_id + 1
+	return id
 end
 
 local function gen_tab_id()
-    local id = next_tab_id
-    next_tab_id = next_tab_id + 1
-    return id
+	local id = next_tab_id
+	next_tab_id = next_tab_id + 1
+	return id
 end
 
 local function gen_window_id()
-    local id = next_window_id
-    next_window_id = next_window_id + 1
-    return id
+	local id = next_window_id
+	next_window_id = next_window_id + 1
+	return id
 end
 
 --------------------------------------------------------------------------------
@@ -34,26 +34,30 @@ end
 --------------------------------------------------------------------------------
 
 local domains = {
-    ["local"] = { name = "local", spawnable = true },
+	["local"] = { name = "local", spawnable = true },
 }
 
 function mux.get_domain(name)
-    local domain = domains[name]
-    if domain then
-        return {
-            name = domain.name,
-            is_spawnable = function() return domain.spawnable end,
-        }
-    end
-    -- Default: unknown domains are spawnable
-    return {
-        name = name,
-        is_spawnable = function() return true end,
-    }
+	local domain = domains[name]
+	if domain then
+		return {
+			name = domain.name,
+			is_spawnable = function()
+				return domain.spawnable
+			end,
+		}
+	end
+	-- Default: unknown domains are spawnable
+	return {
+		name = name,
+		is_spawnable = function()
+			return true
+		end,
+	}
 end
 
 function mux.set_domain_spawnable(name, spawnable)
-    domains[name] = { name = name, spawnable = spawnable }
+	domains[name] = { name = name, spawnable = spawnable }
 end
 
 --------------------------------------------------------------------------------
@@ -79,126 +83,126 @@ local FakePane = {}
 FakePane.__index = FakePane
 
 function FakePane.new(opts)
-    opts = opts or {}
-    local self = setmetatable({}, FakePane)
-    self._id = gen_pane_id()
-    self.left = opts.left or 0
-    self.top = opts.top or 0
-    self.width = opts.width or 160
-    self.height = opts.height or 48
-    self.cwd = opts.cwd or "/home/user"
-    self.domain = opts.domain or "local"
-    self.text = opts.text and { opts.text } or {}
-    self.is_active = opts.is_active or false
-    self.is_zoomed = opts.is_zoomed or false
-    self._process = opts.process or nil
-    self._alt_screen = opts.alt_screen or false
-    self._splits = {}
-    self._tab = nil
-    return self
+	opts = opts or {}
+	local self = setmetatable({}, FakePane)
+	self._id = gen_pane_id()
+	self.left = opts.left or 0
+	self.top = opts.top or 0
+	self.width = opts.width or 160
+	self.height = opts.height or 48
+	self.cwd = opts.cwd or "/home/user"
+	self.domain = opts.domain or "local"
+	self.text = opts.text and { opts.text } or {}
+	self.is_active = opts.is_active or false
+	self.is_zoomed = opts.is_zoomed or false
+	self._process = opts.process or nil
+	self._alt_screen = opts.alt_screen or false
+	self._splits = {}
+	self._tab = nil
+	return self
 end
 
 function FakePane:pane_id()
-    return self._id
+	return self._id
 end
 
 function FakePane:get_domain_name()
-    return self.domain
+	return self.domain
 end
 
 function FakePane:get_current_working_dir()
-    if not self.cwd or self.cwd == "" then
-        return nil
-    end
-    return { file_path = self.cwd }
+	if not self.cwd or self.cwd == "" then
+		return nil
+	end
+	return { file_path = self.cwd }
 end
 
 function FakePane:get_lines_as_escapes(nlines)
-    -- Return scrollback as escape sequences
-    local lines = {}
-    for i = 1, math.min(nlines or #self.text, #self.text) do
-        lines[#lines + 1] = self.text[i]
-    end
-    return table.concat(lines, "\r\n")
+	-- Return scrollback as escape sequences
+	local lines = {}
+	for i = 1, math.min(nlines or #self.text, #self.text) do
+		lines[#lines + 1] = self.text[i]
+	end
+	return table.concat(lines, "\r\n")
 end
 
 function FakePane:is_alt_screen_active()
-    return self._alt_screen
+	return self._alt_screen
 end
 
 function FakePane:get_foreground_process_info()
-    return self._process
+	return self._process
 end
 
 function FakePane:get_dimensions()
-    return { scrollback_rows = #self.text, cols = self.width, rows = self.height }
+	return { scrollback_rows = #self.text, cols = self.width, rows = self.height }
 end
 
 -- Split creates a new pane and tracks it
 function FakePane:split(args)
-    args = args or {}
-    local direction = args.direction or "Right"
-    local size = args.size
+	args = args or {}
+	local direction = args.direction or "Right"
+	local size = args.size
 
-    local new_pane = FakePane.new({
-        cwd = args.cwd or self.cwd,
-        domain = args.domain and args.domain.DomainName or self.domain,
-    })
+	local new_pane = FakePane.new({
+		cwd = args.cwd or self.cwd,
+		domain = args.domain and args.domain.DomainName or self.domain,
+	})
 
-    -- Calculate geometry based on split direction
-    if direction == "Right" then
-        -- Horizontal split: new pane to the right
-        local split_width = size and math.floor(self.width * size) or math.floor(self.width / 2)
-        new_pane.left = self.left + self.width - split_width + 1
-        new_pane.top = self.top
-        new_pane.width = split_width
-        new_pane.height = self.height
-        self.width = self.width - split_width - 1
-    elseif direction == "Bottom" then
-        -- Vertical split: new pane below
-        local split_height = size and math.floor(self.height * size) or math.floor(self.height / 2)
-        new_pane.left = self.left
-        new_pane.top = self.top + self.height - split_height + 1
-        new_pane.width = self.width
-        new_pane.height = split_height
-        self.height = self.height - split_height - 1
-    end
+	-- Calculate geometry based on split direction
+	if direction == "Right" then
+		-- Horizontal split: new pane to the right
+		local split_width = size and math.floor(self.width * size) or math.floor(self.width / 2)
+		new_pane.left = self.left + self.width - split_width + 1
+		new_pane.top = self.top
+		new_pane.width = split_width
+		new_pane.height = self.height
+		self.width = self.width - split_width - 1
+	elseif direction == "Bottom" then
+		-- Vertical split: new pane below
+		local split_height = size and math.floor(self.height * size) or math.floor(self.height / 2)
+		new_pane.left = self.left
+		new_pane.top = self.top + self.height - split_height + 1
+		new_pane.width = self.width
+		new_pane.height = split_height
+		self.height = self.height - split_height - 1
+	end
 
-    table.insert(self._splits, new_pane)
+	table.insert(self._splits, new_pane)
 
-    -- Add to tab's pane list if we have a reference
-    if self._tab then
-        new_pane._tab = self._tab
-        table.insert(self._tab._panes, new_pane)
-    end
+	-- Add to tab's pane list if we have a reference
+	if self._tab then
+		new_pane._tab = self._tab
+		table.insert(self._tab._panes, new_pane)
+	end
 
-    return new_pane
+	return new_pane
 end
 
 function FakePane:send_text(text)
-    table.insert(self.text, text)
+	table.insert(self.text, text)
 end
 
 function FakePane:inject_output(text)
-    table.insert(self.text, text)
+	table.insert(self.text, text)
 end
 
 function FakePane:activate()
-    -- Deactivate other panes in the same tab
-    if self._tab then
-        for _, pane in ipairs(self._tab._panes) do
-            pane.is_active = false
-        end
-    end
-    self.is_active = true
+	-- Deactivate other panes in the same tab
+	if self._tab then
+		for _, pane in ipairs(self._tab._panes) do
+			pane.is_active = false
+		end
+	end
+	self.is_active = true
 end
 
 function FakePane:tab()
-    return self._tab
+	return self._tab
 end
 
 function FakePane:get_lines()
-    return table.concat(self.text, "\n")
+	return table.concat(self.text, "\n")
 end
 
 --------------------------------------------------------------------------------
@@ -216,89 +220,97 @@ local FakeTab = {}
 FakeTab.__index = FakeTab
 
 function FakeTab.new(opts)
-    opts = opts or {}
-    local self = setmetatable({}, FakeTab)
-    self._id = gen_tab_id()
-    self._title = opts.title or ""
-    self._panes = {}
-    self._active_pane = nil
-    self._window = nil
-    self._is_zoomed = false
-    return self
+	opts = opts or {}
+	local self = setmetatable({}, FakeTab)
+	self._id = gen_tab_id()
+	self._title = opts.title or ""
+	self._panes = {}
+	self._active_pane = nil
+	self._window = nil
+	self._is_zoomed = false
+	return self
 end
 
 function FakeTab:tab_id()
-    return self._id
+	return self._id
 end
 
 function FakeTab:get_title()
-    return self._title
+	return self._title
 end
 
 function FakeTab:set_title(title)
-    self._title = title
+	self._title = title
 end
 
 function FakeTab:panes()
-    return self._panes
+	return self._panes
 end
 
 function FakeTab:panes_with_info()
-    local result = {}
-    for _, pane in ipairs(self._panes) do
-        result[#result + 1] = {
-            pane = pane, is_active = pane == self._active_pane or pane.is_active, is_zoomed = pane.is_zoomed,
-            left = pane.left, top = pane.top, width = pane.width, height = pane.height,
-        }
-    end
-    return result
+	local result = {}
+	for _, pane in ipairs(self._panes) do
+		result[#result + 1] = {
+			pane = pane,
+			is_active = pane == self._active_pane or pane.is_active,
+			is_zoomed = pane.is_zoomed,
+			left = pane.left,
+			top = pane.top,
+			width = pane.width,
+			height = pane.height,
+		}
+	end
+	return result
 end
 
 function FakeTab:active_pane()
-    return self._active_pane or self._panes[1]
+	return self._active_pane or self._panes[1]
 end
 
 function FakeTab:get_size()
-    -- Compute from pane dimensions
-    local max_width, max_height = 0, 0
-    for _, p in ipairs(self._panes) do
-        max_width = math.max(max_width, p.left + p.width)
-        max_height = math.max(max_height, p.top + p.height)
-    end
-    return { cols = max_width, rows = max_height, pixel_width = max_width * 10, pixel_height = max_height * 20 }
+	-- Compute from pane dimensions
+	local max_width, max_height = 0, 0
+	for _, p in ipairs(self._panes) do
+		max_width = math.max(max_width, p.left + p.width)
+		max_height = math.max(max_height, p.top + p.height)
+	end
+	return { cols = max_width, rows = max_height, pixel_width = max_width * 10, pixel_height = max_height * 20 }
 end
 
 function FakeTab:window()
-    return self._window
+	return self._window
 end
 
 function FakeTab:activate()
-    if self._window then
-        self._window._active_tab = self
-    end
+	if self._window then
+		self._window._active_tab = self
+	end
 end
 
 function FakeTab:set_zoomed(zoomed)
-    self._is_zoomed = zoomed
-    -- Set zoomed on active pane
-    if self._active_pane then
-        self._active_pane.is_zoomed = zoomed
-    end
+	self._is_zoomed = zoomed
+	-- Set zoomed on active pane
+	if self._active_pane then
+		self._active_pane.is_zoomed = zoomed
+	end
 end
 
 -- Internal: add a pane to the tab
 function FakeTab:_add_pane(pane)
-    pane._tab = self
-    table.insert(self._panes, pane)
-    if not self._active_pane then
-        self._active_pane = pane
-        pane.is_active = true
-    end
+	pane._tab = self
+	table.insert(self._panes, pane)
+	if not self._active_pane then
+		self._active_pane = pane
+		pane.is_active = true
+	end
 end
 
 --------------------------------------------------------------------------------
 -- FakeWindow
 --------------------------------------------------------------------------------
+
+-- Forward declaration for FakeGuiWindow (defined below)
+local FakeGuiWindow
 
 ---@class FakeWindow
 ---@field _id number
@@ -311,84 +323,84 @@ local FakeWindow = {}
 FakeWindow.__index = FakeWindow
 
 function FakeWindow.new(opts)
-    opts = opts or {}
-    local self = setmetatable({}, FakeWindow)
-    self._id = gen_window_id()
-    self._title = opts.title or ""
-    self._workspace = opts.workspace or "default"
-    self._tabs = {}
-    self._active_tab = nil
-    self._gui_window = nil
-    return self
+	opts = opts or {}
+	local self = setmetatable({}, FakeWindow)
+	self._id = gen_window_id()
+	self._title = opts.title or ""
+	self._workspace = opts.workspace or "default"
+	self._tabs = {}
+	self._active_tab = nil
+	self._gui_window = nil
+	return self
 end
 
 function FakeWindow:window_id()
-    return self._id
+	return self._id
 end
 
 function FakeWindow:get_title()
-    return self._title
+	return self._title
 end
 
 function FakeWindow:set_title(title)
-    self._title = title
+	self._title = title
 end
 
 function FakeWindow:get_workspace()
-    return self._workspace
+	return self._workspace
 end
 
 function FakeWindow:tabs()
-    return self._tabs
+	return self._tabs
 end
 
 function FakeWindow:tabs_with_info()
-    local result = {}
-    for _, tab in ipairs(self._tabs) do
-        result[#result + 1] = { tab = tab, is_active = tab == self._active_tab }
-    end
-    return result
+	local result = {}
+	for _, tab in ipairs(self._tabs) do
+		result[#result + 1] = { tab = tab, is_active = tab == self._active_tab }
+	end
+	return result
 end
 
 function FakeWindow:active_tab()
-    return self._active_tab or self._tabs[1]
+	return self._active_tab or self._tabs[1]
 end
 
 function FakeWindow:active_pane()
-    local tab = self:active_tab()
-    return tab and tab:active_pane()
+	local tab = self:active_tab()
+	return tab and tab:active_pane()
 end
 
 function FakeWindow:spawn_tab(args)
-    args = args or {}
-    local tab = FakeTab.new({ title = args.title or "" })
-    local pane = FakePane.new({
-        cwd = args.cwd,
-        domain = args.domain and args.domain.DomainName or "local",
-    })
-    tab:_add_pane(pane)
-    tab._window = self
-    table.insert(self._tabs, tab)
-    if not self._active_tab then
-        self._active_tab = tab
-    end
-    return tab, pane, self
+	args = args or {}
+	local tab = FakeTab.new({ title = args.title or "" })
+	local pane = FakePane.new({
+		cwd = args.cwd,
+		domain = args.domain and args.domain.DomainName or "local",
+	})
+	tab:_add_pane(pane)
+	tab._window = self
+	table.insert(self._tabs, tab)
+	if not self._active_tab then
+		self._active_tab = tab
+	end
+	return tab, pane, self
 end
 
 function FakeWindow:gui_window()
-    if not self._gui_window then
-        self._gui_window = FakeGuiWindow.new(self)
-    end
-    return self._gui_window
+	if not self._gui_window then
+		self._gui_window = FakeGuiWindow.new(self)
+	end
+	return self._gui_window
 end
 
 -- Internal: add a tab to the window
 function FakeWindow:_add_tab(tab)
-    tab._window = self
-    table.insert(self._tabs, tab)
-    if not self._active_tab then
-        self._active_tab = tab
-    end
+	tab._window = self
+	table.insert(self._tabs, tab)
+	if not self._active_tab then
+		self._active_tab = tab
+	end
 end
 
 --------------------------------------------------------------------------------
@@ -400,29 +412,29 @@ end
 ---@field _inner_width number
 ---@field _inner_height number
 ---@field _performed_actions table[]
-local FakeGuiWindow = {}
+FakeGuiWindow = {}
 FakeGuiWindow.__index = FakeGuiWindow
 
 function FakeGuiWindow.new(mux_window)
-    local self = setmetatable({}, FakeGuiWindow)
-    self._mux_window = mux_window
-    self._inner_width = 1600
-    self._inner_height = 960
-    self._performed_actions = {}
-    return self
+	local self = setmetatable({}, FakeGuiWindow)
+	self._mux_window = mux_window
+	self._inner_width = 1600
+	self._inner_height = 960
+	self._performed_actions = {}
+	return self
 end
 
 function FakeGuiWindow:set_inner_size(width, height)
-    self._inner_width = width
-    self._inner_height = height
+	self._inner_width = width
+	self._inner_height = height
 end
 
 function FakeGuiWindow:perform_action(action, pane)
-    table.insert(self._performed_actions, { action = action, pane = pane })
+	table.insert(self._performed_actions, { action = action, pane = pane })
 end
 
 function FakeGuiWindow:is_focused()
-    return true
+	return true
 end
 
 --------------------------------------------------------------------------------
@@ -451,179 +463,181 @@ WindowBuilder.__index = WindowBuilder
 local TabBuilder = {}
 TabBuilder.__index = TabBuilder
 
----@alias PaneConfig {left: number, top: number, width: number, height: number, cwd: string, domain: string?, text: string?, is_active: boolean?, is_zoomed: boolean?, process: table?, alt_screen: boolean?}
+---@alias PaneConfig {left: number, top: number, width: number, height: number,
+---cwd: string, domain: string?, text: string?, is_active: boolean?, is_zoomed: boolean?,
+---process: table?, alt_screen: boolean?}
 
 -- WorkspaceBuilder methods
 
 function WorkspaceBuilder.new(name)
-    local self = setmetatable({}, WorkspaceBuilder)
-    self._name = name or "default"
-    self._windows = {}
-    self._current_window = nil
-    return self
+	local self = setmetatable({}, WorkspaceBuilder)
+	self._name = name or "default"
+	self._windows = {}
+	self._current_window = nil
+	return self
 end
 
 function WorkspaceBuilder:window(title)
-    local win_builder = WindowBuilder.new(title, self)
-    table.insert(self._windows, win_builder)
-    self._current_window = win_builder
-    return win_builder
+	local win_builder = WindowBuilder.new(title, self)
+	table.insert(self._windows, win_builder)
+	self._current_window = win_builder
+	return win_builder
 end
 
 function WorkspaceBuilder:build()
-    local windows = {}
-    for _, win_builder in ipairs(self._windows) do
-        local window = win_builder:_build(self._name)
-        table.insert(windows, window)
-    end
-    return {
-        name = self._name,
-        windows = windows,
-    }
+	local windows = {}
+	for _, win_builder in ipairs(self._windows) do
+		local window = win_builder:_build(self._name)
+		table.insert(windows, window)
+	end
+	return {
+		name = self._name,
+		windows = windows,
+	}
 end
 
 -- WindowBuilder methods
 
 function WindowBuilder.new(title, workspace_builder)
-    local self = setmetatable({}, WindowBuilder)
-    self._title = title or ""
-    self._tabs = {}
-    self._current_tab = nil
-    self._workspace_builder = workspace_builder
-    return self
+	local self = setmetatable({}, WindowBuilder)
+	self._title = title or ""
+	self._tabs = {}
+	self._current_tab = nil
+	self._workspace_builder = workspace_builder
+	return self
 end
 
 function WindowBuilder:tab(title)
-    local tab_builder = TabBuilder.new(title, self)
-    table.insert(self._tabs, tab_builder)
-    self._current_tab = tab_builder
-    return tab_builder
+	local tab_builder = TabBuilder.new(title, self)
+	table.insert(self._tabs, tab_builder)
+	self._current_tab = tab_builder
+	return tab_builder
 end
 
 function WindowBuilder:window(title)
-    -- Delegate to workspace builder to add another window
-    return self._workspace_builder:window(title)
+	-- Delegate to workspace builder to add another window
+	return self._workspace_builder:window(title)
 end
 
 function WindowBuilder:build()
-    return self._workspace_builder:build()
+	return self._workspace_builder:build()
 end
 
 function WindowBuilder:_build(workspace_name)
-    local window = FakeWindow.new({
-        title = self._title,
-        workspace = workspace_name,
-    })
+	local window = FakeWindow.new({
+		title = self._title,
+		workspace = workspace_name,
+	})
 
-    for _, tab_builder in ipairs(self._tabs) do
-        local tab = tab_builder:_build()
-        window:_add_tab(tab)
-    end
+	for _, tab_builder in ipairs(self._tabs) do
+		local tab = tab_builder:_build()
+		window:_add_tab(tab)
+	end
 
-    return window
+	return window
 end
 
 -- TabBuilder methods
 
 function TabBuilder.new(title, window_builder)
-    local self = setmetatable({}, TabBuilder)
-    self._title = title or ""
-    self._panes = {}
-    self._window_builder = window_builder
-    return self
+	local self = setmetatable({}, TabBuilder)
+	self._title = title or ""
+	self._panes = {}
+	self._window_builder = window_builder
+	return self
 end
 
 function TabBuilder:pane(config)
-    config = config or {}
-    config.is_first = #self._panes == 0
-    table.insert(self._panes, { type = "pane", config = config })
-    return self
+	config = config or {}
+	config.is_first = #self._panes == 0
+	table.insert(self._panes, { type = "pane", config = config })
+	return self
 end
 
 function TabBuilder:hsplit(config)
-    config = config or {}
-    config.split_direction = "Right"
-    table.insert(self._panes, { type = "split", config = config })
-    return self
+	config = config or {}
+	config.split_direction = "Right"
+	table.insert(self._panes, { type = "split", config = config })
+	return self
 end
 
 function TabBuilder:vsplit(config)
-    config = config or {}
-    config.split_direction = "Bottom"
-    table.insert(self._panes, { type = "split", config = config })
-    return self
+	config = config or {}
+	config.split_direction = "Bottom"
+	table.insert(self._panes, { type = "split", config = config })
+	return self
 end
 
 function TabBuilder:tab(title)
-    return self._window_builder:tab(title)
+	return self._window_builder:tab(title)
 end
 
 function TabBuilder:window(title)
-    return self._window_builder:window(title)
+	return self._window_builder:window(title)
 end
 
 function TabBuilder:build()
-    return self._window_builder:build()
+	return self._window_builder:build()
 end
 
 function TabBuilder:_build()
-    local tab = FakeTab.new({ title = self._title })
-    local active_pane = nil
+	local tab = FakeTab.new({ title = self._title })
+	local active_pane = nil
 
-    for _, pane_spec in ipairs(self._panes) do
-        local config = pane_spec.config
-        local pane
+	for _, pane_spec in ipairs(self._panes) do
+		local config = pane_spec.config
+		local pane
 
-        if pane_spec.type == "pane" or pane_spec.config.is_first then
-            -- Create initial pane with explicit geometry
-            pane = FakePane.new({
-                left = config.left or 0,
-                top = config.top or 0,
-                width = config.width or 160,
-                height = config.height or 48,
-                cwd = config.cwd or "/home/user",
-                domain = config.domain or "local",
-                text = config.text,
-                is_active = config.is_active,
-                is_zoomed = config.is_zoomed,
-                process = config.process,
-                alt_screen = config.alt_screen,
-            })
-            tab:_add_pane(pane)
-        else
-            -- Split from the last pane in the tab
-            local parent = tab._panes[#tab._panes]
-            pane = FakePane.new({
-                left = config.left or 0,
-                top = config.top or 0,
-                width = config.width or 80,
-                height = config.height or 48,
-                cwd = config.cwd or parent.cwd,
-                domain = config.domain or parent.domain,
-                text = config.text,
-                is_active = config.is_active,
-                is_zoomed = config.is_zoomed,
-                process = config.process,
-                alt_screen = config.alt_screen,
-            })
-            pane._tab = tab
-            table.insert(tab._panes, pane)
-        end
+		if pane_spec.type == "pane" or pane_spec.config.is_first then
+			-- Create initial pane with explicit geometry
+			pane = FakePane.new({
+				left = config.left or 0,
+				top = config.top or 0,
+				width = config.width or 160,
+				height = config.height or 48,
+				cwd = config.cwd or "/home/user",
+				domain = config.domain or "local",
+				text = config.text,
+				is_active = config.is_active,
+				is_zoomed = config.is_zoomed,
+				process = config.process,
+				alt_screen = config.alt_screen,
+			})
+			tab:_add_pane(pane)
+		else
+			-- Split from the last pane in the tab
+			local parent = tab._panes[#tab._panes]
+			pane = FakePane.new({
+				left = config.left or 0,
+				top = config.top or 0,
+				width = config.width or 80,
+				height = config.height or 48,
+				cwd = config.cwd or parent.cwd,
+				domain = config.domain or parent.domain,
+				text = config.text,
+				is_active = config.is_active,
+				is_zoomed = config.is_zoomed,
+				process = config.process,
+				alt_screen = config.alt_screen,
+			})
+			pane._tab = tab
+			table.insert(tab._panes, pane)
+		end
 
-        if config.is_active then
-            active_pane = pane
-        end
-    end
+		if config.is_active then
+			active_pane = pane
+		end
+	end
 
-    -- Set active pane
-    if active_pane then
-        tab._active_pane = active_pane
-    elseif #tab._panes > 0 then
-        tab._active_pane = tab._panes[1]
-        tab._panes[1].is_active = true
-    end
+	-- Set active pane
+	if active_pane then
+		tab._active_pane = active_pane
+	elseif #tab._panes > 0 then
+		tab._active_pane = tab._panes[1]
+		tab._panes[1].is_active = true
+	end
 
-    return tab
+	return tab
 end
 
 --------------------------------------------------------------------------------
@@ -631,63 +645,63 @@ end
 --------------------------------------------------------------------------------
 
 local active_workspace = "default"
-local workspaces = {}
+local workspaces = {} -- luacheck: ignore 241 (variable never accessed)
 local all_windows = {}
 
 function mux.reset()
-    active_workspace = "default"
-    workspaces = {}
-    all_windows = {}
-    domains = {
-        ["local"] = { name = "local", spawnable = true },
-    }
-    -- Reset ID generators
-    next_pane_id = 1
-    next_tab_id = 1
-    next_window_id = 1
+	active_workspace = "default"
+	workspaces = {}
+	all_windows = {}
+	domains = {
+		["local"] = { name = "local", spawnable = true },
+	}
+	-- Reset ID generators
+	next_pane_id = 1
+	next_tab_id = 1
+	next_window_id = 1
 end
 
 function mux.get_active_workspace()
-    return active_workspace
+	return active_workspace
 end
 
 function mux.set_active(workspace_data)
-    if type(workspace_data) == "string" then
-        active_workspace = workspace_data
-    elseif workspace_data and workspace_data.name then
-        active_workspace = workspace_data.name
-        workspaces[workspace_data.name] = workspace_data
-        -- Add windows to all_windows
-        for _, win in ipairs(workspace_data.windows or {}) do
-            all_windows[#all_windows + 1] = win
-        end
-    end
+	if type(workspace_data) == "string" then
+		active_workspace = workspace_data
+	elseif workspace_data and workspace_data.name then
+		active_workspace = workspace_data.name
+		workspaces[workspace_data.name] = workspace_data
+		-- Add windows to all_windows
+		for _, win in ipairs(workspace_data.windows or {}) do
+			all_windows[#all_windows + 1] = win
+		end
+	end
 end
 
 function mux.all_windows()
-    return all_windows
+	return all_windows
 end
 
 function mux.spawn_window(args)
-    args = args or {}
-    local workspace_name = args.workspace or active_workspace
+	args = args or {}
+	local workspace_name = args.workspace or active_workspace
 
-    local window = FakeWindow.new({
-        workspace = workspace_name,
-    })
+	local window = FakeWindow.new({
+		workspace = workspace_name,
+	})
 
-    local tab = FakeTab.new({})
-    local pane = FakePane.new({
-        cwd = args.cwd,
-        width = args.width or 160,
-        height = args.height or 48,
-    })
-    tab:_add_pane(pane)
-    window:_add_tab(tab)
+	local tab = FakeTab.new({})
+	local pane = FakePane.new({
+		cwd = args.cwd,
+		width = args.width or 160,
+		height = args.height or 48,
+	})
+	tab:_add_pane(pane)
+	window:_add_tab(tab)
 
-    all_windows[#all_windows + 1] = window
+	all_windows[#all_windows + 1] = window
 
-    return tab, pane, window
+	return tab, pane, window
 end
 
 --------------------------------------------------------------------------------
@@ -695,30 +709,28 @@ end
 --------------------------------------------------------------------------------
 
 function mux.workspace(name)
-    return WorkspaceBuilder.new(name)
+	return WorkspaceBuilder.new(name)
 end
 
 -- Create workspace from fixture data
 function mux.from_fixture(fixture)
-    -- Simple fixture format: just panes with geometry
-    local builder = mux.workspace("fixture")
-        :window("main")
-            :tab("tab")
+	-- Simple fixture format: just panes with geometry
+	local builder = mux.workspace("fixture"):window("main"):tab("tab")
 
-    for i, pane_config in ipairs(fixture.panes or {}) do
-        if i == 1 then
-            builder:pane(pane_config)
-        else
-            -- Determine split direction based on position
-            if pane_config.left > 0 and pane_config.top == 0 then
-                builder:hsplit(pane_config)
-            else
-                builder:vsplit(pane_config)
-            end
-        end
-    end
+	for i, pane_config in ipairs(fixture.panes or {}) do
+		if i == 1 then
+			builder:pane(pane_config)
+		else
+			-- Determine split direction based on position
+			if pane_config.left > 0 and pane_config.top == 0 then
+				builder:hsplit(pane_config)
+			else
+				builder:vsplit(pane_config)
+			end
+		end
+	end
 
-    return builder:build()
+	return builder:build()
 end
 
 return mux

--- a/plugin/resurrect/test/fakes/wezterm.lua
+++ b/plugin/resurrect/test/fakes/wezterm.lua
@@ -1,0 +1,312 @@
+-- Fake WezTerm API for testing
+-- Provides a working implementation with test helpers for inspection
+local wezterm = {}
+
+-- Configurable platform settings
+wezterm.target_triple = "x86_64-apple-darwin"  -- default to macOS
+
+-- Directory paths (configurable)
+wezterm.home_dir = os.getenv("HOME") or "/home/test"
+wezterm.config_dir = wezterm.home_dir .. "/.config/wezterm"
+
+--------------------------------------------------------------------------------
+-- JSON encode/decode (using dkjson library)
+--------------------------------------------------------------------------------
+
+local json = require("test.lib.dkjson")
+
+function wezterm.json_encode(val)
+    return json.encode(val)
+end
+
+function wezterm.json_parse(str)
+    return json.decode(str)
+end
+
+-- Log capture storage (array of {level, message} objects)
+local captured_logs = {}
+
+-- Logging functions that capture output
+function wezterm.log_info(...)
+    local msg = table.concat({...}, " ")
+    captured_logs[#captured_logs + 1] = { level = "info", message = msg }
+end
+
+function wezterm.log_error(...)
+    local msg = table.concat({...}, " ")
+    captured_logs[#captured_logs + 1] = { level = "error", message = msg }
+end
+
+function wezterm.log_warn(...)
+    local msg = table.concat({...}, " ")
+    captured_logs[#captured_logs + 1] = { level = "warn", message = msg }
+end
+
+-- Event system
+local event_handlers = {}
+
+function wezterm.on(event_name, callback)
+    if not event_handlers[event_name] then
+        event_handlers[event_name] = {}
+    end
+    table.insert(event_handlers[event_name], callback)
+end
+
+function wezterm.emit(event_name, ...)
+    local handlers = event_handlers[event_name]
+    if handlers then
+        for _, callback in ipairs(handlers) do
+            callback(...)
+        end
+    end
+end
+
+-- Action callback (commonly used in wezterm configs)
+function wezterm.action_callback(fn)
+    return { callback = fn, type = "action_callback" }
+end
+
+-- Action table (mock)
+wezterm.action = setmetatable({}, {
+    __index = function(_, key)
+        return function(...)
+            return { action = key, args = {...} }
+        end
+    end
+})
+
+-- Config builder (mock)
+function wezterm.config_builder()
+    return {}
+end
+
+-- Plugin system (mock)
+wezterm.plugin = {}
+function wezterm.plugin.require(url)
+    return { url = url }
+end
+
+-- Utility functions
+function wezterm.format(items)
+    -- Simple format mock - just concatenate text items
+    local result = ""
+    for _, item in ipairs(items) do
+        if item.Text then
+            result = result .. item.Text
+        end
+    end
+    return result
+end
+
+function wezterm.strftime(format)
+    return os.date(format)
+end
+
+function wezterm.sleep_ms(ms)
+    -- No-op in tests, or use os.execute for actual sleep if needed
+end
+
+-- Shell join args (for restoring processes)
+function wezterm.shell_join_args(args)
+    if not args then return "" end
+    local parts = {}
+    for _, arg in ipairs(args) do
+        -- Simple quoting for args with spaces
+        if arg:match("%s") then
+            parts[#parts + 1] = '"' .. arg .. '"'
+        else
+            parts[#parts + 1] = arg
+        end
+    end
+    return table.concat(parts, " ")
+end
+
+--------------------------------------------------------------------------------
+-- Time module (for periodic saves and delayed operations)
+--------------------------------------------------------------------------------
+
+local pending_timers = {}
+
+wezterm.time = {
+    call_after = function(seconds, callback)
+        pending_timers[#pending_timers + 1] = {
+            seconds = seconds,
+            callback = callback,
+        }
+    end,
+}
+
+--------------------------------------------------------------------------------
+-- Emitted events tracking (for verifying event emissions in tests)
+--------------------------------------------------------------------------------
+
+local emitted_events = {}
+
+-- Wrap emit to track emitted events
+local original_emit = wezterm.emit
+wezterm.emit = function(event_name, ...)
+    emitted_events[#emitted_events + 1] = {
+        name = event_name,
+        args = {...},
+    }
+    -- Also call original handlers if any
+    local handlers = event_handlers[event_name]
+    if handlers then
+        for _, callback in ipairs(handlers) do
+            callback(...)
+        end
+    end
+end
+
+--------------------------------------------------------------------------------
+-- GUI stub (for tests that need gui_window access)
+--------------------------------------------------------------------------------
+
+wezterm.gui = {
+    gui_windows = function()
+        return {}
+    end,
+}
+
+--------------------------------------------------------------------------------
+-- Mux stub (will be replaced by mux fake when loaded)
+--------------------------------------------------------------------------------
+
+wezterm.mux = {
+    _active_workspace = "default",
+    _windows = {},
+
+    get_active_workspace = function()
+        return wezterm.mux._active_workspace
+    end,
+
+    all_windows = function()
+        return wezterm.mux._windows
+    end,
+
+    spawn_window = function(args)
+        -- Stub: return nil values, real implementation in mux fake
+        return nil, nil, nil
+    end,
+
+    get_domain = function(name)
+        return {
+            name = name,
+            is_spawnable = function() return true end,
+        }
+    end,
+}
+
+-- Run a child process and return success, stdout, stderr
+-- This is a test implementation using io.popen for portability
+function wezterm.run_child_process(args)
+    if not args or #args == 0 then
+        return false, "", "No command provided"
+    end
+
+    -- Build command string from args array
+    local cmd = table.concat(args, " ")
+
+    -- For test command, we need special handling
+    if args[1] == "test" then
+        -- Use shell to run test command
+        cmd = "sh -c '" .. table.concat(args, " ") .. "'"
+        local handle = io.popen(cmd .. " 2>&1; echo $?", "r")
+        if handle then
+            local output = handle:read("*a")
+            handle:close()
+            -- Extract exit code from last line
+            local exit_code = output:match("(%d+)%s*$")
+            return exit_code == "0", "", ""
+        end
+        return false, "", "Failed to execute"
+    end
+
+    -- For mkdir and other commands
+    local handle = io.popen(cmd .. " 2>&1", "r")
+    if handle then
+        local output = handle:read("*a")
+        handle:close()
+        -- Consider success if no error output or if directory was created
+        return true, output, ""
+    end
+    return false, "", "Failed to execute"
+end
+
+-- Test helper functions (not part of real wezterm API)
+wezterm._test = {
+    _pending_timers = pending_timers,
+}
+
+function wezterm._test.get_logs()
+    return captured_logs
+end
+
+function wezterm._test.clear_logs()
+    captured_logs = {}
+end
+
+function wezterm._test.get_events()
+    return event_handlers
+end
+
+function wezterm._test.clear_events()
+    event_handlers = {}
+end
+
+function wezterm._test.get_emitted_events()
+    return emitted_events
+end
+
+function wezterm._test.clear_emitted_events()
+    emitted_events = {}
+end
+
+function wezterm._test.reset()
+    wezterm._test.clear_logs()
+    wezterm._test.clear_events()
+    wezterm._test.clear_emitted_events()
+    pending_timers = {}
+    wezterm._test._pending_timers = pending_timers
+    wezterm.mux._active_workspace = "default"
+    wezterm.mux._windows = {}
+end
+
+-- Tick all pending timers (execute their callbacks)
+function wezterm._test.tick_timers()
+    local timers = pending_timers
+    pending_timers = {}
+    wezterm._test._pending_timers = pending_timers
+    for _, timer in ipairs(timers) do
+        timer.callback()
+    end
+end
+
+function wezterm._test.set_target_triple(triple)
+    wezterm.target_triple = triple
+end
+
+function wezterm._test.set_home_dir(path)
+    wezterm.home_dir = path
+end
+
+function wezterm._test.set_config_dir(path)
+    wezterm.config_dir = path
+end
+
+-- Set the active workspace name
+function wezterm._test.set_active_workspace(name)
+    wezterm.mux._active_workspace = name
+end
+
+-- Set the mux windows list (used by mux fake)
+function wezterm._test.set_windows(windows)
+    wezterm.mux._windows = windows
+end
+
+-- Inject a mux fake (replaces wezterm.mux with the provided fake)
+function wezterm._test.set_mux(mux_fake)
+    wezterm.mux = mux_fake
+end
+
+return wezterm

--- a/plugin/resurrect/test/fakes/wezterm.lua
+++ b/plugin/resurrect/test/fakes/wezterm.lua
@@ -3,7 +3,7 @@
 local wezterm = {}
 
 -- Configurable platform settings
-wezterm.target_triple = "x86_64-apple-darwin"  -- default to macOS
+wezterm.target_triple = "x86_64-apple-darwin" -- default to macOS
 
 -- Directory paths (configurable)
 wezterm.home_dir = os.getenv("HOME") or "/home/test"
@@ -16,11 +16,11 @@ wezterm.config_dir = wezterm.home_dir .. "/.config/wezterm"
 local json = require("test.lib.dkjson")
 
 function wezterm.json_encode(val)
-    return json.encode(val)
+	return json.encode(val)
 end
 
 function wezterm.json_parse(str)
-    return json.decode(str)
+	return json.decode(str)
 end
 
 -- Log capture storage (array of {level, message} objects)
@@ -28,97 +28,99 @@ local captured_logs = {}
 
 -- Logging functions that capture output
 function wezterm.log_info(...)
-    local msg = table.concat({...}, " ")
-    captured_logs[#captured_logs + 1] = { level = "info", message = msg }
+	local msg = table.concat({ ... }, " ")
+	captured_logs[#captured_logs + 1] = { level = "info", message = msg }
 end
 
 function wezterm.log_error(...)
-    local msg = table.concat({...}, " ")
-    captured_logs[#captured_logs + 1] = { level = "error", message = msg }
+	local msg = table.concat({ ... }, " ")
+	captured_logs[#captured_logs + 1] = { level = "error", message = msg }
 end
 
 function wezterm.log_warn(...)
-    local msg = table.concat({...}, " ")
-    captured_logs[#captured_logs + 1] = { level = "warn", message = msg }
+	local msg = table.concat({ ... }, " ")
+	captured_logs[#captured_logs + 1] = { level = "warn", message = msg }
 end
 
 -- Event system
 local event_handlers = {}
 
 function wezterm.on(event_name, callback)
-    if not event_handlers[event_name] then
-        event_handlers[event_name] = {}
-    end
-    table.insert(event_handlers[event_name], callback)
+	if not event_handlers[event_name] then
+		event_handlers[event_name] = {}
+	end
+	table.insert(event_handlers[event_name], callback)
 end
 
 function wezterm.emit(event_name, ...)
-    local handlers = event_handlers[event_name]
-    if handlers then
-        for _, callback in ipairs(handlers) do
-            callback(...)
-        end
-    end
+	local handlers = event_handlers[event_name]
+	if handlers then
+		for _, callback in ipairs(handlers) do
+			callback(...)
+		end
+	end
 end
 
 -- Action callback (commonly used in wezterm configs)
 function wezterm.action_callback(fn)
-    return { callback = fn, type = "action_callback" }
+	return { callback = fn, type = "action_callback" }
 end
 
 -- Action table (mock)
 wezterm.action = setmetatable({}, {
-    __index = function(_, key)
-        return function(...)
-            return { action = key, args = {...} }
-        end
-    end
+	__index = function(_, key)
+		return function(...)
+			return { action = key, args = { ... } }
+		end
+	end,
 })
 
 -- Config builder (mock)
 function wezterm.config_builder()
-    return {}
+	return {}
 end
 
 -- Plugin system (mock)
 wezterm.plugin = {}
 function wezterm.plugin.require(url)
-    return { url = url }
+	return { url = url }
 end
 
 -- Utility functions
 function wezterm.format(items)
-    -- Simple format mock - just concatenate text items
-    local result = ""
-    for _, item in ipairs(items) do
-        if item.Text then
-            result = result .. item.Text
-        end
-    end
-    return result
+	-- Simple format mock - just concatenate text items
+	local result = ""
+	for _, item in ipairs(items) do
+		if item.Text then
+			result = result .. item.Text
+		end
+	end
+	return result
 end
 
 function wezterm.strftime(format)
-    return os.date(format)
+	return os.date(format)
 end
 
 function wezterm.sleep_ms(ms)
-    -- No-op in tests, or use os.execute for actual sleep if needed
+	-- No-op in tests, or use os.execute for actual sleep if needed
 end
 
 -- Shell join args (for restoring processes)
 function wezterm.shell_join_args(args)
-    if not args then return "" end
-    local parts = {}
-    for _, arg in ipairs(args) do
-        -- Simple quoting for args with spaces
-        if arg:match("%s") then
-            parts[#parts + 1] = '"' .. arg .. '"'
-        else
-            parts[#parts + 1] = arg
-        end
-    end
-    return table.concat(parts, " ")
+	if not args then
+		return ""
+	end
+	local parts = {}
+	for _, arg in ipairs(args) do
+		-- Simple quoting for args with spaces
+		if arg:match("%s") then
+			parts[#parts + 1] = '"' .. arg .. '"'
+		else
+			parts[#parts + 1] = arg
+		end
+	end
+	return table.concat(parts, " ")
 end
 
 --------------------------------------------------------------------------------
@@ -128,12 +130,12 @@ end
 local pending_timers = {}
 
 wezterm.time = {
-    call_after = function(seconds, callback)
-        pending_timers[#pending_timers + 1] = {
-            seconds = seconds,
-            callback = callback,
-        }
-    end,
+	call_after = function(seconds, callback)
+		pending_timers[#pending_timers + 1] = {
+			seconds = seconds,
+			callback = callback,
+		}
+	end,
 }
 
 --------------------------------------------------------------------------------
@@ -143,19 +145,19 @@ wezterm.time = {
 local emitted_events = {}
 
 -- Wrap emit to track emitted events
-local original_emit = wezterm.emit
+local _original_emit = wezterm.emit -- luacheck: ignore 211 (kept for reference)
 wezterm.emit = function(event_name, ...)
-    emitted_events[#emitted_events + 1] = {
-        name = event_name,
-        args = {...},
-    }
-    -- Also call original handlers if any
-    local handlers = event_handlers[event_name]
-    if handlers then
-        for _, callback in ipairs(handlers) do
-            callback(...)
-        end
-    end
+	emitted_events[#emitted_events + 1] = {
+		name = event_name,
+		args = { ... },
+	}
+	-- Also call original handlers if any
+	local handlers = event_handlers[event_name]
+	if handlers then
+		for _, callback in ipairs(handlers) do
+			callback(...)
+		end
+	end
 end
 
 --------------------------------------------------------------------------------
@@ -163,9 +165,9 @@ end
 --------------------------------------------------------------------------------
 
 wezterm.gui = {
-    gui_windows = function()
-        return {}
-    end,
+	gui_windows = function()
+		return {}
+	end,
 }
 
 --------------------------------------------------------------------------------
@@ -173,140 +175,142 @@ wezterm.gui = {
 --------------------------------------------------------------------------------
 
 wezterm.mux = {
-    _active_workspace = "default",
-    _windows = {},
+	_active_workspace = "default",
+	_windows = {},
 
-    get_active_workspace = function()
-        return wezterm.mux._active_workspace
-    end,
+	get_active_workspace = function()
+		return wezterm.mux._active_workspace
+	end,
 
-    all_windows = function()
-        return wezterm.mux._windows
-    end,
+	all_windows = function()
+		return wezterm.mux._windows
+	end,
 
-    spawn_window = function(args)
-        -- Stub: return nil values, real implementation in mux fake
-        return nil, nil, nil
-    end,
+	spawn_window = function(args)
+		-- Stub: return nil values, real implementation in mux fake
+		return nil, nil, nil
+	end,
 
-    get_domain = function(name)
-        return {
-            name = name,
-            is_spawnable = function() return true end,
-        }
-    end,
+	get_domain = function(name)
+		return {
+			name = name,
+			is_spawnable = function()
+				return true
+			end,
+		}
+	end,
 }
 
 -- Run a child process and return success, stdout, stderr
 -- This is a test implementation using io.popen for portability
 function wezterm.run_child_process(args)
-    if not args or #args == 0 then
-        return false, "", "No command provided"
-    end
+	if not args or #args == 0 then
+		return false, "", "No command provided"
+	end
 
-    -- Build command string from args array
-    local cmd = table.concat(args, " ")
+	-- Build command string from args array
+	local cmd = table.concat(args, " ")
 
-    -- For test command, we need special handling
-    if args[1] == "test" then
-        -- Use shell to run test command
-        cmd = "sh -c '" .. table.concat(args, " ") .. "'"
-        local handle = io.popen(cmd .. " 2>&1; echo $?", "r")
-        if handle then
-            local output = handle:read("*a")
-            handle:close()
-            -- Extract exit code from last line
-            local exit_code = output:match("(%d+)%s*$")
-            return exit_code == "0", "", ""
-        end
-        return false, "", "Failed to execute"
-    end
+	-- For test command, we need special handling
+	if args[1] == "test" then
+		-- Use shell to run test command
+		cmd = "sh -c '" .. table.concat(args, " ") .. "'"
+		local handle = io.popen(cmd .. " 2>&1; echo $?", "r")
+		if handle then
+			local output = handle:read("*a")
+			handle:close()
+			-- Extract exit code from last line
+			local exit_code = output:match("(%d+)%s*$")
+			return exit_code == "0", "", ""
+		end
+		return false, "", "Failed to execute"
+	end
 
-    -- For mkdir and other commands
-    local handle = io.popen(cmd .. " 2>&1", "r")
-    if handle then
-        local output = handle:read("*a")
-        handle:close()
-        -- Consider success if no error output or if directory was created
-        return true, output, ""
-    end
-    return false, "", "Failed to execute"
+	-- For mkdir and other commands
+	local handle = io.popen(cmd .. " 2>&1", "r")
+	if handle then
+		local output = handle:read("*a")
+		handle:close()
+		-- Consider success if no error output or if directory was created
+		return true, output, ""
+	end
+	return false, "", "Failed to execute"
 end
 
 -- Test helper functions (not part of real wezterm API)
 wezterm._test = {
-    _pending_timers = pending_timers,
+	_pending_timers = pending_timers,
 }
 
 function wezterm._test.get_logs()
-    return captured_logs
+	return captured_logs
 end
 
 function wezterm._test.clear_logs()
-    captured_logs = {}
+	captured_logs = {}
 end
 
 function wezterm._test.get_events()
-    return event_handlers
+	return event_handlers
 end
 
 function wezterm._test.clear_events()
-    event_handlers = {}
+	event_handlers = {}
 end
 
 function wezterm._test.get_emitted_events()
-    return emitted_events
+	return emitted_events
 end
 
 function wezterm._test.clear_emitted_events()
-    emitted_events = {}
+	emitted_events = {}
 end
 
 function wezterm._test.reset()
-    wezterm._test.clear_logs()
-    wezterm._test.clear_events()
-    wezterm._test.clear_emitted_events()
-    pending_timers = {}
-    wezterm._test._pending_timers = pending_timers
-    wezterm.mux._active_workspace = "default"
-    wezterm.mux._windows = {}
+	wezterm._test.clear_logs()
+	wezterm._test.clear_events()
+	wezterm._test.clear_emitted_events()
+	pending_timers = {}
+	wezterm._test._pending_timers = pending_timers
+	wezterm.mux._active_workspace = "default"
+	wezterm.mux._windows = {}
 end
 
 -- Tick all pending timers (execute their callbacks)
 function wezterm._test.tick_timers()
-    local timers = pending_timers
-    pending_timers = {}
-    wezterm._test._pending_timers = pending_timers
-    for _, timer in ipairs(timers) do
-        timer.callback()
-    end
+	local timers = pending_timers
+	pending_timers = {}
+	wezterm._test._pending_timers = pending_timers
+	for _, timer in ipairs(timers) do
+		timer.callback()
+	end
 end
 
 function wezterm._test.set_target_triple(triple)
-    wezterm.target_triple = triple
+	wezterm.target_triple = triple
 end
 
 function wezterm._test.set_home_dir(path)
-    wezterm.home_dir = path
+	wezterm.home_dir = path
 end
 
 function wezterm._test.set_config_dir(path)
-    wezterm.config_dir = path
+	wezterm.config_dir = path
 end
 
 -- Set the active workspace name
 function wezterm._test.set_active_workspace(name)
-    wezterm.mux._active_workspace = name
+	wezterm.mux._active_workspace = name
 end
 
 -- Set the mux windows list (used by mux fake)
 function wezterm._test.set_windows(windows)
-    wezterm.mux._windows = windows
+	wezterm.mux._windows = windows
 end
 
 -- Inject a mux fake (replaces wezterm.mux with the provided fake)
 function wezterm._test.set_mux(mux_fake)
-    wezterm.mux = mux_fake
+	wezterm.mux = mux_fake
 end
 
 return wezterm

--- a/plugin/resurrect/test/fixtures/pane_layouts.lua
+++ b/plugin/resurrect/test/fixtures/pane_layouts.lua
@@ -8,13 +8,19 @@ local fixtures = {}
 --------------------------------------------------------------------------------
 
 fixtures.single_pane = {
-    panes = {
-        { left = 0, top = 0, width = 160, height = 48, cwd = "/home/user", is_active = true },
-    },
-    expected_tree = {
-        left = 0, top = 0, width = 160, height = 48,
-        cwd = "/home/user", is_active = true, right = nil, bottom = nil,
-    },
+	panes = {
+		{ left = 0, top = 0, width = 160, height = 48, cwd = "/home/user", is_active = true },
+	},
+	expected_tree = {
+		left = 0,
+		top = 0,
+		width = 160,
+		height = 48,
+		cwd = "/home/user",
+		is_active = true,
+		right = nil,
+		bottom = nil,
+	},
 }
 
 --------------------------------------------------------------------------------
@@ -26,15 +32,20 @@ fixtures.single_pane = {
 --------------------------------------------------------------------------------
 
 fixtures.hsplit = {
-    panes = {
-        { left = 0, top = 0, width = 80, height = 48, cwd = "/home", is_active = true },
-        { left = 81, top = 0, width = 80, height = 48, cwd = "/tmp" },
-    },
-    expected_tree = {
-        left = 0, top = 0, width = 80, height = 48, cwd = "/home", is_active = true,
-        right = { left = 81, top = 0, width = 80, height = 48, cwd = "/tmp" },
-        bottom = nil,
-    },
+	panes = {
+		{ left = 0, top = 0, width = 80, height = 48, cwd = "/home", is_active = true },
+		{ left = 81, top = 0, width = 80, height = 48, cwd = "/tmp" },
+	},
+	expected_tree = {
+		left = 0,
+		top = 0,
+		width = 80,
+		height = 48,
+		cwd = "/home",
+		is_active = true,
+		right = { left = 81, top = 0, width = 80, height = 48, cwd = "/tmp" },
+		bottom = nil,
+	},
 }
 
 --------------------------------------------------------------------------------
@@ -47,14 +58,19 @@ fixtures.hsplit = {
 --------------------------------------------------------------------------------
 
 fixtures.vsplit = {
-    panes = {
-        { left = 0, top = 0, width = 160, height = 24, cwd = "/home", is_active = true },
-        { left = 0, top = 25, width = 160, height = 24, cwd = "/var/log" },
-    },
-    expected_tree = {
-        left = 0, top = 0, width = 160, height = 24, cwd = "/home", right = nil,
-        bottom = { left = 0, top = 25, width = 160, height = 24, cwd = "/var/log" },
-    },
+	panes = {
+		{ left = 0, top = 0, width = 160, height = 24, cwd = "/home", is_active = true },
+		{ left = 0, top = 25, width = 160, height = 24, cwd = "/var/log" },
+	},
+	expected_tree = {
+		left = 0,
+		top = 0,
+		width = 160,
+		height = 24,
+		cwd = "/home",
+		right = nil,
+		bottom = { left = 0, top = 25, width = 160, height = 24, cwd = "/var/log" },
+	},
 }
 
 --------------------------------------------------------------------------------
@@ -67,18 +83,26 @@ fixtures.vsplit = {
 --------------------------------------------------------------------------------
 
 fixtures.ide_layout = {
-    panes = {
-        { left = 0, top = 0, width = 100, height = 48, cwd = "/project", is_active = true },
-        { left = 101, top = 0, width = 60, height = 24, cwd = "/project" },
-        { left = 101, top = 25, width = 60, height = 24, cwd = "/project" },
-    },
-    expected_tree = {
-        left = 0, top = 0, width = 100, height = 48, cwd = "/project",
-        right = {
-            left = 101, top = 0, width = 60, height = 24, cwd = "/project",
-            bottom = { left = 101, top = 25, width = 60, height = 24, cwd = "/project" },
-        },
-    },
+	panes = {
+		{ left = 0, top = 0, width = 100, height = 48, cwd = "/project", is_active = true },
+		{ left = 101, top = 0, width = 60, height = 24, cwd = "/project" },
+		{ left = 101, top = 25, width = 60, height = 24, cwd = "/project" },
+	},
+	expected_tree = {
+		left = 0,
+		top = 0,
+		width = 100,
+		height = 48,
+		cwd = "/project",
+		right = {
+			left = 101,
+			top = 0,
+			width = 60,
+			height = 24,
+			cwd = "/project",
+			bottom = { left = 101, top = 25, width = 60, height = 24, cwd = "/project" },
+		},
+	},
 }
 
 --------------------------------------------------------------------------------
@@ -89,18 +113,26 @@ fixtures.ide_layout = {
 --------------------------------------------------------------------------------
 
 fixtures.three_way_hsplit = {
-    panes = {
-        { left = 0, top = 0, width = 53, height = 48, cwd = "/a", is_active = true },
-        { left = 54, top = 0, width = 53, height = 48, cwd = "/b" },
-        { left = 108, top = 0, width = 53, height = 48, cwd = "/c" },
-    },
-    expected_tree = {
-        left = 0, top = 0, width = 53, height = 48, cwd = "/a",
-        right = {
-            left = 54, top = 0, width = 53, height = 48, cwd = "/b",
-            right = { left = 108, top = 0, width = 53, height = 48, cwd = "/c" },
-        },
-    },
+	panes = {
+		{ left = 0, top = 0, width = 53, height = 48, cwd = "/a", is_active = true },
+		{ left = 54, top = 0, width = 53, height = 48, cwd = "/b" },
+		{ left = 108, top = 0, width = 53, height = 48, cwd = "/c" },
+	},
+	expected_tree = {
+		left = 0,
+		top = 0,
+		width = 53,
+		height = 48,
+		cwd = "/a",
+		right = {
+			left = 54,
+			top = 0,
+			width = 53,
+			height = 48,
+			cwd = "/b",
+			right = { left = 108, top = 0, width = 53, height = 48, cwd = "/c" },
+		},
+	},
 }
 
 --------------------------------------------------------------------------------
@@ -108,9 +140,17 @@ fixtures.three_way_hsplit = {
 --------------------------------------------------------------------------------
 
 fixtures.with_scrollback = {
-    panes = {
-        { left = 0, top = 0, width = 160, height = 48, cwd = "/home", text = "$ ls\nfile1.txt\nfile2.txt\n$ ", is_active = true },
-    },
+	panes = {
+		{
+			left = 0,
+			top = 0,
+			width = 160,
+			height = 48,
+			cwd = "/home",
+			text = "$ ls\nfile1.txt\nfile2.txt\n$ ",
+			is_active = true,
+		},
+	},
 }
 
 --------------------------------------------------------------------------------
@@ -118,10 +158,10 @@ fixtures.with_scrollback = {
 --------------------------------------------------------------------------------
 
 fixtures.multi_domain = {
-    panes = {
-        { left = 0, top = 0, width = 80, height = 48, cwd = "/home", domain = "local", is_active = true },
-        { left = 81, top = 0, width = 80, height = 48, cwd = "/remote", domain = "SSH:server" },
-    },
+	panes = {
+		{ left = 0, top = 0, width = 80, height = 48, cwd = "/home", domain = "local", is_active = true },
+		{ left = 81, top = 0, width = 80, height = 48, cwd = "/remote", domain = "SSH:server" },
+	},
 }
 
 --------------------------------------------------------------------------------
@@ -129,12 +169,18 @@ fixtures.multi_domain = {
 --------------------------------------------------------------------------------
 
 fixtures.with_alt_screen = {
-    panes = {
-        {
-            left = 0, top = 0, width = 160, height = 48, cwd = "/project", alt_screen = true, is_active = true,
-            process = { name = "vim", argv = { "vim", "file.txt" }, cwd = "/project", executable = "/usr/bin/vim" },
-        },
-    },
+	panes = {
+		{
+			left = 0,
+			top = 0,
+			width = 160,
+			height = 48,
+			cwd = "/project",
+			alt_screen = true,
+			is_active = true,
+			process = { name = "vim", argv = { "vim", "file.txt" }, cwd = "/project", executable = "/usr/bin/vim" },
+		},
+	},
 }
 
 --------------------------------------------------------------------------------
@@ -142,10 +188,10 @@ fixtures.with_alt_screen = {
 --------------------------------------------------------------------------------
 
 fixtures.zoomed_pane = {
-    panes = {
-        { left = 0, top = 0, width = 80, height = 48, cwd = "/home", is_zoomed = true, is_active = true },
-        { left = 81, top = 0, width = 80, height = 48, cwd = "/tmp" },
-    },
+	panes = {
+		{ left = 0, top = 0, width = 80, height = 48, cwd = "/home", is_zoomed = true, is_active = true },
+		{ left = 81, top = 0, width = 80, height = 48, cwd = "/tmp" },
+	},
 }
 
 --------------------------------------------------------------------------------
@@ -153,9 +199,9 @@ fixtures.zoomed_pane = {
 --------------------------------------------------------------------------------
 
 fixtures.empty_cwd = {
-    panes = {
-        { left = 0, top = 0, width = 160, height = 48, cwd = "", is_active = true },
-    },
+	panes = {
+		{ left = 0, top = 0, width = 160, height = 48, cwd = "", is_active = true },
+	},
 }
 
 --------------------------------------------------------------------------------
@@ -168,12 +214,12 @@ fixtures.empty_cwd = {
 --------------------------------------------------------------------------------
 
 fixtures.grid_2x2 = {
-    panes = {
-        { left = 0, top = 0, width = 80, height = 24, cwd = "/tl", is_active = true },
-        { left = 81, top = 0, width = 80, height = 24, cwd = "/tr" },
-        { left = 0, top = 25, width = 80, height = 24, cwd = "/bl" },
-        { left = 81, top = 25, width = 80, height = 24, cwd = "/br" },
-    },
+	panes = {
+		{ left = 0, top = 0, width = 80, height = 24, cwd = "/tl", is_active = true },
+		{ left = 81, top = 0, width = 80, height = 24, cwd = "/tr" },
+		{ left = 0, top = 25, width = 80, height = 24, cwd = "/bl" },
+		{ left = 81, top = 25, width = 80, height = 24, cwd = "/br" },
+	},
 }
 
 --------------------------------------------------------------------------------
@@ -181,27 +227,27 @@ fixtures.grid_2x2 = {
 --------------------------------------------------------------------------------
 
 function fixtures.to_workspace_state(fixture, workspace_name, window_title, tab_title)
-    -- Ensure the expected_tree has is_active set
-    local pane_tree = fixture.expected_tree
-    if pane_tree and not pane_tree.is_active then
-        -- Make a shallow copy and set is_active
-        pane_tree = {}
-        for k, v in pairs(fixture.expected_tree) do
-            pane_tree[k] = v
-        end
-        pane_tree.is_active = true
-    end
+	-- Ensure the expected_tree has is_active set
+	local pane_tree = fixture.expected_tree
+	if pane_tree and not pane_tree.is_active then
+		-- Make a shallow copy and set is_active
+		pane_tree = {}
+		for k, v in pairs(fixture.expected_tree) do
+			pane_tree[k] = v
+		end
+		pane_tree.is_active = true
+	end
 
-    return {
-        workspace = workspace_name or "test",
-        window_states = {
-            {
-                title = window_title or "main",
-                tabs = { { title = tab_title or "tab", is_active = true, pane_tree = pane_tree } },
-                size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-            },
-        },
-    }
+	return {
+		workspace = workspace_name or "test",
+		window_states = {
+			{
+				title = window_title or "main",
+				tabs = { { title = tab_title or "tab", is_active = true, pane_tree = pane_tree } },
+				size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+			},
+		},
+	}
 end
 
 return fixtures

--- a/plugin/resurrect/test/fixtures/pane_layouts.lua
+++ b/plugin/resurrect/test/fixtures/pane_layouts.lua
@@ -1,0 +1,207 @@
+-- Pre-built pane layout fixtures for testing
+-- These fixtures define common pane layouts with expected pane tree structures
+
+local fixtures = {}
+
+--------------------------------------------------------------------------------
+-- Single Pane (simplest case)
+--------------------------------------------------------------------------------
+
+fixtures.single_pane = {
+    panes = {
+        { left = 0, top = 0, width = 160, height = 48, cwd = "/home/user", is_active = true },
+    },
+    expected_tree = {
+        left = 0, top = 0, width = 160, height = 48,
+        cwd = "/home/user", is_active = true, right = nil, bottom = nil,
+    },
+}
+
+--------------------------------------------------------------------------------
+-- Horizontal Split (two panes side by side)
+--  ┌─────────┬─────────┐
+--  │  left   │  right  │
+--  │         │         │
+--  └─────────┴─────────┘
+--------------------------------------------------------------------------------
+
+fixtures.hsplit = {
+    panes = {
+        { left = 0, top = 0, width = 80, height = 48, cwd = "/home", is_active = true },
+        { left = 81, top = 0, width = 80, height = 48, cwd = "/tmp" },
+    },
+    expected_tree = {
+        left = 0, top = 0, width = 80, height = 48, cwd = "/home", is_active = true,
+        right = { left = 81, top = 0, width = 80, height = 48, cwd = "/tmp" },
+        bottom = nil,
+    },
+}
+
+--------------------------------------------------------------------------------
+-- Vertical Split (two panes stacked)
+--  ┌─────────────────────┐
+--  │        top          │
+--  ├─────────────────────┤
+--  │       bottom        │
+--  └─────────────────────┘
+--------------------------------------------------------------------------------
+
+fixtures.vsplit = {
+    panes = {
+        { left = 0, top = 0, width = 160, height = 24, cwd = "/home", is_active = true },
+        { left = 0, top = 25, width = 160, height = 24, cwd = "/var/log" },
+    },
+    expected_tree = {
+        left = 0, top = 0, width = 160, height = 24, cwd = "/home", right = nil,
+        bottom = { left = 0, top = 25, width = 160, height = 24, cwd = "/var/log" },
+    },
+}
+
+--------------------------------------------------------------------------------
+-- IDE Layout (editor + terminal column)
+--  ┌─────────┬─────────┐
+--  │         │ terminal│
+--  │ editor  ├─────────┤
+--  │         │ output  │
+--  └─────────┴─────────┘
+--------------------------------------------------------------------------------
+
+fixtures.ide_layout = {
+    panes = {
+        { left = 0, top = 0, width = 100, height = 48, cwd = "/project", is_active = true },
+        { left = 101, top = 0, width = 60, height = 24, cwd = "/project" },
+        { left = 101, top = 25, width = 60, height = 24, cwd = "/project" },
+    },
+    expected_tree = {
+        left = 0, top = 0, width = 100, height = 48, cwd = "/project",
+        right = {
+            left = 101, top = 0, width = 60, height = 24, cwd = "/project",
+            bottom = { left = 101, top = 25, width = 60, height = 24, cwd = "/project" },
+        },
+    },
+}
+
+--------------------------------------------------------------------------------
+-- Three-way Horizontal Split
+--  ┌───────┬───────┬───────┐
+--  │ left  │ middle│ right │
+--  └───────┴───────┴───────┘
+--------------------------------------------------------------------------------
+
+fixtures.three_way_hsplit = {
+    panes = {
+        { left = 0, top = 0, width = 53, height = 48, cwd = "/a", is_active = true },
+        { left = 54, top = 0, width = 53, height = 48, cwd = "/b" },
+        { left = 108, top = 0, width = 53, height = 48, cwd = "/c" },
+    },
+    expected_tree = {
+        left = 0, top = 0, width = 53, height = 48, cwd = "/a",
+        right = {
+            left = 54, top = 0, width = 53, height = 48, cwd = "/b",
+            right = { left = 108, top = 0, width = 53, height = 48, cwd = "/c" },
+        },
+    },
+}
+
+--------------------------------------------------------------------------------
+-- With Scrollback Content
+--------------------------------------------------------------------------------
+
+fixtures.with_scrollback = {
+    panes = {
+        { left = 0, top = 0, width = 160, height = 48, cwd = "/home", text = "$ ls\nfile1.txt\nfile2.txt\n$ ", is_active = true },
+    },
+}
+
+--------------------------------------------------------------------------------
+-- Multi-Domain (local + SSH pane)
+--------------------------------------------------------------------------------
+
+fixtures.multi_domain = {
+    panes = {
+        { left = 0, top = 0, width = 80, height = 48, cwd = "/home", domain = "local", is_active = true },
+        { left = 81, top = 0, width = 80, height = 48, cwd = "/remote", domain = "SSH:server" },
+    },
+}
+
+--------------------------------------------------------------------------------
+-- With Alt Screen Active (running vim, etc.)
+--------------------------------------------------------------------------------
+
+fixtures.with_alt_screen = {
+    panes = {
+        {
+            left = 0, top = 0, width = 160, height = 48, cwd = "/project", alt_screen = true, is_active = true,
+            process = { name = "vim", argv = { "vim", "file.txt" }, cwd = "/project", executable = "/usr/bin/vim" },
+        },
+    },
+}
+
+--------------------------------------------------------------------------------
+-- Zoomed Pane
+--------------------------------------------------------------------------------
+
+fixtures.zoomed_pane = {
+    panes = {
+        { left = 0, top = 0, width = 80, height = 48, cwd = "/home", is_zoomed = true, is_active = true },
+        { left = 81, top = 0, width = 80, height = 48, cwd = "/tmp" },
+    },
+}
+
+--------------------------------------------------------------------------------
+-- Empty CWD (edge case)
+--------------------------------------------------------------------------------
+
+fixtures.empty_cwd = {
+    panes = {
+        { left = 0, top = 0, width = 160, height = 48, cwd = "", is_active = true },
+    },
+}
+
+--------------------------------------------------------------------------------
+-- Complex Grid (2x2)
+--  ┌─────────┬─────────┐
+--  │   TL    │   TR    │
+--  ├─────────┼─────────┤
+--  │   BL    │   BR    │
+--  └─────────┴─────────┘
+--------------------------------------------------------------------------------
+
+fixtures.grid_2x2 = {
+    panes = {
+        { left = 0, top = 0, width = 80, height = 24, cwd = "/tl", is_active = true },
+        { left = 81, top = 0, width = 80, height = 24, cwd = "/tr" },
+        { left = 0, top = 25, width = 80, height = 24, cwd = "/bl" },
+        { left = 81, top = 25, width = 80, height = 24, cwd = "/br" },
+    },
+}
+
+--------------------------------------------------------------------------------
+-- Helper: Create state object from fixture
+--------------------------------------------------------------------------------
+
+function fixtures.to_workspace_state(fixture, workspace_name, window_title, tab_title)
+    -- Ensure the expected_tree has is_active set
+    local pane_tree = fixture.expected_tree
+    if pane_tree and not pane_tree.is_active then
+        -- Make a shallow copy and set is_active
+        pane_tree = {}
+        for k, v in pairs(fixture.expected_tree) do
+            pane_tree[k] = v
+        end
+        pane_tree.is_active = true
+    end
+
+    return {
+        workspace = workspace_name or "test",
+        window_states = {
+            {
+                title = window_title or "main",
+                tabs = { { title = tab_title or "tab", is_active = true, pane_tree = pane_tree } },
+                size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+            },
+        },
+    }
+end
+
+return fixtures

--- a/plugin/resurrect/test/init.lua
+++ b/plugin/resurrect/test/init.lua
@@ -11,13 +11,19 @@ local script_dir = debug.getinfo(1, "S").source:match("@(.*/)")
 -- 4. fakes/?.lua - for test fakes
 -- 5. fixtures/?.lua - for test fixtures
 -- 6. ?.lua - for local test modules
-package.path = script_dir .. "lib/?.lua;"
-    .. script_dir .. "../../?.lua;"
-    .. script_dir .. "../?.lua;"
-    .. script_dir .. "fakes/?.lua;"
-    .. script_dir .. "fixtures/?.lua;"
-    .. script_dir .. "?.lua;"
-    .. package.path
+package.path = script_dir
+	.. "lib/?.lua;"
+	.. script_dir
+	.. "../../?.lua;"
+	.. script_dir
+	.. "../?.lua;"
+	.. script_dir
+	.. "fakes/?.lua;"
+	.. script_dir
+	.. "fixtures/?.lua;"
+	.. script_dir
+	.. "?.lua;"
+	.. package.path
 
 -- Load lust test framework
 local lust = require("lust")
@@ -38,64 +44,65 @@ _G.wezterm = wezterm_fake
 
 -- Reset fake state between test files
 local function reset_test_state()
-    wezterm_fake._test.reset()
+	wezterm_fake._test.reset()
 end
 
 -- Discover and run test files
 local function run_tests()
-    print("\n" .. string.char(27) .. "[36mResurrect.wezterm Test Suite" .. string.char(27) .. "[0m")
-    print(string.rep("=", 50))
+	print("\n" .. string.char(27) .. "[36mResurrect.wezterm Test Suite" .. string.char(27) .. "[0m")
+	print(string.rep("=", 50))
 
-    -- Find test files (test_*.lua and spec/*_spec.lua) in this directory
-    local test_files = {}
+	-- Find test files (test_*.lua and spec/*_spec.lua) in this directory
+	local test_files = {}
 
-    -- Check command line args first for specific test files
-    if #arg > 0 then
-        test_files = arg
-    else
-        -- Find test_*.lua files
-        local handle = io.popen('ls "' .. script_dir .. '"test_*.lua 2>/dev/null')
-        if handle then
-            for file in handle:lines() do
-                test_files[#test_files + 1] = file
-            end
-            handle:close()
-        end
+	-- Check command line args first for specific test files
+	if #arg > 0 then
+		test_files = arg
+	else
+		-- Find test_*.lua files
+		local handle = io.popen('ls "' .. script_dir .. '"test_*.lua 2>/dev/null')
+		if handle then
+			for file in handle:lines() do
+				test_files[#test_files + 1] = file
+			end
+			handle:close()
+		end
 
-        -- Find spec/*_spec.lua files
-        handle = io.popen('ls "' .. script_dir .. 'spec/"*_spec.lua 2>/dev/null')
-        if handle then
-            for file in handle:lines() do
-                test_files[#test_files + 1] = file
-            end
-            handle:close()
-        end
-    end
+		-- Find spec/*_spec.lua files
+		handle = io.popen('ls "' .. script_dir .. 'spec/"*_spec.lua 2>/dev/null')
+		if handle then
+			for file in handle:lines() do
+				test_files[#test_files + 1] = file
+			end
+			handle:close()
+		end
+	end
 
-    -- Run each test file
-    for _, file in ipairs(test_files) do
-        print(string.char(27) .. "[33m\nRunning: " .. file .. string.char(27) .. "[0m")
-        reset_test_state()
-        dofile(file)
-    end
+	-- Run each test file
+	for _, file in ipairs(test_files) do
+		print(string.char(27) .. "[33m\nRunning: " .. file .. string.char(27) .. "[0m")
+		reset_test_state()
+		dofile(file)
+	end
 
-    -- Print summary
-    print("\n" .. string.rep("-", 50))
-    local color = lust.errors == 0 and string.char(27) .. "[32m" or string.char(27) .. "[31m"
-    local total = lust.passes + lust.errors
-    print(color .. "Tests: " .. lust.passes .. " passed, " .. lust.errors .. " failed, " .. total .. " total" .. string.char(27) .. "[0m")
+	-- Print summary
+	print("\n" .. string.rep("-", 50))
+	local color = lust.errors == 0 and string.char(27) .. "[32m" or string.char(27) .. "[31m"
+	local total = lust.passes + lust.errors
+	local summary = "Tests: " .. lust.passes .. " passed, " .. lust.errors .. " failed, " .. total .. " total"
+	print(color .. summary .. string.char(27) .. "[0m")
 
-    return lust.errors == 0 and 0 or 1
+	return lust.errors == 0 and 0 or 1
 end
 
 -- Run if executed directly
 if arg then
-    os.exit(run_tests())
+	os.exit(run_tests())
 end
 
 return {
-    lust = lust,
-    describe = describe,
-    it = it,
-    expect = expect,
+	lust = lust,
+	describe = describe,
+	it = it,
+	expect = expect,
 }

--- a/plugin/resurrect/test/init.lua
+++ b/plugin/resurrect/test/init.lua
@@ -1,0 +1,101 @@
+-- Test runner for resurrect.wezterm plugin
+-- Uses lust (https://github.com/bjornbytes/lust) for assertions
+-- Run with: lua plugin/resurrect/test/init.lua
+
+-- Setup paths
+local script_dir = debug.getinfo(1, "S").source:match("@(.*/)")
+-- Add paths for:
+-- 1. lib/?.lua - lust test framework
+-- 2. ../../?.lua - for require("resurrect.utils") pattern (plugin/resurrect/utils.lua)
+-- 3. ../?.lua - for direct require("utils") pattern if needed
+-- 4. fakes/?.lua - for test fakes
+-- 5. fixtures/?.lua - for test fixtures
+-- 6. ?.lua - for local test modules
+package.path = script_dir .. "lib/?.lua;"
+    .. script_dir .. "../../?.lua;"
+    .. script_dir .. "../?.lua;"
+    .. script_dir .. "fakes/?.lua;"
+    .. script_dir .. "fixtures/?.lua;"
+    .. script_dir .. "?.lua;"
+    .. package.path
+
+-- Load lust test framework
+local lust = require("lust")
+local describe, it, expect = lust.describe, lust.it, lust.expect
+
+-- Load WezTerm fake and inject into package.loaded
+local wezterm_fake = dofile(script_dir .. "fakes/wezterm.lua")
+package.loaded["wezterm"] = wezterm_fake
+
+-- Export lust globals for test files
+_G.describe = describe
+_G.it = it
+_G.expect = expect
+_G.lust = lust
+_G.before = lust.before
+_G.after = lust.after
+_G.wezterm = wezterm_fake
+
+-- Reset fake state between test files
+local function reset_test_state()
+    wezterm_fake._test.reset()
+end
+
+-- Discover and run test files
+local function run_tests()
+    print("\n" .. string.char(27) .. "[36mResurrect.wezterm Test Suite" .. string.char(27) .. "[0m")
+    print(string.rep("=", 50))
+
+    -- Find test files (test_*.lua and spec/*_spec.lua) in this directory
+    local test_files = {}
+
+    -- Check command line args first for specific test files
+    if #arg > 0 then
+        test_files = arg
+    else
+        -- Find test_*.lua files
+        local handle = io.popen('ls "' .. script_dir .. '"test_*.lua 2>/dev/null')
+        if handle then
+            for file in handle:lines() do
+                test_files[#test_files + 1] = file
+            end
+            handle:close()
+        end
+
+        -- Find spec/*_spec.lua files
+        handle = io.popen('ls "' .. script_dir .. 'spec/"*_spec.lua 2>/dev/null')
+        if handle then
+            for file in handle:lines() do
+                test_files[#test_files + 1] = file
+            end
+            handle:close()
+        end
+    end
+
+    -- Run each test file
+    for _, file in ipairs(test_files) do
+        print(string.char(27) .. "[33m\nRunning: " .. file .. string.char(27) .. "[0m")
+        reset_test_state()
+        dofile(file)
+    end
+
+    -- Print summary
+    print("\n" .. string.rep("-", 50))
+    local color = lust.errors == 0 and string.char(27) .. "[32m" or string.char(27) .. "[31m"
+    local total = lust.passes + lust.errors
+    print(color .. "Tests: " .. lust.passes .. " passed, " .. lust.errors .. " failed, " .. total .. " total" .. string.char(27) .. "[0m")
+
+    return lust.errors == 0 and 0 or 1
+end
+
+-- Run if executed directly
+if arg then
+    os.exit(run_tests())
+end
+
+return {
+    lust = lust,
+    describe = describe,
+    it = it,
+    expect = expect,
+}

--- a/plugin/resurrect/test/lib/dkjson.lua
+++ b/plugin/resurrect/test/lib/dkjson.lua
@@ -1,0 +1,752 @@
+-- Module options:
+local always_use_lpeg = false
+local register_global_module_table = false
+local global_module_name = 'json'
+
+--[==[
+
+David Kolf's JSON module for Lua 5.1 - 5.4
+
+Version 2.8
+
+
+For the documentation see the corresponding readme.txt or visit
+<http://dkolf.de/dkjson-lua/>.
+
+You can contact the author by sending an e-mail to 'david' at the
+domain 'dkolf.de'.
+
+
+Copyright (C) 2010-2024 David Heiko Kolf
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--]==]
+
+-- global dependencies:
+local pairs, type, tostring, tonumber, getmetatable, setmetatable =
+      pairs, type, tostring, tonumber, getmetatable, setmetatable
+local error, require, pcall, select = error, require, pcall, select
+local floor, huge = math.floor, math.huge
+local strrep, gsub, strsub, strbyte, strchar, strfind, strlen, strformat =
+      string.rep, string.gsub, string.sub, string.byte, string.char,
+      string.find, string.len, string.format
+local strmatch = string.match
+local concat = table.concat
+
+local json = { version = "dkjson 2.8" }
+
+local jsonlpeg = {}
+
+if register_global_module_table then
+  if always_use_lpeg then
+    _G[global_module_name] = jsonlpeg
+  else
+    _G[global_module_name] = json
+  end
+end
+
+local _ENV = nil -- blocking globals in Lua 5.2 and later
+
+pcall (function()
+  -- Enable access to blocked metatables.
+  -- Don't worry, this module doesn't change anything in them.
+  local debmeta = require "debug".getmetatable
+  if debmeta then getmetatable = debmeta end
+end)
+
+json.null = setmetatable ({}, {
+  __tojson = function () return "null" end
+})
+
+local function isarray (tbl)
+  local max, n, arraylen = 0, 0, 0
+  for k,v in pairs (tbl) do
+    if k == 'n' and type(v) == 'number' then
+      arraylen = v
+      if v > max then
+        max = v
+      end
+    else
+      if type(k) ~= 'number' or k < 1 or floor(k) ~= k then
+        return false
+      end
+      if k > max then
+        max = k
+      end
+      n = n + 1
+    end
+  end
+  if max > 10 and max > arraylen and max > n * 2 then
+    return false -- don't create an array with too many holes
+  end
+  return true, max
+end
+
+local escapecodes = {
+  ["\""] = "\\\"", ["\\"] = "\\\\", ["\b"] = "\\b", ["\f"] = "\\f",
+  ["\n"] = "\\n",  ["\r"] = "\\r",  ["\t"] = "\\t"
+}
+
+local function escapeutf8 (uchar)
+  local value = escapecodes[uchar]
+  if value then
+    return value
+  end
+  local a, b, c, d = strbyte (uchar, 1, 4)
+  a, b, c, d = a or 0, b or 0, c or 0, d or 0
+  if a <= 0x7f then
+    value = a
+  elseif 0xc0 <= a and a <= 0xdf and b >= 0x80 then
+    value = (a - 0xc0) * 0x40 + b - 0x80
+  elseif 0xe0 <= a and a <= 0xef and b >= 0x80 and c >= 0x80 then
+    value = ((a - 0xe0) * 0x40 + b - 0x80) * 0x40 + c - 0x80
+  elseif 0xf0 <= a and a <= 0xf7 and b >= 0x80 and c >= 0x80 and d >= 0x80 then
+    value = (((a - 0xf0) * 0x40 + b - 0x80) * 0x40 + c - 0x80) * 0x40 + d - 0x80
+  else
+    return ""
+  end
+  if value <= 0xffff then
+    return strformat ("\\u%.4x", value)
+  elseif value <= 0x10ffff then
+    -- encode as UTF-16 surrogate pair
+    value = value - 0x10000
+    local highsur, lowsur = 0xD800 + floor (value/0x400), 0xDC00 + (value % 0x400)
+    return strformat ("\\u%.4x\\u%.4x", highsur, lowsur)
+  else
+    return ""
+  end
+end
+
+local function fsub (str, pattern, repl)
+  -- gsub always builds a new string in a buffer, even when no match
+  -- exists. First using find should be more efficient when most strings
+  -- don't contain the pattern.
+  if strfind (str, pattern) then
+    return gsub (str, pattern, repl)
+  else
+    return str
+  end
+end
+
+local function quotestring (value)
+  -- based on the regexp "escapable" in https://github.com/douglascrockford/JSON-js
+  value = fsub (value, "[%z\1-\31\"\\\127]", escapeutf8)
+  if strfind (value, "[\194\216\220\225\226\239]") then
+    value = fsub (value, "\194[\128-\159\173]", escapeutf8)
+    value = fsub (value, "\216[\128-\132]", escapeutf8)
+    value = fsub (value, "\220\143", escapeutf8)
+    value = fsub (value, "\225\158[\180\181]", escapeutf8)
+    value = fsub (value, "\226\128[\140-\143\168-\175]", escapeutf8)
+    value = fsub (value, "\226\129[\160-\175]", escapeutf8)
+    value = fsub (value, "\239\187\191", escapeutf8)
+    value = fsub (value, "\239\191[\176-\191]", escapeutf8)
+  end
+  return "\"" .. value .. "\""
+end
+json.quotestring = quotestring
+
+local function replace(str, o, n)
+  local i, j = strfind (str, o, 1, true)
+  if i then
+    return strsub(str, 1, i-1) .. n .. strsub(str, j+1, -1)
+  else
+    return str
+  end
+end
+
+-- locale independent num2str and str2num functions
+local decpoint, numfilter
+
+local function updatedecpoint ()
+  decpoint = strmatch(tostring(0.5), "([^05+])")
+  -- build a filter that can be used to remove group separators
+  numfilter = "[^0-9%-%+eE" .. gsub(decpoint, "[%^%$%(%)%%%.%[%]%*%+%-%?]", "%%%0") .. "]+"
+end
+
+updatedecpoint()
+
+local function num2str (num)
+  return replace(fsub(tostring(num), numfilter, ""), decpoint, ".")
+end
+
+local function str2num (str)
+  local num = tonumber(replace(str, ".", decpoint))
+  if not num then
+    updatedecpoint()
+    num = tonumber(replace(str, ".", decpoint))
+  end
+  return num
+end
+
+local function addnewline2 (level, buffer, buflen)
+  buffer[buflen+1] = "\n"
+  buffer[buflen+2] = strrep ("  ", level)
+  buflen = buflen + 2
+  return buflen
+end
+
+function json.addnewline (state)
+  if state.indent then
+    state.bufferlen = addnewline2 (state.level or 0,
+                           state.buffer, state.bufferlen or #(state.buffer))
+  end
+end
+
+local encode2 -- forward declaration
+
+local function addpair (key, value, prev, indent, level, buffer, buflen, tables, globalorder, state)
+  local kt = type (key)
+  if kt ~= 'string' and kt ~= 'number' then
+    return nil, "type '" .. kt .. "' is not supported as a key by JSON."
+  end
+  if prev then
+    buflen = buflen + 1
+    buffer[buflen] = ","
+  end
+  if indent then
+    buflen = addnewline2 (level, buffer, buflen)
+  end
+  -- When Lua is compiled with LUA_NOCVTN2S this will fail when
+  -- numbers are mixed into the keys of the table. JSON keys are always
+  -- strings, so this would be an implicit conversion too and the failure
+  -- is intentional.
+  buffer[buflen+1] = quotestring (key)
+  buffer[buflen+2] = ":"
+  return encode2 (value, indent, level, buffer, buflen + 2, tables, globalorder, state)
+end
+
+local function appendcustom(res, buffer, state)
+  local buflen = state.bufferlen
+  if type (res) == 'string' then
+    buflen = buflen + 1
+    buffer[buflen] = res
+  end
+  return buflen
+end
+
+local function exception(reason, value, state, buffer, buflen, defaultmessage)
+  defaultmessage = defaultmessage or reason
+  local handler = state.exception
+  if not handler then
+    return nil, defaultmessage
+  else
+    state.bufferlen = buflen
+    local ret, msg = handler (reason, value, state, defaultmessage)
+    if not ret then return nil, msg or defaultmessage end
+    return appendcustom(ret, buffer, state)
+  end
+end
+
+function json.encodeexception(reason, value, state, defaultmessage)
+  return quotestring("<" .. defaultmessage .. ">")
+end
+
+encode2 = function (value, indent, level, buffer, buflen, tables, globalorder, state)
+  local valtype = type (value)
+  local valmeta = getmetatable (value)
+  valmeta = type (valmeta) == 'table' and valmeta -- only tables
+  local valtojson = valmeta and valmeta.__tojson
+  if valtojson then
+    if tables[value] then
+      return exception('reference cycle', value, state, buffer, buflen)
+    end
+    tables[value] = true
+    state.bufferlen = buflen
+    local ret, msg = valtojson (value, state)
+    if not ret then return exception('custom encoder failed', value, state, buffer, buflen, msg) end
+    tables[value] = nil
+    buflen = appendcustom(ret, buffer, state)
+  elseif value == nil then
+    buflen = buflen + 1
+    buffer[buflen] = "null"
+  elseif valtype == 'number' then
+    local s
+    if value ~= value or value >= huge or -value >= huge then
+      -- This is the behaviour of the original JSON implementation.
+      s = "null"
+    else
+      s = num2str (value)
+    end
+    buflen = buflen + 1
+    buffer[buflen] = s
+  elseif valtype == 'boolean' then
+    buflen = buflen + 1
+    buffer[buflen] = value and "true" or "false"
+  elseif valtype == 'string' then
+    buflen = buflen + 1
+    buffer[buflen] = quotestring (value)
+  elseif valtype == 'table' then
+    if tables[value] then
+      return exception('reference cycle', value, state, buffer, buflen)
+    end
+    tables[value] = true
+    level = level + 1
+    local isa, n = isarray (value)
+    if n == 0 and valmeta and valmeta.__jsontype == 'object' then
+      isa = false
+    end
+    local msg
+    if isa then -- JSON array
+      buflen = buflen + 1
+      buffer[buflen] = "["
+      for i = 1, n do
+        buflen, msg = encode2 (value[i], indent, level, buffer, buflen, tables, globalorder, state)
+        if not buflen then return nil, msg end
+        if i < n then
+          buflen = buflen + 1
+          buffer[buflen] = ","
+        end
+      end
+      buflen = buflen + 1
+      buffer[buflen] = "]"
+    else -- JSON object
+      local prev = false
+      buflen = buflen + 1
+      buffer[buflen] = "{"
+      local order = valmeta and valmeta.__jsonorder or globalorder
+      if order then
+        local used = {}
+        n = #order
+        for i = 1, n do
+          local k = order[i]
+          local v = value[k]
+          if v ~= nil then
+            used[k] = true
+            buflen, msg = addpair (k, v, prev, indent, level, buffer, buflen, tables, globalorder, state)
+            if not buflen then return nil, msg end
+            prev = true -- add a seperator before the next element
+          end
+        end
+        for k,v in pairs (value) do
+          if not used[k] then
+            buflen, msg = addpair (k, v, prev, indent, level, buffer, buflen, tables, globalorder, state)
+            if not buflen then return nil, msg end
+            prev = true -- add a seperator before the next element
+          end
+        end
+      else -- unordered
+        for k,v in pairs (value) do
+          buflen, msg = addpair (k, v, prev, indent, level, buffer, buflen, tables, globalorder, state)
+          if not buflen then return nil, msg end
+          prev = true -- add a seperator before the next element
+        end
+      end
+      if indent then
+        buflen = addnewline2 (level - 1, buffer, buflen)
+      end
+      buflen = buflen + 1
+      buffer[buflen] = "}"
+    end
+    tables[value] = nil
+  else
+    return exception ('unsupported type', value, state, buffer, buflen,
+      "type '" .. valtype .. "' is not supported by JSON.")
+  end
+  return buflen
+end
+
+function json.encode (value, state)
+  state = state or {}
+  local oldbuffer = state.buffer
+  local buffer = oldbuffer or {}
+  state.buffer = buffer
+  updatedecpoint()
+  local ret, msg = encode2 (value, state.indent, state.level or 0,
+                   buffer, state.bufferlen or 0, state.tables or {}, state.keyorder, state)
+  if not ret then
+    error (msg, 2)
+  elseif oldbuffer == buffer then
+    state.bufferlen = ret
+    return true
+  else
+    state.bufferlen = nil
+    state.buffer = nil
+    return concat (buffer)
+  end
+end
+
+local function loc (str, where)
+  local line, pos, linepos = 1, 1, 0
+  while true do
+    pos = strfind (str, "\n", pos, true)
+    if pos and pos < where then
+      line = line + 1
+      linepos = pos
+      pos = pos + 1
+    else
+      break
+    end
+  end
+  return strformat ("line %d, column %d", line, where - linepos)
+end
+
+local function unterminated (str, what, where)
+  return nil, strlen (str) + 1, "unterminated " .. what .. " at " .. loc (str, where)
+end
+
+local function scanwhite (str, pos)
+  while true do
+    pos = strfind (str, "%S", pos)
+    if not pos then return nil end
+    local sub2 = strsub (str, pos, pos + 1)
+    if sub2 == "\239\187" and strsub (str, pos + 2, pos + 2) == "\191" then
+      -- UTF-8 Byte Order Mark
+      pos = pos + 3
+    elseif sub2 == "//" then
+      pos = strfind (str, "[\n\r]", pos + 2)
+      if not pos then return nil end
+    elseif sub2 == "/*" then
+      pos = strfind (str, "*/", pos + 2)
+      if not pos then return nil end
+      pos = pos + 2
+    else
+      return pos
+    end
+  end
+end
+
+local escapechars = {
+  ["\""] = "\"", ["\\"] = "\\", ["/"] = "/", ["b"] = "\b", ["f"] = "\f",
+  ["n"] = "\n", ["r"] = "\r", ["t"] = "\t"
+}
+
+local function unichar (value)
+  if value < 0 then
+    return nil
+  elseif value <= 0x007f then
+    return strchar (value)
+  elseif value <= 0x07ff then
+    return strchar (0xc0 + floor(value/0x40),
+                    0x80 + (floor(value) % 0x40))
+  elseif value <= 0xffff then
+    return strchar (0xe0 + floor(value/0x1000),
+                    0x80 + (floor(value/0x40) % 0x40),
+                    0x80 + (floor(value) % 0x40))
+  elseif value <= 0x10ffff then
+    return strchar (0xf0 + floor(value/0x40000),
+                    0x80 + (floor(value/0x1000) % 0x40),
+                    0x80 + (floor(value/0x40) % 0x40),
+                    0x80 + (floor(value) % 0x40))
+  else
+    return nil
+  end
+end
+
+local function scanstring (str, pos)
+  local lastpos = pos + 1
+  local buffer, n = {}, 0
+  while true do
+    local nextpos = strfind (str, "[\"\\]", lastpos)
+    if not nextpos then
+      return unterminated (str, "string", pos)
+    end
+    if nextpos > lastpos then
+      n = n + 1
+      buffer[n] = strsub (str, lastpos, nextpos - 1)
+    end
+    if strsub (str, nextpos, nextpos) == "\"" then
+      lastpos = nextpos + 1
+      break
+    else
+      local escchar = strsub (str, nextpos + 1, nextpos + 1)
+      local value
+      if escchar == "u" then
+        value = tonumber (strsub (str, nextpos + 2, nextpos + 5), 16)
+        if value then
+          local value2
+          if 0xD800 <= value and value <= 0xDBff then
+            -- we have the high surrogate of UTF-16. Check if there is a
+            -- low surrogate escaped nearby to combine them.
+            if strsub (str, nextpos + 6, nextpos + 7) == "\\u" then
+              value2 = tonumber (strsub (str, nextpos + 8, nextpos + 11), 16)
+              if value2 and 0xDC00 <= value2 and value2 <= 0xDFFF then
+                value = (value - 0xD800)  * 0x400 + (value2 - 0xDC00) + 0x10000
+              else
+                value2 = nil -- in case it was out of range for a low surrogate
+              end
+            end
+          end
+          value = value and unichar (value)
+          if value then
+            if value2 then
+              lastpos = nextpos + 12
+            else
+              lastpos = nextpos + 6
+            end
+          end
+        end
+      end
+      if not value then
+        value = escapechars[escchar] or escchar
+        lastpos = nextpos + 2
+      end
+      n = n + 1
+      buffer[n] = value
+    end
+  end
+  if n == 1 then
+    return buffer[1], lastpos
+  elseif n > 1 then
+    return concat (buffer), lastpos
+  else
+    return "", lastpos
+  end
+end
+
+local scanvalue -- forward declaration
+
+local function scantable (what, closechar, str, startpos, nullval, objectmeta, arraymeta)
+  local tbl, n = {}, 0
+  local pos = startpos + 1
+  if what == 'object' then
+    setmetatable (tbl, objectmeta)
+  else
+    setmetatable (tbl, arraymeta)
+  end
+  while true do
+    pos = scanwhite (str, pos)
+    if not pos then return unterminated (str, what, startpos) end
+    local char = strsub (str, pos, pos)
+    if char == closechar then
+      return tbl, pos + 1
+    end
+    local val1, err
+    val1, pos, err = scanvalue (str, pos, nullval, objectmeta, arraymeta)
+    if err then return nil, pos, err end
+    pos = scanwhite (str, pos)
+    if not pos then return unterminated (str, what, startpos) end
+    char = strsub (str, pos, pos)
+    if char == ":" then
+      if val1 == nil then
+        return nil, pos, "cannot use nil as table index (at " .. loc (str, pos) .. ")"
+      end
+      pos = scanwhite (str, pos + 1)
+      if not pos then return unterminated (str, what, startpos) end
+      local val2
+      val2, pos, err = scanvalue (str, pos, nullval, objectmeta, arraymeta)
+      if err then return nil, pos, err end
+      tbl[val1] = val2
+      pos = scanwhite (str, pos)
+      if not pos then return unterminated (str, what, startpos) end
+      char = strsub (str, pos, pos)
+    else
+      n = n + 1
+      tbl[n] = val1
+    end
+    if char == "," then
+      pos = pos + 1
+    end
+  end
+end
+
+scanvalue = function (str, pos, nullval, objectmeta, arraymeta)
+  pos = pos or 1
+  pos = scanwhite (str, pos)
+  if not pos then
+    return nil, strlen (str) + 1, "no valid JSON value (reached the end)"
+  end
+  local char = strsub (str, pos, pos)
+  if char == "{" then
+    return scantable ('object', "}", str, pos, nullval, objectmeta, arraymeta)
+  elseif char == "[" then
+    return scantable ('array', "]", str, pos, nullval, objectmeta, arraymeta)
+  elseif char == "\"" then
+    return scanstring (str, pos)
+  else
+    local pstart, pend = strfind (str, "^%-?[%d%.]+[eE]?[%+%-]?%d*", pos)
+    if pstart then
+      local number = str2num (strsub (str, pstart, pend))
+      if number then
+        return number, pend + 1
+      end
+    end
+    pstart, pend = strfind (str, "^%a%w*", pos)
+    if pstart then
+      local name = strsub (str, pstart, pend)
+      if name == "true" then
+        return true, pend + 1
+      elseif name == "false" then
+        return false, pend + 1
+      elseif name == "null" then
+        return nullval, pend + 1
+      end
+    end
+    return nil, pos, "no valid JSON value at " .. loc (str, pos)
+  end
+end
+
+local function optionalmetatables(...)
+  if select("#", ...) > 0 then
+    return ...
+  else
+    return {__jsontype = 'object'}, {__jsontype = 'array'}
+  end
+end
+
+function json.decode (str, pos, nullval, ...)
+  local objectmeta, arraymeta = optionalmetatables(...)
+  return scanvalue (str, pos, nullval, objectmeta, arraymeta)
+end
+
+function json.use_lpeg ()
+  local g = require ("lpeg")
+
+  if type(g.version) == 'function' and g.version() == "0.11" then
+    error "due to a bug in LPeg 0.11, it cannot be used for JSON matching"
+  end
+
+  local pegmatch = g.match
+  local P, S, R = g.P, g.S, g.R
+
+  local function ErrorCall (str, pos, msg, state)
+    if not state.msg then
+      state.msg = msg .. " at " .. loc (str, pos)
+      state.pos = pos
+    end
+    return false
+  end
+
+  local function Err (msg)
+    return g.Cmt (g.Cc (msg) * g.Carg (2), ErrorCall)
+  end
+
+  local function ErrorUnterminatedCall (str, pos, what, state)
+    return ErrorCall (str, pos - 1, "unterminated " .. what, state)
+  end
+
+  local SingleLineComment = P"//" * (1 - S"\n\r")^0
+  local MultiLineComment = P"/*" * (1 - P"*/")^0 * P"*/"
+  local Space = (S" \n\r\t" + P"\239\187\191" + SingleLineComment + MultiLineComment)^0
+
+  local function ErrUnterminated (what)
+    return g.Cmt (g.Cc (what) * g.Carg (2), ErrorUnterminatedCall)
+  end
+
+  local PlainChar = 1 - S"\"\\\n\r"
+  local EscapeSequence = (P"\\" * g.C (S"\"\\/bfnrt" + Err "unsupported escape sequence")) / escapechars
+  local HexDigit = R("09", "af", "AF")
+  local function UTF16Surrogate (match, pos, high, low)
+    high, low = tonumber (high, 16), tonumber (low, 16)
+    if 0xD800 <= high and high <= 0xDBff and 0xDC00 <= low and low <= 0xDFFF then
+      return true, unichar ((high - 0xD800)  * 0x400 + (low - 0xDC00) + 0x10000)
+    else
+      return false
+    end
+  end
+  local function UTF16BMP (hex)
+    return unichar (tonumber (hex, 16))
+  end
+  local U16Sequence = (P"\\u" * g.C (HexDigit * HexDigit * HexDigit * HexDigit))
+  local UnicodeEscape = g.Cmt (U16Sequence * U16Sequence, UTF16Surrogate) + U16Sequence/UTF16BMP
+  local Char = UnicodeEscape + EscapeSequence + PlainChar
+  local String = P"\"" * (g.Cs (Char ^ 0) * P"\"" + ErrUnterminated "string")
+  local Integer = P"-"^(-1) * (P"0" + (R"19" * R"09"^0))
+  local Fractal = P"." * R"09"^0
+  local Exponent = (S"eE") * (S"+-")^(-1) * R"09"^1
+  local Number = (Integer * Fractal^(-1) * Exponent^(-1))/str2num
+  local Constant = P"true" * g.Cc (true) + P"false" * g.Cc (false) + P"null" * g.Carg (1)
+  local SimpleValue = Number + String + Constant
+  local ArrayContent, ObjectContent
+
+  -- The functions parsearray and parseobject parse only a single value/pair
+  -- at a time and store them directly to avoid hitting the LPeg limits.
+  local function parsearray (str, pos, nullval, state)
+    local obj, cont
+    local start = pos
+    local npos
+    local t, nt = {}, 0
+    repeat
+      obj, cont, npos = pegmatch (ArrayContent, str, pos, nullval, state)
+      if cont == 'end' then
+        return ErrorUnterminatedCall (str, start, "array", state)
+      end
+      pos = npos
+      if cont == 'cont' or cont == 'last' then
+        nt = nt + 1
+        t[nt] = obj
+      end
+    until cont ~= 'cont'
+    return pos, setmetatable (t, state.arraymeta)
+  end
+
+  local function parseobject (str, pos, nullval, state)
+    local obj, key, cont
+    local start = pos
+    local npos
+    local t = {}
+    repeat
+      key, obj, cont, npos = pegmatch (ObjectContent, str, pos, nullval, state)
+      if cont == 'end' then
+        return ErrorUnterminatedCall (str, start, "object", state)
+      end
+      pos = npos
+      if cont == 'cont' or cont == 'last' then
+        t[key] = obj
+      end
+    until cont ~= 'cont'
+    return pos, setmetatable (t, state.objectmeta)
+  end
+
+  local Array = P"[" * g.Cmt (g.Carg(1) * g.Carg(2), parsearray)
+  local Object = P"{" * g.Cmt (g.Carg(1) * g.Carg(2), parseobject)
+  local Value = Space * (Array + Object + SimpleValue)
+  local ExpectedValue = Value + Space * Err "value expected"
+  local ExpectedKey = String + Err "key expected"
+  local End = P(-1) * g.Cc'end'
+  local ErrInvalid = Err "invalid JSON"
+  ArrayContent = (Value * Space * (P"," * g.Cc'cont' + P"]" * g.Cc'last'+ End + ErrInvalid)  + g.Cc(nil) * (P"]" * g.Cc'empty' + End  + ErrInvalid)) * g.Cp()
+  local Pair = g.Cg (Space * ExpectedKey * Space * (P":" + Err "colon expected") * ExpectedValue)
+  ObjectContent = (g.Cc(nil) * g.Cc(nil) * P"}" * g.Cc'empty' + End + (Pair * Space * (P"," * g.Cc'cont' + P"}" * g.Cc'last' + End + ErrInvalid) + ErrInvalid)) * g.Cp()
+  local DecodeValue = ExpectedValue * g.Cp ()
+
+  jsonlpeg.version = json.version
+  jsonlpeg.encode = json.encode
+  jsonlpeg.null = json.null
+  jsonlpeg.quotestring = json.quotestring
+  jsonlpeg.addnewline = json.addnewline
+  jsonlpeg.encodeexception = json.encodeexception
+  jsonlpeg.using_lpeg = true
+
+  function jsonlpeg.decode (str, pos, nullval, ...)
+    local state = {}
+    state.objectmeta, state.arraymeta = optionalmetatables(...)
+    local obj, retpos = pegmatch (DecodeValue, str, pos, nullval, state)
+    if state.msg then
+      return nil, state.pos, state.msg
+    else
+      return obj, retpos
+    end
+  end
+
+  -- cache result of this function:
+  json.use_lpeg = function () return jsonlpeg end
+  jsonlpeg.use_lpeg = json.use_lpeg
+
+  return jsonlpeg
+end
+
+if always_use_lpeg then
+  return json.use_lpeg()
+end
+
+return json
+

--- a/plugin/resurrect/test/lib/lust.lua
+++ b/plugin/resurrect/test/lib/lust.lua
@@ -1,0 +1,272 @@
+-- lust v0.2.0 - Lua test framework
+-- https://github.com/bjornbytes/lust
+-- MIT LICENSE
+
+local lust = {}
+lust.level = 0
+lust.passes = 0
+lust.errors = 0
+lust.befores = {}
+lust.afters = {}
+
+local red = string.char(27) .. '[31m'
+local green = string.char(27) .. '[32m'
+local normal = string.char(27) .. '[0m'
+local function indent(level) return string.rep('\t', level or lust.level) end
+
+function lust.nocolor()
+  red, green, normal = '', '', ''
+  return lust
+end
+
+function lust.describe(name, fn)
+  print(indent() .. name)
+  lust.level = lust.level + 1
+  fn()
+  lust.befores[lust.level] = {}
+  lust.afters[lust.level] = {}
+  lust.level = lust.level - 1
+end
+
+function lust.it(name, fn)
+  for level = 1, lust.level do
+    if lust.befores[level] then
+      for i = 1, #lust.befores[level] do
+        lust.befores[level][i](name)
+      end
+    end
+  end
+
+  local success, err = pcall(fn)
+  if success then lust.passes = lust.passes + 1
+  else lust.errors = lust.errors + 1 end
+  local color = success and green or red
+  local label = success and 'PASS' or 'FAIL'
+  print(indent() .. color .. label .. normal .. ' ' .. name)
+  if err then
+    print(indent(lust.level + 1) .. red .. tostring(err) .. normal)
+  end
+
+  for level = 1, lust.level do
+    if lust.afters[level] then
+      for i = 1, #lust.afters[level] do
+        lust.afters[level][i](name)
+      end
+    end
+  end
+end
+
+function lust.before(fn)
+  lust.befores[lust.level] = lust.befores[lust.level] or {}
+  table.insert(lust.befores[lust.level], fn)
+end
+
+function lust.after(fn)
+  lust.afters[lust.level] = lust.afters[lust.level] or {}
+  table.insert(lust.afters[lust.level], fn)
+end
+
+-- Assertions
+local function isa(v, x)
+  if type(x) == 'string' then
+    return type(v) == x,
+      'expected ' .. tostring(v) .. ' to be a ' .. x,
+      'expected ' .. tostring(v) .. ' to not be a ' .. x
+  elseif type(x) == 'table' then
+    if type(v) ~= 'table' then
+      return false,
+        'expected ' .. tostring(v) .. ' to be a ' .. tostring(x),
+        'expected ' .. tostring(v) .. ' to not be a ' .. tostring(x)
+    end
+
+    local seen = {}
+    local meta = v
+    while meta and not seen[meta] do
+      if meta == x then return true end
+      seen[meta] = true
+      meta = getmetatable(meta) and getmetatable(meta).__index
+    end
+
+    return false,
+      'expected ' .. tostring(v) .. ' to be a ' .. tostring(x),
+      'expected ' .. tostring(v) .. ' to not be a ' .. tostring(x)
+  end
+
+  error('invalid type ' .. tostring(x))
+end
+
+local function has(t, x)
+  for k, v in pairs(t) do
+    if v == x then return true end
+  end
+  return false
+end
+
+local function eq(t1, t2, eps)
+  if type(t1) ~= type(t2) then return false end
+  if type(t1) == 'number' then return math.abs(t1 - t2) <= (eps or 0) end
+  if type(t1) ~= 'table' then return t1 == t2 end
+  for k, _ in pairs(t1) do
+    if not eq(t1[k], t2[k], eps) then return false end
+  end
+  for k, _ in pairs(t2) do
+    if not eq(t2[k], t1[k], eps) then return false end
+  end
+  return true
+end
+
+local function stringify(t)
+  if type(t) == 'string' then return "'" .. tostring(t) .. "'" end
+  if type(t) ~= 'table' or getmetatable(t) and getmetatable(t).__tostring then return tostring(t) end
+  local strings = {}
+  for i, v in ipairs(t) do
+    strings[#strings + 1] = stringify(v)
+  end
+  for k, v in pairs(t) do
+    if type(k) ~= 'number' or k > #t or k < 1 then
+      strings[#strings + 1] = ('[%s] = %s'):format(stringify(k), stringify(v))
+    end
+  end
+  return '{ ' .. table.concat(strings, ', ') .. ' }'
+end
+
+local paths = {
+  [''] = { 'to', 'to_not' },
+  to = { 'have', 'equal', 'be', 'exist', 'fail', 'match' },
+  to_not = { 'have', 'equal', 'be', 'exist', 'fail', 'match', chain = function(a) a.negate = not a.negate end },
+  a = { test = isa },
+  an = { test = isa },
+  be = { 'a', 'an', 'truthy',
+    test = function(v, x)
+      return v == x,
+        'expected ' .. tostring(v) .. ' and ' .. tostring(x) .. ' to be the same',
+        'expected ' .. tostring(v) .. ' and ' .. tostring(x) .. ' to not be the same'
+    end
+  },
+  exist = {
+    test = function(v)
+      return v ~= nil,
+        'expected ' .. tostring(v) .. ' to exist',
+        'expected ' .. tostring(v) .. ' to not exist'
+    end
+  },
+  truthy = {
+    test = function(v)
+      return v,
+        'expected ' .. tostring(v) .. ' to be truthy',
+        'expected ' .. tostring(v) .. ' to not be truthy'
+    end
+  },
+  equal = {
+    test = function(v, x, eps)
+      local comparison = ''
+      local equal = eq(v, x, eps)
+
+      if not equal and (type(v) == 'table' or type(x) == 'table') then
+        comparison = comparison .. '\n' .. indent(lust.level + 1) .. 'LHS: ' .. stringify(v)
+        comparison = comparison .. '\n' .. indent(lust.level + 1) .. 'RHS: ' .. stringify(x)
+      end
+
+      return equal,
+        'expected ' .. tostring(v) .. ' and ' .. tostring(x) .. ' to be equal' .. comparison,
+        'expected ' .. tostring(v) .. ' and ' .. tostring(x) .. ' to not be equal'
+    end
+  },
+  have = {
+    test = function(v, x)
+      if type(v) ~= 'table' then
+        error('expected ' .. tostring(v) .. ' to be a table')
+      end
+
+      return has(v, x),
+        'expected ' .. tostring(v) .. ' to contain ' .. tostring(x),
+        'expected ' .. tostring(v) .. ' to not contain ' .. tostring(x)
+    end
+  },
+  fail = { 'with',
+    test = function(v)
+      return not pcall(v),
+        'expected ' .. tostring(v) .. ' to fail',
+        'expected ' .. tostring(v) .. ' to not fail'
+    end
+  },
+  with = {
+    test = function(v, pattern)
+      local ok, message = pcall(v)
+      return not ok and message:match(pattern),
+        'expected ' .. tostring(v) .. ' to fail with error matching "' .. pattern .. '"',
+        'expected ' .. tostring(v) .. ' to not fail with error matching "' .. pattern .. '"'
+    end
+  },
+  match = {
+    test = function(v, p)
+      if type(v) ~= 'string' then v = tostring(v) end
+      local result = string.find(v, p)
+      return result ~= nil,
+        'expected ' .. v .. ' to match pattern [[' .. p .. ']]',
+        'expected ' .. v .. ' to not match pattern [[' .. p .. ']]'
+    end
+  }
+}
+
+function lust.expect(v)
+  local assertion = {}
+  assertion.val = v
+  assertion.action = ''
+  assertion.negate = false
+
+  setmetatable(assertion, {
+    __index = function(t, k)
+      if has(paths[rawget(t, 'action')], k) then
+        rawset(t, 'action', k)
+        local chain = paths[rawget(t, 'action')].chain
+        if chain then chain(t) end
+        return t
+      end
+      return rawget(t, k)
+    end,
+    __call = function(t, ...)
+      if paths[t.action].test then
+        local res, err, nerr = paths[t.action].test(t.val, ...)
+        if assertion.negate then
+          res = not res
+          err = nerr or err
+        end
+        if not res then
+          error(err or 'unknown failure', 2)
+        end
+      end
+    end
+  })
+
+  return assertion
+end
+
+function lust.spy(target, name, run)
+  local spy = {}
+  local subject
+
+  local function capture(...)
+    table.insert(spy, {...})
+    return subject(...)
+  end
+
+  if type(target) == 'table' then
+    subject = target[name]
+    target[name] = capture
+  else
+    run = name
+    subject = target or function() end
+  end
+
+  setmetatable(spy, {__call = function(_, ...) return capture(...) end})
+
+  if run then run() end
+
+  return spy
+end
+
+lust.test = lust.it
+lust.paths = paths
+
+return lust

--- a/plugin/resurrect/test/spec/api_spec.lua
+++ b/plugin/resurrect/test/spec/api_spec.lua
@@ -1,0 +1,407 @@
+-- Tests for shell/api.lua
+-- Verifies that WezTerm API data extraction is correctly centralized
+
+local mux = require("mux")
+local fixtures = require("pane_layouts")
+
+-- Import module under test
+local shell_api = require("resurrect.shell.api")
+
+--------------------------------------------------------------------------------
+-- Setup / Teardown
+--------------------------------------------------------------------------------
+
+describe("Shell API", function()
+	before(function()
+		mux.reset()
+		wezterm._test.reset()
+		wezterm._test.set_mux(mux)
+	end)
+
+	---------------------------------------------------------------------------
+	-- extract_pane Tests
+	---------------------------------------------------------------------------
+
+	describe("extract_pane", function()
+		it("extracts cwd from pane", function()
+			local workspace = mux.workspace("test"):window("win"):tab("tab"):pane(fixtures.single_pane.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local pane = tab:active_pane()
+
+			local raw = shell_api.extract_pane(pane, 1000)
+
+			expect(raw.cwd).to.equal("/home/user")
+		end)
+
+		it("extracts domain name", function()
+			local workspace = mux.workspace("test"):window("win"):tab("tab"):pane(fixtures.single_pane.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local pane = tab:active_pane()
+
+			local raw = shell_api.extract_pane(pane, 1000)
+
+			expect(raw.domain).to.equal("local")
+		end)
+
+		it("extracts is_spawnable for local domain", function()
+			local workspace = mux.workspace("test"):window("win"):tab("tab"):pane(fixtures.single_pane.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local pane = tab:active_pane()
+
+			local raw = shell_api.extract_pane(pane, 1000)
+
+			expect(raw.is_spawnable).to.equal(true)
+		end)
+
+		it("handles empty cwd", function()
+			local workspace = mux.workspace("test"):window("win"):tab("tab"):pane(fixtures.empty_cwd.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local pane = tab:active_pane()
+
+			local raw = shell_api.extract_pane(pane, 1000)
+
+			expect(raw.cwd).to.equal("")
+		end)
+
+		it("extracts alt_screen_active status", function()
+			local workspace =
+				mux.workspace("test"):window("win"):tab("tab"):pane(fixtures.with_alt_screen.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local pane = tab:active_pane()
+
+			local raw = shell_api.extract_pane(pane, 1000)
+
+			expect(raw.alt_screen_active).to.equal(true)
+		end)
+
+		it("extracts process info when alt screen active", function()
+			local workspace =
+				mux.workspace("test"):window("win"):tab("tab"):pane(fixtures.with_alt_screen.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local pane = tab:active_pane()
+
+			local raw = shell_api.extract_pane(pane, 1000)
+
+			expect(raw.process).to.exist()
+			expect(raw.process.name).to.equal("vim")
+		end)
+
+		it("extracts scrollback text when not in alt screen", function()
+			local workspace =
+				mux.workspace("test"):window("win"):tab("tab"):pane(fixtures.with_scrollback.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local pane = tab:active_pane()
+
+			local raw = shell_api.extract_pane(pane, 1000)
+
+			expect(raw.text).to.exist()
+			expect(raw.text:find("ls")).to.exist()
+		end)
+
+		it("marks non-spawnable domains", function()
+			-- Set up a non-spawnable domain
+			mux.set_domain_spawnable("SSH:broken", false)
+
+			local workspace = mux.workspace("test")
+				:window("win")
+				:tab("tab")
+				:pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/remote", domain = "SSH:broken" })
+				:build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local pane = tab:active_pane()
+
+			local raw = shell_api.extract_pane(pane, 1000)
+
+			expect(raw.is_spawnable).to.equal(false)
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- extract_panes Tests
+	---------------------------------------------------------------------------
+
+	describe("extract_panes", function()
+		it("extracts all panes with geometry", function()
+			local workspace = mux.workspace("test")
+				:window("win")
+				:tab("tab")
+				:pane(fixtures.hsplit.panes[1])
+				:hsplit(fixtures.hsplit.panes[2])
+				:build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local panes_info = tab:panes_with_info()
+
+			local raw_panes = shell_api.extract_panes(panes_info, 1000)
+
+			expect(#raw_panes).to.equal(2)
+		end)
+
+		it("preserves geometry from PaneInformation", function()
+			local workspace = mux.workspace("test")
+				:window("win")
+				:tab("tab")
+				:pane(fixtures.hsplit.panes[1])
+				:hsplit(fixtures.hsplit.panes[2])
+				:build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local panes_info = tab:panes_with_info()
+
+			local raw_panes = shell_api.extract_panes(panes_info, 1000)
+
+			-- First pane should be at left=0
+			expect(raw_panes[1].left).to.equal(0)
+			expect(raw_panes[1].width).to.equal(80)
+
+			-- Second pane should be to the right
+			expect(raw_panes[2].left).to.equal(81)
+		end)
+
+		it("preserves is_active from PaneInformation", function()
+			local workspace = mux.workspace("test")
+				:window("win")
+				:tab("tab")
+				:pane(fixtures.hsplit.panes[1])
+				:hsplit(fixtures.hsplit.panes[2])
+				:build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local panes_info = tab:panes_with_info()
+
+			local raw_panes = shell_api.extract_panes(panes_info, 1000)
+
+			-- First pane is active in fixture
+			expect(raw_panes[1].is_active).to.equal(true)
+		end)
+
+		it("preserves is_zoomed from PaneInformation", function()
+			local workspace = mux.workspace("test"):window("win"):tab("tab"):pane(fixtures.zoomed_pane.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local panes_info = tab:panes_with_info()
+
+			local raw_panes = shell_api.extract_panes(panes_info, 1000)
+
+			expect(raw_panes[1].is_zoomed).to.equal(true)
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- extract_tab Tests
+	---------------------------------------------------------------------------
+
+	describe("extract_tab", function()
+		it("extracts tab title", function()
+			local workspace =
+				mux.workspace("test"):window("win"):tab("my-tab"):pane(fixtures.single_pane.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+
+			local raw_tab = shell_api.extract_tab(tab, 1000)
+
+			expect(raw_tab.title).to.equal("my-tab")
+		end)
+
+		it("extracts all panes in tab", function()
+			local workspace = mux.workspace("test")
+				:window("win")
+				:tab("tab")
+				:pane(fixtures.ide_layout.panes[1])
+				:hsplit(fixtures.ide_layout.panes[2])
+				:vsplit(fixtures.ide_layout.panes[3])
+				:build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+
+			local raw_tab = shell_api.extract_tab(tab, 1000)
+
+			expect(#raw_tab.panes).to.equal(3)
+		end)
+
+		it("detects zoomed state from any pane", function()
+			local workspace = mux.workspace("test")
+				:window("win")
+				:tab("tab")
+				:pane(fixtures.zoomed_pane.panes[1])
+				:hsplit(fixtures.zoomed_pane.panes[2])
+				:build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+
+			local raw_tab = shell_api.extract_tab(tab, 1000)
+
+			expect(raw_tab.is_zoomed).to.equal(true)
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- extract_window Tests
+	---------------------------------------------------------------------------
+
+	describe("extract_window", function()
+		it("extracts window title", function()
+			local workspace =
+				mux.workspace("test"):window("my-window"):tab("tab"):pane(fixtures.single_pane.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local window = workspace.windows[1]
+
+			local raw_window = shell_api.extract_window(window, 1000)
+
+			expect(raw_window.title).to.equal("my-window")
+		end)
+
+		it("extracts all tabs", function()
+			local workspace = mux.workspace("test")
+				:window("win")
+				:tab("tab1")
+				:pane(fixtures.single_pane.panes[1])
+				:tab("tab2")
+				:pane(fixtures.single_pane.panes[1])
+				:build()
+
+			mux.set_active(workspace)
+
+			local window = workspace.windows[1]
+
+			local raw_window = shell_api.extract_window(window, 1000)
+
+			expect(#raw_window.tabs).to.equal(2)
+		end)
+
+		it("marks active tab", function()
+			local workspace = mux.workspace("test")
+				:window("win")
+				:tab("tab1")
+				:pane(fixtures.single_pane.panes[1])
+				:tab("tab2")
+				:pane(fixtures.single_pane.panes[1])
+				:build()
+
+			mux.set_active(workspace)
+
+			local window = workspace.windows[1]
+
+			local raw_window = shell_api.extract_window(window, 1000)
+
+			-- First tab is active by default
+			expect(raw_window.tabs[1].is_active).to.equal(true)
+		end)
+
+		it("extracts window size", function()
+			local workspace = mux.workspace("test"):window("win"):tab("tab"):pane(fixtures.single_pane.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local window = workspace.windows[1]
+
+			local raw_window = shell_api.extract_window(window, 1000)
+
+			expect(raw_window.size).to.exist()
+			expect(raw_window.size.cols).to.exist()
+			expect(raw_window.size.rows).to.exist()
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- warn_not_spawnable Tests
+	---------------------------------------------------------------------------
+
+	describe("warn_not_spawnable", function()
+		it("emits resurrect.error event", function()
+			wezterm._test.clear_emitted_events()
+
+			shell_api.warn_not_spawnable("SSH:broken")
+
+			local events = wezterm._test.get_emitted_events()
+			local found = false
+			for _, event in ipairs(events) do
+				if event.name == "resurrect.error" then
+					found = true
+					expect(event.args[1]:find("SSH:broken")).to.exist()
+				end
+			end
+			expect(found).to.equal(true)
+		end)
+
+		it("logs warning", function()
+			wezterm._test.clear_logs()
+
+			shell_api.warn_not_spawnable("SSH:broken")
+
+			local logs = wezterm._test.get_logs()
+			local found = false
+			for _, log in ipairs(logs) do
+				if log.level == "warn" and log.message:find("SSH:broken") then
+					found = true
+				end
+			end
+			expect(found).to.equal(true)
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Multi-domain Tests
+	---------------------------------------------------------------------------
+
+	describe("multi-domain scenarios", function()
+		it("handles mixed local and SSH domains", function()
+			local workspace = mux.workspace("test")
+				:window("win")
+				:tab("tab")
+				:pane(fixtures.multi_domain.panes[1])
+				:hsplit(fixtures.multi_domain.panes[2])
+				:build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local panes_info = tab:panes_with_info()
+
+			local raw_panes = shell_api.extract_panes(panes_info, 1000)
+
+			expect(raw_panes[1].domain).to.equal("local")
+			expect(raw_panes[2].domain).to.equal("SSH:server")
+		end)
+	end)
+end)

--- a/plugin/resurrect/test/spec/capture_spec.lua
+++ b/plugin/resurrect/test/spec/capture_spec.lua
@@ -15,551 +15,551 @@ local workspace_state_mod = require("resurrect.workspace_state")
 --------------------------------------------------------------------------------
 
 describe("State Capture", function()
-
-    before(function()
-        mux.reset()
-        wezterm._test.reset()
-        -- Inject mux fake into wezterm
-        wezterm._test.set_mux(mux)
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Pane Tree Creation Tests
-    ---------------------------------------------------------------------------
-
-    describe("pane tree creation", function()
-
-        describe("single pane", function()
-            it("creates tree with correct geometry", function()
-                local workspace = mux.workspace("test")
-                    :window("win")
-                        :tab("tab")
-                            :pane(fixtures.single_pane.panes[1])
-                    :build()
-
-                mux.set_active(workspace)
-
-                local tab = workspace.windows[1]:tabs()[1]
-                local panes_info = tab:panes_with_info()
-
-                local tree = pane_tree_mod.create_pane_tree(panes_info)
-
-                expect(tree).to.exist()
-                expect(tree.cwd).to.equal("/home/user")
-                expect(tree.width).to.equal(160)
-                expect(tree.height).to.equal(48)
-                expect(tree.left).to.equal(0)
-                expect(tree.top).to.equal(0)
-            end)
-
-            it("has no children for single pane", function()
-                local workspace = mux.workspace("test")
-                    :window("win")
-                        :tab("tab")
-                            :pane(fixtures.single_pane.panes[1])
-                    :build()
-
-                mux.set_active(workspace)
-
-                local tab = workspace.windows[1]:tabs()[1]
-                local panes_info = tab:panes_with_info()
-                local tree = pane_tree_mod.create_pane_tree(panes_info)
-
-                expect(tree.right).to_not.exist()
-                expect(tree.bottom).to_not.exist()
-            end)
-        end)
-
-        describe("horizontal split", function()
-            it("captures right pane as child", function()
-                local workspace = mux.workspace("test")
-                    :window("win")
-                        :tab("tab")
-                            :pane(fixtures.hsplit.panes[1])
-                            :hsplit(fixtures.hsplit.panes[2])
-                    :build()
-
-                mux.set_active(workspace)
-
-                local tab = workspace.windows[1]:tabs()[1]
-                local panes_info = tab:panes_with_info()
-                local tree = pane_tree_mod.create_pane_tree(panes_info)
-
-                expect(tree.right).to.exist()
-                expect(tree.right.cwd).to.equal("/tmp")
-                expect(tree.bottom).to_not.exist()
-            end)
-
-            it("preserves left pane geometry", function()
-                local workspace = mux.workspace("test")
-                    :window("win")
-                        :tab("tab")
-                            :pane(fixtures.hsplit.panes[1])
-                            :hsplit(fixtures.hsplit.panes[2])
-                    :build()
-
-                mux.set_active(workspace)
-
-                local tab = workspace.windows[1]:tabs()[1]
-                local panes_info = tab:panes_with_info()
-                local tree = pane_tree_mod.create_pane_tree(panes_info)
-
-                expect(tree.left).to.equal(0)
-                expect(tree.width).to.equal(80)
-                expect(tree.cwd).to.equal("/home")
-            end)
-        end)
-
-        describe("vertical split", function()
-            it("captures bottom pane as child", function()
-                local workspace = mux.workspace("test")
-                    :window("win")
-                        :tab("tab")
-                            :pane(fixtures.vsplit.panes[1])
-                            :vsplit(fixtures.vsplit.panes[2])
-                    :build()
-
-                mux.set_active(workspace)
-
-                local tab = workspace.windows[1]:tabs()[1]
-                local panes_info = tab:panes_with_info()
-                local tree = pane_tree_mod.create_pane_tree(panes_info)
-
-                expect(tree.bottom).to.exist()
-                expect(tree.bottom.cwd).to.equal("/var/log")
-                expect(tree.right).to_not.exist()
-            end)
-
-            it("preserves top pane geometry", function()
-                local workspace = mux.workspace("test")
-                    :window("win")
-                        :tab("tab")
-                            :pane(fixtures.vsplit.panes[1])
-                            :vsplit(fixtures.vsplit.panes[2])
-                    :build()
-
-                mux.set_active(workspace)
-
-                local tab = workspace.windows[1]:tabs()[1]
-                local panes_info = tab:panes_with_info()
-                local tree = pane_tree_mod.create_pane_tree(panes_info)
-
-                expect(tree.top).to.equal(0)
-                expect(tree.height).to.equal(24)
-                expect(tree.cwd).to.equal("/home")
-            end)
-        end)
-
-        describe("IDE layout", function()
-            it("preserves nested structure", function()
-                local workspace = mux.workspace("test")
-                    :window("win")
-                        :tab("tab")
-                            :pane(fixtures.ide_layout.panes[1])
-                            :hsplit(fixtures.ide_layout.panes[2])
-                            :vsplit(fixtures.ide_layout.panes[3])
-                    :build()
-
-                mux.set_active(workspace)
-
-                local tab = workspace.windows[1]:tabs()[1]
-                local panes_info = tab:panes_with_info()
-                local tree = pane_tree_mod.create_pane_tree(panes_info)
-
-                -- Root has right child (terminal column)
-                expect(tree.right).to.exist()
-                -- Terminal column has bottom child (output pane)
-                expect(tree.right.bottom).to.exist()
-            end)
-        end)
-
-        describe("three-way horizontal split", function()
-            it("captures nested right chain", function()
-                local workspace = mux.workspace("test")
-                    :window("win")
-                        :tab("tab")
-                            :pane(fixtures.three_way_hsplit.panes[1])
-                            :hsplit(fixtures.three_way_hsplit.panes[2])
-                            :hsplit(fixtures.three_way_hsplit.panes[3])
-                    :build()
-
-                mux.set_active(workspace)
-
-                local tab = workspace.windows[1]:tabs()[1]
-                local panes_info = tab:panes_with_info()
-                local tree = pane_tree_mod.create_pane_tree(panes_info)
-
-                -- Left pane (/a) has right child (/b), which has right child (/c)
-                expect(tree.cwd).to.equal("/a")
-                expect(tree.right).to.exist()
-                expect(tree.right.cwd).to.equal("/b")
-                expect(tree.right.right).to.exist()
-                expect(tree.right.right.cwd).to.equal("/c")
-            end)
-
-            it("has no bottom splits", function()
-                local workspace = mux.workspace("test")
-                    :window("win")
-                        :tab("tab")
-                            :pane(fixtures.three_way_hsplit.panes[1])
-                            :hsplit(fixtures.three_way_hsplit.panes[2])
-                            :hsplit(fixtures.three_way_hsplit.panes[3])
-                    :build()
-
-                mux.set_active(workspace)
-
-                local tab = workspace.windows[1]:tabs()[1]
-                local panes_info = tab:panes_with_info()
-                local tree = pane_tree_mod.create_pane_tree(panes_info)
-
-                expect(tree.bottom).to_not.exist()
-                expect(tree.right.bottom).to_not.exist()
-            end)
-        end)
-
-        describe("grid 2x2 layout", function()
-            it("captures four panes in grid structure", function()
-                local workspace = mux.workspace("test")
-                    :window("win")
-                        :tab("tab")
-                            :pane(fixtures.grid_2x2.panes[1])
-                            :hsplit(fixtures.grid_2x2.panes[2])
-                            :vsplit(fixtures.grid_2x2.panes[3])
-                            :vsplit(fixtures.grid_2x2.panes[4])
-                    :build()
-
-                mux.set_active(workspace)
-
-                local tab = workspace.windows[1]:tabs()[1]
-                local panes_info = tab:panes_with_info()
-                local tree = pane_tree_mod.create_pane_tree(panes_info)
-
-                -- Verify we have 4 panes total (root + 3 children in tree)
-                expect(tree).to.exist()
-                expect(tree.cwd).to.equal("/tl")
-            end)
-
-            it("preserves pane positions", function()
-                local workspace = mux.workspace("test")
-                    :window("win")
-                        :tab("tab")
-                            :pane(fixtures.grid_2x2.panes[1])
-                            :hsplit(fixtures.grid_2x2.panes[2])
-                            :vsplit(fixtures.grid_2x2.panes[3])
-                            :vsplit(fixtures.grid_2x2.panes[4])
-                    :build()
-
-                mux.set_active(workspace)
-
-                local tab = workspace.windows[1]:tabs()[1]
-                local panes_info = tab:panes_with_info()
-                local tree = pane_tree_mod.create_pane_tree(panes_info)
-
-                -- Top-left pane should be at origin
-                expect(tree.left).to.equal(0)
-                expect(tree.top).to.equal(0)
-            end)
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Tab State Tests
-    ---------------------------------------------------------------------------
-
-    describe("tab state", function()
-
-        it("captures tab title", function()
-            local workspace = mux.workspace("test")
-                :window("win")
-                    :tab("My Custom Tab")
-                        :pane(fixtures.single_pane.panes[1])
-                :build()
-
-            mux.set_active(workspace)
-
-            local tab = workspace.windows[1]:tabs()[1]
-            local tab_state = tab_state_mod.get_tab_state(tab)
-
-            expect(tab_state.title).to.equal("My Custom Tab")
-        end)
-
-        it("captures pane tree", function()
-            local workspace = mux.workspace("test")
-                :window("win")
-                    :tab("tab")
-                        :pane(fixtures.single_pane.panes[1])
-                :build()
-
-            mux.set_active(workspace)
-
-            local tab = workspace.windows[1]:tabs()[1]
-            local tab_state = tab_state_mod.get_tab_state(tab)
-
-            expect(tab_state.pane_tree).to.exist()
-            expect(tab_state.pane_tree.cwd).to.equal("/home/user")
-        end)
-
-        it("captures zoomed state", function()
-            local workspace = mux.workspace("test")
-                :window("win")
-                    :tab("tab")
-                        :pane(fixtures.zoomed_pane.panes[1])
-                        :hsplit(fixtures.zoomed_pane.panes[2])
-                :build()
-
-            mux.set_active(workspace)
-
-            local tab = workspace.windows[1]:tabs()[1]
-            local tab_state = tab_state_mod.get_tab_state(tab)
-
-            expect(tab_state.is_zoomed).to.equal(true)
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Window State Tests
-    ---------------------------------------------------------------------------
-
-    describe("window state", function()
-
-        it("captures window title", function()
-            local workspace = mux.workspace("test")
-                :window("Main Window")
-                    :tab("tab")
-                        :pane(fixtures.single_pane.panes[1])
-                :build()
-
-            mux.set_active(workspace)
-
-            local window = workspace.windows[1]
-            local window_state = window_state_mod.get_window_state(window)
-
-            expect(window_state.title).to.equal("Main Window")
-        end)
-
-        it("captures all tabs", function()
-            local workspace = mux.workspace("test")
-                :window("win")
-                    :tab("Tab 1"):pane(fixtures.single_pane.panes[1])
-                    :tab("Tab 2"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/other" })
-                :build()
-
-            mux.set_active(workspace)
-
-            local window = workspace.windows[1]
-            local window_state = window_state_mod.get_window_state(window)
-
-            expect(#window_state.tabs).to.equal(2)
-            expect(window_state.tabs[1].title).to.equal("Tab 1")
-            expect(window_state.tabs[2].title).to.equal("Tab 2")
-        end)
-
-        it("captures window size", function()
-            local workspace = mux.workspace("test")
-                :window("win")
-                    :tab("tab")
-                        :pane(fixtures.single_pane.panes[1])
-                :build()
-
-            mux.set_active(workspace)
-
-            local window = workspace.windows[1]
-            local window_state = window_state_mod.get_window_state(window)
-
-            expect(window_state.size).to.exist()
-            expect(window_state.size.cols).to.be.a("number")
-            expect(window_state.size.rows).to.be.a("number")
-        end)
-
-        it("marks active tab", function()
-            local workspace = mux.workspace("test")
-                :window("win")
-                    :tab("Tab 1"):pane(fixtures.single_pane.panes[1])
-                    :tab("Tab 2"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/other", is_active = true })
-                :build()
-
-            mux.set_active(workspace)
-
-            local window = workspace.windows[1]
-            local window_state = window_state_mod.get_window_state(window)
-
-            -- At least one tab should be marked active
-            local has_active = false
-            for _, tab in ipairs(window_state.tabs) do
-                if tab.is_active then
-                    has_active = true
-                    break
-                end
-            end
-            expect(has_active).to.equal(true)
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Workspace State Tests
-    ---------------------------------------------------------------------------
-
-    describe("workspace state", function()
-
-        it("captures workspace name", function()
-            local workspace = mux.workspace("my-project")
-                :window("win")
-                    :tab("tab")
-                        :pane(fixtures.single_pane.panes[1])
-                :build()
-
-            mux.set_active(workspace)
-
-            local state = workspace_state_mod.get_workspace_state()
-
-            expect(state.workspace).to.equal("my-project")
-        end)
-
-        it("captures all windows in workspace", function()
-            local workspace = mux.workspace("test")
-                :window("Window 1"):tab("tab"):pane(fixtures.single_pane.panes[1])
-                :window("Window 2"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/other" })
-                :build()
-
-            mux.set_active(workspace)
-
-            local state = workspace_state_mod.get_workspace_state()
-
-            expect(#state.window_states).to.equal(2)
-        end)
-
-        it("only captures windows from active workspace", function()
-            -- Create first workspace
-            local workspace1 = mux.workspace("workspace1")
-                :window("Win1"):tab("tab"):pane(fixtures.single_pane.panes[1])
-                :build()
-
-            mux.set_active(workspace1)
-
-            -- Create second workspace (different name means different workspace)
-            local workspace2 = mux.workspace("workspace2")
-                :window("Win2"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/other" })
-                :build()
-
-            -- Don't set workspace2 as active, just add windows
-            for _, win in ipairs(workspace2.windows) do
-                table.insert(mux.all_windows(), win)
-            end
-
-            local state = workspace_state_mod.get_workspace_state()
-
-            -- Should only have windows from workspace1
-            expect(state.workspace).to.equal("workspace1")
-            for _, win_state in ipairs(state.window_states) do
-                -- All windows should be from workspace1
-                expect(win_state).to.exist()
-            end
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Scrollback Capture Tests
-    ---------------------------------------------------------------------------
-
-    describe("scrollback capture", function()
-
-        it("captures terminal content", function()
-            local workspace = mux.workspace("test")
-                :window("win")
-                    :tab("tab")
-                        :pane(fixtures.with_scrollback.panes[1])
-                :build()
-
-            mux.set_active(workspace)
-
-            local tab = workspace.windows[1]:tabs()[1]
-            local panes_info = tab:panes_with_info()
-            local tree = pane_tree_mod.create_pane_tree(panes_info)
-
-            expect(tree.text).to.exist()
-            expect(tree.text).to.match("file1.txt")
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Domain Capture Tests
-    ---------------------------------------------------------------------------
-
-    describe("domain capture", function()
-
-        it("captures domain name", function()
-            local workspace = mux.workspace("test")
-                :window("win")
-                    :tab("tab")
-                        :pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/home", domain = "local", is_active = true })
-                :build()
-
-            mux.set_active(workspace)
-
-            local tab = workspace.windows[1]:tabs()[1]
-            local panes_info = tab:panes_with_info()
-            local tree = pane_tree_mod.create_pane_tree(panes_info)
-
-            expect(tree.domain).to.equal("local")
-        end)
-
-        it("warns for non-spawnable domains", function()
-            mux.set_domain_spawnable("SSH:dead", false)
-
-            local workspace = mux.workspace("test")
-                :window("win")
-                    :tab("tab")
-                        :pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/remote", domain = "SSH:dead", is_active = true })
-                :build()
-
-            mux.set_active(workspace)
-
-            local tab = workspace.windows[1]:tabs()[1]
-            local panes_info = tab:panes_with_info()
-
-            -- Clear logs before test
-            wezterm._test.clear_logs()
-
-            local tree = pane_tree_mod.create_pane_tree(panes_info)
-
-            -- Should have logged a warning
-            local logs = wezterm._test.get_logs()
-            local found_warning = false
-            for _, log in ipairs(logs) do
-                if log.level == "warn" and log.message:match("SSH:dead") then
-                    found_warning = true
-                    break
-                end
-            end
-            expect(found_warning).to.equal(true)
-        end)
-
-        it("continues processing after non-spawnable domain", function()
-            mux.set_domain_spawnable("SSH:remote", false)
-
-            local workspace = mux.workspace("test")
-                :window("win")
-                    :tab("tab")
-                        :pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/home", domain = "SSH:remote", is_active = true })
-                :build()
-
-            mux.set_active(workspace)
-
-            local tab = workspace.windows[1]:tabs()[1]
-            local panes_info = tab:panes_with_info()
-
-            -- Should not crash - pane tree is created but domain is not stored (correct behavior)
-            local tree = pane_tree_mod.create_pane_tree(panes_info)
-            expect(tree).to.exist()
-            -- Non-spawnable domains are intentionally not stored in the tree
-            expect(tree.domain).to.equal(nil)
-        end)
-
-    end)
-
+	before(function()
+		mux.reset()
+		wezterm._test.reset()
+		-- Inject mux fake into wezterm
+		wezterm._test.set_mux(mux)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Pane Tree Creation Tests
+	---------------------------------------------------------------------------
+
+	describe("pane tree creation", function()
+		describe("single pane", function()
+			it("creates tree with correct geometry", function()
+				local workspace =
+					mux.workspace("test"):window("win"):tab("tab"):pane(fixtures.single_pane.panes[1]):build()
+
+				mux.set_active(workspace)
+
+				local tab = workspace.windows[1]:tabs()[1]
+				local panes_info = tab:panes_with_info()
+
+				local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+				expect(tree).to.exist()
+				expect(tree.cwd).to.equal("/home/user")
+				expect(tree.width).to.equal(160)
+				expect(tree.height).to.equal(48)
+				expect(tree.left).to.equal(0)
+				expect(tree.top).to.equal(0)
+			end)
+
+			it("has no children for single pane", function()
+				local workspace =
+					mux.workspace("test"):window("win"):tab("tab"):pane(fixtures.single_pane.panes[1]):build()
+
+				mux.set_active(workspace)
+
+				local tab = workspace.windows[1]:tabs()[1]
+				local panes_info = tab:panes_with_info()
+				local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+				expect(tree.right).to_not.exist()
+				expect(tree.bottom).to_not.exist()
+			end)
+		end)
+
+		describe("horizontal split", function()
+			it("captures right pane as child", function()
+				local workspace = mux.workspace("test")
+					:window("win")
+					:tab("tab")
+					:pane(fixtures.hsplit.panes[1])
+					:hsplit(fixtures.hsplit.panes[2])
+					:build()
+
+				mux.set_active(workspace)
+
+				local tab = workspace.windows[1]:tabs()[1]
+				local panes_info = tab:panes_with_info()
+				local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+				expect(tree.right).to.exist()
+				expect(tree.right.cwd).to.equal("/tmp")
+				expect(tree.bottom).to_not.exist()
+			end)
+
+			it("preserves left pane geometry", function()
+				local workspace = mux.workspace("test")
+					:window("win")
+					:tab("tab")
+					:pane(fixtures.hsplit.panes[1])
+					:hsplit(fixtures.hsplit.panes[2])
+					:build()
+
+				mux.set_active(workspace)
+
+				local tab = workspace.windows[1]:tabs()[1]
+				local panes_info = tab:panes_with_info()
+				local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+				expect(tree.left).to.equal(0)
+				expect(tree.width).to.equal(80)
+				expect(tree.cwd).to.equal("/home")
+			end)
+		end)
+
+		describe("vertical split", function()
+			it("captures bottom pane as child", function()
+				local workspace = mux.workspace("test")
+					:window("win")
+					:tab("tab")
+					:pane(fixtures.vsplit.panes[1])
+					:vsplit(fixtures.vsplit.panes[2])
+					:build()
+
+				mux.set_active(workspace)
+
+				local tab = workspace.windows[1]:tabs()[1]
+				local panes_info = tab:panes_with_info()
+				local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+				expect(tree.bottom).to.exist()
+				expect(tree.bottom.cwd).to.equal("/var/log")
+				expect(tree.right).to_not.exist()
+			end)
+
+			it("preserves top pane geometry", function()
+				local workspace = mux.workspace("test")
+					:window("win")
+					:tab("tab")
+					:pane(fixtures.vsplit.panes[1])
+					:vsplit(fixtures.vsplit.panes[2])
+					:build()
+
+				mux.set_active(workspace)
+
+				local tab = workspace.windows[1]:tabs()[1]
+				local panes_info = tab:panes_with_info()
+				local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+				expect(tree.top).to.equal(0)
+				expect(tree.height).to.equal(24)
+				expect(tree.cwd).to.equal("/home")
+			end)
+		end)
+
+		describe("IDE layout", function()
+			it("preserves nested structure", function()
+				local workspace = mux.workspace("test")
+					:window("win")
+					:tab("tab")
+					:pane(fixtures.ide_layout.panes[1])
+					:hsplit(fixtures.ide_layout.panes[2])
+					:vsplit(fixtures.ide_layout.panes[3])
+					:build()
+
+				mux.set_active(workspace)
+
+				local tab = workspace.windows[1]:tabs()[1]
+				local panes_info = tab:panes_with_info()
+				local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+				-- Root has right child (terminal column)
+				expect(tree.right).to.exist()
+				-- Terminal column has bottom child (output pane)
+				expect(tree.right.bottom).to.exist()
+			end)
+		end)
+
+		describe("three-way horizontal split", function()
+			it("captures nested right chain", function()
+				local workspace = mux.workspace("test")
+					:window("win")
+					:tab("tab")
+					:pane(fixtures.three_way_hsplit.panes[1])
+					:hsplit(fixtures.three_way_hsplit.panes[2])
+					:hsplit(fixtures.three_way_hsplit.panes[3])
+					:build()
+
+				mux.set_active(workspace)
+
+				local tab = workspace.windows[1]:tabs()[1]
+				local panes_info = tab:panes_with_info()
+				local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+				-- Left pane (/a) has right child (/b), which has right child (/c)
+				expect(tree.cwd).to.equal("/a")
+				expect(tree.right).to.exist()
+				expect(tree.right.cwd).to.equal("/b")
+				expect(tree.right.right).to.exist()
+				expect(tree.right.right.cwd).to.equal("/c")
+			end)
+
+			it("has no bottom splits", function()
+				local workspace = mux.workspace("test")
+					:window("win")
+					:tab("tab")
+					:pane(fixtures.three_way_hsplit.panes[1])
+					:hsplit(fixtures.three_way_hsplit.panes[2])
+					:hsplit(fixtures.three_way_hsplit.panes[3])
+					:build()
+
+				mux.set_active(workspace)
+
+				local tab = workspace.windows[1]:tabs()[1]
+				local panes_info = tab:panes_with_info()
+				local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+				expect(tree.bottom).to_not.exist()
+				expect(tree.right.bottom).to_not.exist()
+			end)
+		end)
+
+		describe("grid 2x2 layout", function()
+			it("captures four panes in grid structure", function()
+				local workspace = mux.workspace("test")
+					:window("win")
+					:tab("tab")
+					:pane(fixtures.grid_2x2.panes[1])
+					:hsplit(fixtures.grid_2x2.panes[2])
+					:vsplit(fixtures.grid_2x2.panes[3])
+					:vsplit(fixtures.grid_2x2.panes[4])
+					:build()
+
+				mux.set_active(workspace)
+
+				local tab = workspace.windows[1]:tabs()[1]
+				local panes_info = tab:panes_with_info()
+				local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+				-- Verify we have 4 panes total (root + 3 children in tree)
+				expect(tree).to.exist()
+				expect(tree.cwd).to.equal("/tl")
+			end)
+
+			it("preserves pane positions", function()
+				local workspace = mux.workspace("test")
+					:window("win")
+					:tab("tab")
+					:pane(fixtures.grid_2x2.panes[1])
+					:hsplit(fixtures.grid_2x2.panes[2])
+					:vsplit(fixtures.grid_2x2.panes[3])
+					:vsplit(fixtures.grid_2x2.panes[4])
+					:build()
+
+				mux.set_active(workspace)
+
+				local tab = workspace.windows[1]:tabs()[1]
+				local panes_info = tab:panes_with_info()
+				local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+				-- Top-left pane should be at origin
+				expect(tree.left).to.equal(0)
+				expect(tree.top).to.equal(0)
+			end)
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Tab State Tests
+	---------------------------------------------------------------------------
+
+	describe("tab state", function()
+		it("captures tab title", function()
+			local workspace =
+				mux.workspace("test"):window("win"):tab("My Custom Tab"):pane(fixtures.single_pane.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local tab_state = tab_state_mod.get_tab_state(tab)
+
+			expect(tab_state.title).to.equal("My Custom Tab")
+		end)
+
+		it("captures pane tree", function()
+			local workspace = mux.workspace("test"):window("win"):tab("tab"):pane(fixtures.single_pane.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local tab_state = tab_state_mod.get_tab_state(tab)
+
+			expect(tab_state.pane_tree).to.exist()
+			expect(tab_state.pane_tree.cwd).to.equal("/home/user")
+		end)
+
+		it("captures zoomed state", function()
+			local workspace = mux.workspace("test")
+				:window("win")
+				:tab("tab")
+				:pane(fixtures.zoomed_pane.panes[1])
+				:hsplit(fixtures.zoomed_pane.panes[2])
+				:build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local tab_state = tab_state_mod.get_tab_state(tab)
+
+			expect(tab_state.is_zoomed).to.equal(true)
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Window State Tests
+	---------------------------------------------------------------------------
+
+	describe("window state", function()
+		it("captures window title", function()
+			local workspace =
+				mux.workspace("test"):window("Main Window"):tab("tab"):pane(fixtures.single_pane.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local window = workspace.windows[1]
+			local window_state = window_state_mod.get_window_state(window)
+
+			expect(window_state.title).to.equal("Main Window")
+		end)
+
+		it("captures all tabs", function()
+			local workspace = mux.workspace("test")
+				:window("win")
+				:tab("Tab 1")
+				:pane(fixtures.single_pane.panes[1])
+				:tab("Tab 2")
+				:pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/other" })
+				:build()
+
+			mux.set_active(workspace)
+
+			local window = workspace.windows[1]
+			local window_state = window_state_mod.get_window_state(window)
+
+			expect(#window_state.tabs).to.equal(2)
+			expect(window_state.tabs[1].title).to.equal("Tab 1")
+			expect(window_state.tabs[2].title).to.equal("Tab 2")
+		end)
+
+		it("captures window size", function()
+			local workspace = mux.workspace("test"):window("win"):tab("tab"):pane(fixtures.single_pane.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local window = workspace.windows[1]
+			local window_state = window_state_mod.get_window_state(window)
+
+			expect(window_state.size).to.exist()
+			expect(window_state.size.cols).to.be.a("number")
+			expect(window_state.size.rows).to.be.a("number")
+		end)
+
+		it("marks active tab", function()
+			local workspace = mux.workspace("test")
+				:window("win")
+				:tab("Tab 1")
+				:pane(fixtures.single_pane.panes[1])
+				:tab("Tab 2")
+				:pane({
+					left = 0,
+					top = 0,
+					width = 160,
+					height = 48,
+					cwd = "/other",
+					is_active = true,
+				})
+				:build()
+
+			mux.set_active(workspace)
+
+			local window = workspace.windows[1]
+			local window_state = window_state_mod.get_window_state(window)
+
+			-- At least one tab should be marked active
+			local has_active = false
+			for _, tab in ipairs(window_state.tabs) do
+				if tab.is_active then
+					has_active = true
+					break
+				end
+			end
+			expect(has_active).to.equal(true)
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Workspace State Tests
+	---------------------------------------------------------------------------
+
+	describe("workspace state", function()
+		it("captures workspace name", function()
+			local workspace =
+				mux.workspace("my-project"):window("win"):tab("tab"):pane(fixtures.single_pane.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local state = workspace_state_mod.get_workspace_state()
+
+			expect(state.workspace).to.equal("my-project")
+		end)
+
+		it("captures all windows in workspace", function()
+			local workspace = mux.workspace("test")
+				:window("Window 1")
+				:tab("tab")
+				:pane(fixtures.single_pane.panes[1])
+				:window("Window 2")
+				:tab("tab")
+				:pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/other" })
+				:build()
+
+			mux.set_active(workspace)
+
+			local state = workspace_state_mod.get_workspace_state()
+
+			expect(#state.window_states).to.equal(2)
+		end)
+
+		it("only captures windows from active workspace", function()
+			-- Create first workspace
+			local workspace1 =
+				mux.workspace("workspace1"):window("Win1"):tab("tab"):pane(fixtures.single_pane.panes[1]):build()
+
+			mux.set_active(workspace1)
+
+			-- Create second workspace (different name means different workspace)
+			local workspace2 = mux.workspace("workspace2")
+				:window("Win2")
+				:tab("tab")
+				:pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/other" })
+				:build()
+
+			-- Don't set workspace2 as active, just add windows
+			for _, win in ipairs(workspace2.windows) do
+				table.insert(mux.all_windows(), win)
+			end
+
+			local state = workspace_state_mod.get_workspace_state()
+
+			-- Should only have windows from workspace1
+			expect(state.workspace).to.equal("workspace1")
+			for _, win_state in ipairs(state.window_states) do
+				-- All windows should be from workspace1
+				expect(win_state).to.exist()
+			end
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Scrollback Capture Tests
+	---------------------------------------------------------------------------
+
+	describe("scrollback capture", function()
+		it("captures terminal content", function()
+			local workspace =
+				mux.workspace("test"):window("win"):tab("tab"):pane(fixtures.with_scrollback.panes[1]):build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local panes_info = tab:panes_with_info()
+			local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+			expect(tree.text).to.exist()
+			expect(tree.text).to.match("file1.txt")
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Domain Capture Tests
+	---------------------------------------------------------------------------
+
+	describe("domain capture", function()
+		it("captures domain name", function()
+			local workspace = mux.workspace("test")
+				:window("win")
+				:tab("tab")
+				:pane({
+					left = 0,
+					top = 0,
+					width = 160,
+					height = 48,
+					cwd = "/home",
+					domain = "local",
+					is_active = true,
+				})
+				:build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local panes_info = tab:panes_with_info()
+			local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+			expect(tree.domain).to.equal("local")
+		end)
+
+		it("warns for non-spawnable domains", function()
+			mux.set_domain_spawnable("SSH:dead", false)
+
+			local workspace = mux.workspace("test")
+				:window("win")
+				:tab("tab")
+				:pane({
+					left = 0,
+					top = 0,
+					width = 160,
+					height = 48,
+					cwd = "/remote",
+					domain = "SSH:dead",
+					is_active = true,
+				})
+				:build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local panes_info = tab:panes_with_info()
+
+			-- Clear logs before test
+			wezterm._test.clear_logs()
+
+			local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+			-- Should have logged a warning
+			local logs = wezterm._test.get_logs()
+			local found_warning = false
+			for _, log in ipairs(logs) do
+				if log.level == "warn" and log.message:match("SSH:dead") then
+					found_warning = true
+					break
+				end
+			end
+			expect(found_warning).to.equal(true)
+		end)
+
+		it("continues processing after non-spawnable domain", function()
+			mux.set_domain_spawnable("SSH:remote", false)
+
+			local workspace = mux.workspace("test")
+				:window("win")
+				:tab("tab")
+				:pane({
+					left = 0,
+					top = 0,
+					width = 160,
+					height = 48,
+					cwd = "/home",
+					domain = "SSH:remote",
+					is_active = true,
+				})
+				:build()
+
+			mux.set_active(workspace)
+
+			local tab = workspace.windows[1]:tabs()[1]
+			local panes_info = tab:panes_with_info()
+
+			-- Should not crash - pane tree is created but domain is not stored (correct behavior)
+			local tree = pane_tree_mod.create_pane_tree(panes_info)
+			expect(tree).to.exist()
+			-- Non-spawnable domains are intentionally not stored in the tree
+			expect(tree.domain).to.equal(nil)
+		end)
+	end)
 end)

--- a/plugin/resurrect/test/spec/capture_spec.lua
+++ b/plugin/resurrect/test/spec/capture_spec.lua
@@ -539,6 +539,27 @@ describe("State Capture", function()
             expect(found_warning).to.equal(true)
         end)
 
+        it("continues processing after non-spawnable domain", function()
+            mux.set_domain_spawnable("SSH:remote", false)
+
+            local workspace = mux.workspace("test")
+                :window("win")
+                    :tab("tab")
+                        :pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/home", domain = "SSH:remote", is_active = true })
+                :build()
+
+            mux.set_active(workspace)
+
+            local tab = workspace.windows[1]:tabs()[1]
+            local panes_info = tab:panes_with_info()
+
+            -- Should not crash - pane tree is created but domain is not stored (correct behavior)
+            local tree = pane_tree_mod.create_pane_tree(panes_info)
+            expect(tree).to.exist()
+            -- Non-spawnable domains are intentionally not stored in the tree
+            expect(tree.domain).to.equal(nil)
+        end)
+
     end)
 
 end)

--- a/plugin/resurrect/test/spec/capture_spec.lua
+++ b/plugin/resurrect/test/spec/capture_spec.lua
@@ -173,6 +173,94 @@ describe("State Capture", function()
             end)
         end)
 
+        describe("three-way horizontal split", function()
+            it("captures nested right chain", function()
+                local workspace = mux.workspace("test")
+                    :window("win")
+                        :tab("tab")
+                            :pane(fixtures.three_way_hsplit.panes[1])
+                            :hsplit(fixtures.three_way_hsplit.panes[2])
+                            :hsplit(fixtures.three_way_hsplit.panes[3])
+                    :build()
+
+                mux.set_active(workspace)
+
+                local tab = workspace.windows[1]:tabs()[1]
+                local panes_info = tab:panes_with_info()
+                local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+                -- Left pane (/a) has right child (/b), which has right child (/c)
+                expect(tree.cwd).to.equal("/a")
+                expect(tree.right).to.exist()
+                expect(tree.right.cwd).to.equal("/b")
+                expect(tree.right.right).to.exist()
+                expect(tree.right.right.cwd).to.equal("/c")
+            end)
+
+            it("has no bottom splits", function()
+                local workspace = mux.workspace("test")
+                    :window("win")
+                        :tab("tab")
+                            :pane(fixtures.three_way_hsplit.panes[1])
+                            :hsplit(fixtures.three_way_hsplit.panes[2])
+                            :hsplit(fixtures.three_way_hsplit.panes[3])
+                    :build()
+
+                mux.set_active(workspace)
+
+                local tab = workspace.windows[1]:tabs()[1]
+                local panes_info = tab:panes_with_info()
+                local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+                expect(tree.bottom).to_not.exist()
+                expect(tree.right.bottom).to_not.exist()
+            end)
+        end)
+
+        describe("grid 2x2 layout", function()
+            it("captures four panes in grid structure", function()
+                local workspace = mux.workspace("test")
+                    :window("win")
+                        :tab("tab")
+                            :pane(fixtures.grid_2x2.panes[1])
+                            :hsplit(fixtures.grid_2x2.panes[2])
+                            :vsplit(fixtures.grid_2x2.panes[3])
+                            :vsplit(fixtures.grid_2x2.panes[4])
+                    :build()
+
+                mux.set_active(workspace)
+
+                local tab = workspace.windows[1]:tabs()[1]
+                local panes_info = tab:panes_with_info()
+                local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+                -- Verify we have 4 panes total (root + 3 children in tree)
+                expect(tree).to.exist()
+                expect(tree.cwd).to.equal("/tl")
+            end)
+
+            it("preserves pane positions", function()
+                local workspace = mux.workspace("test")
+                    :window("win")
+                        :tab("tab")
+                            :pane(fixtures.grid_2x2.panes[1])
+                            :hsplit(fixtures.grid_2x2.panes[2])
+                            :vsplit(fixtures.grid_2x2.panes[3])
+                            :vsplit(fixtures.grid_2x2.panes[4])
+                    :build()
+
+                mux.set_active(workspace)
+
+                local tab = workspace.windows[1]:tabs()[1]
+                local panes_info = tab:panes_with_info()
+                local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+                -- Top-left pane should be at origin
+                expect(tree.left).to.equal(0)
+                expect(tree.top).to.equal(0)
+            end)
+        end)
+
     end)
 
     ---------------------------------------------------------------------------

--- a/plugin/resurrect/test/spec/capture_spec.lua
+++ b/plugin/resurrect/test/spec/capture_spec.lua
@@ -1,0 +1,456 @@
+-- Tests for state capture functionality
+-- Verifies that workspace/window/tab/pane state is correctly captured
+
+local mux = require("mux")
+local fixtures = require("pane_layouts")
+
+-- Import modules under test
+local pane_tree_mod = require("resurrect.pane_tree")
+local tab_state_mod = require("resurrect.tab_state")
+local window_state_mod = require("resurrect.window_state")
+local workspace_state_mod = require("resurrect.workspace_state")
+
+--------------------------------------------------------------------------------
+-- Setup / Teardown
+--------------------------------------------------------------------------------
+
+describe("State Capture", function()
+
+    before(function()
+        mux.reset()
+        wezterm._test.reset()
+        -- Inject mux fake into wezterm
+        wezterm._test.set_mux(mux)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Pane Tree Creation Tests
+    ---------------------------------------------------------------------------
+
+    describe("pane tree creation", function()
+
+        describe("single pane", function()
+            it("creates tree with correct geometry", function()
+                local workspace = mux.workspace("test")
+                    :window("win")
+                        :tab("tab")
+                            :pane(fixtures.single_pane.panes[1])
+                    :build()
+
+                mux.set_active(workspace)
+
+                local tab = workspace.windows[1]:tabs()[1]
+                local panes_info = tab:panes_with_info()
+
+                local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+                expect(tree).to.exist()
+                expect(tree.cwd).to.equal("/home/user")
+                expect(tree.width).to.equal(160)
+                expect(tree.height).to.equal(48)
+                expect(tree.left).to.equal(0)
+                expect(tree.top).to.equal(0)
+            end)
+
+            it("has no children for single pane", function()
+                local workspace = mux.workspace("test")
+                    :window("win")
+                        :tab("tab")
+                            :pane(fixtures.single_pane.panes[1])
+                    :build()
+
+                mux.set_active(workspace)
+
+                local tab = workspace.windows[1]:tabs()[1]
+                local panes_info = tab:panes_with_info()
+                local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+                expect(tree.right).to_not.exist()
+                expect(tree.bottom).to_not.exist()
+            end)
+        end)
+
+        describe("horizontal split", function()
+            it("captures right pane as child", function()
+                local workspace = mux.workspace("test")
+                    :window("win")
+                        :tab("tab")
+                            :pane(fixtures.hsplit.panes[1])
+                            :hsplit(fixtures.hsplit.panes[2])
+                    :build()
+
+                mux.set_active(workspace)
+
+                local tab = workspace.windows[1]:tabs()[1]
+                local panes_info = tab:panes_with_info()
+                local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+                expect(tree.right).to.exist()
+                expect(tree.right.cwd).to.equal("/tmp")
+                expect(tree.bottom).to_not.exist()
+            end)
+
+            it("preserves left pane geometry", function()
+                local workspace = mux.workspace("test")
+                    :window("win")
+                        :tab("tab")
+                            :pane(fixtures.hsplit.panes[1])
+                            :hsplit(fixtures.hsplit.panes[2])
+                    :build()
+
+                mux.set_active(workspace)
+
+                local tab = workspace.windows[1]:tabs()[1]
+                local panes_info = tab:panes_with_info()
+                local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+                expect(tree.left).to.equal(0)
+                expect(tree.width).to.equal(80)
+                expect(tree.cwd).to.equal("/home")
+            end)
+        end)
+
+        describe("vertical split", function()
+            it("captures bottom pane as child", function()
+                local workspace = mux.workspace("test")
+                    :window("win")
+                        :tab("tab")
+                            :pane(fixtures.vsplit.panes[1])
+                            :vsplit(fixtures.vsplit.panes[2])
+                    :build()
+
+                mux.set_active(workspace)
+
+                local tab = workspace.windows[1]:tabs()[1]
+                local panes_info = tab:panes_with_info()
+                local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+                expect(tree.bottom).to.exist()
+                expect(tree.bottom.cwd).to.equal("/var/log")
+                expect(tree.right).to_not.exist()
+            end)
+
+            it("preserves top pane geometry", function()
+                local workspace = mux.workspace("test")
+                    :window("win")
+                        :tab("tab")
+                            :pane(fixtures.vsplit.panes[1])
+                            :vsplit(fixtures.vsplit.panes[2])
+                    :build()
+
+                mux.set_active(workspace)
+
+                local tab = workspace.windows[1]:tabs()[1]
+                local panes_info = tab:panes_with_info()
+                local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+                expect(tree.top).to.equal(0)
+                expect(tree.height).to.equal(24)
+                expect(tree.cwd).to.equal("/home")
+            end)
+        end)
+
+        describe("IDE layout", function()
+            it("preserves nested structure", function()
+                local workspace = mux.workspace("test")
+                    :window("win")
+                        :tab("tab")
+                            :pane(fixtures.ide_layout.panes[1])
+                            :hsplit(fixtures.ide_layout.panes[2])
+                            :vsplit(fixtures.ide_layout.panes[3])
+                    :build()
+
+                mux.set_active(workspace)
+
+                local tab = workspace.windows[1]:tabs()[1]
+                local panes_info = tab:panes_with_info()
+                local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+                -- Root has right child (terminal column)
+                expect(tree.right).to.exist()
+                -- Terminal column has bottom child (output pane)
+                expect(tree.right.bottom).to.exist()
+            end)
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Tab State Tests
+    ---------------------------------------------------------------------------
+
+    describe("tab state", function()
+
+        it("captures tab title", function()
+            local workspace = mux.workspace("test")
+                :window("win")
+                    :tab("My Custom Tab")
+                        :pane(fixtures.single_pane.panes[1])
+                :build()
+
+            mux.set_active(workspace)
+
+            local tab = workspace.windows[1]:tabs()[1]
+            local tab_state = tab_state_mod.get_tab_state(tab)
+
+            expect(tab_state.title).to.equal("My Custom Tab")
+        end)
+
+        it("captures pane tree", function()
+            local workspace = mux.workspace("test")
+                :window("win")
+                    :tab("tab")
+                        :pane(fixtures.single_pane.panes[1])
+                :build()
+
+            mux.set_active(workspace)
+
+            local tab = workspace.windows[1]:tabs()[1]
+            local tab_state = tab_state_mod.get_tab_state(tab)
+
+            expect(tab_state.pane_tree).to.exist()
+            expect(tab_state.pane_tree.cwd).to.equal("/home/user")
+        end)
+
+        it("captures zoomed state", function()
+            local workspace = mux.workspace("test")
+                :window("win")
+                    :tab("tab")
+                        :pane(fixtures.zoomed_pane.panes[1])
+                        :hsplit(fixtures.zoomed_pane.panes[2])
+                :build()
+
+            mux.set_active(workspace)
+
+            local tab = workspace.windows[1]:tabs()[1]
+            local tab_state = tab_state_mod.get_tab_state(tab)
+
+            expect(tab_state.is_zoomed).to.equal(true)
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Window State Tests
+    ---------------------------------------------------------------------------
+
+    describe("window state", function()
+
+        it("captures window title", function()
+            local workspace = mux.workspace("test")
+                :window("Main Window")
+                    :tab("tab")
+                        :pane(fixtures.single_pane.panes[1])
+                :build()
+
+            mux.set_active(workspace)
+
+            local window = workspace.windows[1]
+            local window_state = window_state_mod.get_window_state(window)
+
+            expect(window_state.title).to.equal("Main Window")
+        end)
+
+        it("captures all tabs", function()
+            local workspace = mux.workspace("test")
+                :window("win")
+                    :tab("Tab 1"):pane(fixtures.single_pane.panes[1])
+                    :tab("Tab 2"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/other" })
+                :build()
+
+            mux.set_active(workspace)
+
+            local window = workspace.windows[1]
+            local window_state = window_state_mod.get_window_state(window)
+
+            expect(#window_state.tabs).to.equal(2)
+            expect(window_state.tabs[1].title).to.equal("Tab 1")
+            expect(window_state.tabs[2].title).to.equal("Tab 2")
+        end)
+
+        it("captures window size", function()
+            local workspace = mux.workspace("test")
+                :window("win")
+                    :tab("tab")
+                        :pane(fixtures.single_pane.panes[1])
+                :build()
+
+            mux.set_active(workspace)
+
+            local window = workspace.windows[1]
+            local window_state = window_state_mod.get_window_state(window)
+
+            expect(window_state.size).to.exist()
+            expect(window_state.size.cols).to.be.a("number")
+            expect(window_state.size.rows).to.be.a("number")
+        end)
+
+        it("marks active tab", function()
+            local workspace = mux.workspace("test")
+                :window("win")
+                    :tab("Tab 1"):pane(fixtures.single_pane.panes[1])
+                    :tab("Tab 2"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/other", is_active = true })
+                :build()
+
+            mux.set_active(workspace)
+
+            local window = workspace.windows[1]
+            local window_state = window_state_mod.get_window_state(window)
+
+            -- At least one tab should be marked active
+            local has_active = false
+            for _, tab in ipairs(window_state.tabs) do
+                if tab.is_active then
+                    has_active = true
+                    break
+                end
+            end
+            expect(has_active).to.equal(true)
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Workspace State Tests
+    ---------------------------------------------------------------------------
+
+    describe("workspace state", function()
+
+        it("captures workspace name", function()
+            local workspace = mux.workspace("my-project")
+                :window("win")
+                    :tab("tab")
+                        :pane(fixtures.single_pane.panes[1])
+                :build()
+
+            mux.set_active(workspace)
+
+            local state = workspace_state_mod.get_workspace_state()
+
+            expect(state.workspace).to.equal("my-project")
+        end)
+
+        it("captures all windows in workspace", function()
+            local workspace = mux.workspace("test")
+                :window("Window 1"):tab("tab"):pane(fixtures.single_pane.panes[1])
+                :window("Window 2"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/other" })
+                :build()
+
+            mux.set_active(workspace)
+
+            local state = workspace_state_mod.get_workspace_state()
+
+            expect(#state.window_states).to.equal(2)
+        end)
+
+        it("only captures windows from active workspace", function()
+            -- Create first workspace
+            local workspace1 = mux.workspace("workspace1")
+                :window("Win1"):tab("tab"):pane(fixtures.single_pane.panes[1])
+                :build()
+
+            mux.set_active(workspace1)
+
+            -- Create second workspace (different name means different workspace)
+            local workspace2 = mux.workspace("workspace2")
+                :window("Win2"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/other" })
+                :build()
+
+            -- Don't set workspace2 as active, just add windows
+            for _, win in ipairs(workspace2.windows) do
+                table.insert(mux.all_windows(), win)
+            end
+
+            local state = workspace_state_mod.get_workspace_state()
+
+            -- Should only have windows from workspace1
+            expect(state.workspace).to.equal("workspace1")
+            for _, win_state in ipairs(state.window_states) do
+                -- All windows should be from workspace1
+                expect(win_state).to.exist()
+            end
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Scrollback Capture Tests
+    ---------------------------------------------------------------------------
+
+    describe("scrollback capture", function()
+
+        it("captures terminal content", function()
+            local workspace = mux.workspace("test")
+                :window("win")
+                    :tab("tab")
+                        :pane(fixtures.with_scrollback.panes[1])
+                :build()
+
+            mux.set_active(workspace)
+
+            local tab = workspace.windows[1]:tabs()[1]
+            local panes_info = tab:panes_with_info()
+            local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+            expect(tree.text).to.exist()
+            expect(tree.text).to.match("file1.txt")
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Domain Capture Tests
+    ---------------------------------------------------------------------------
+
+    describe("domain capture", function()
+
+        it("captures domain name", function()
+            local workspace = mux.workspace("test")
+                :window("win")
+                    :tab("tab")
+                        :pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/home", domain = "local", is_active = true })
+                :build()
+
+            mux.set_active(workspace)
+
+            local tab = workspace.windows[1]:tabs()[1]
+            local panes_info = tab:panes_with_info()
+            local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+            expect(tree.domain).to.equal("local")
+        end)
+
+        it("warns for non-spawnable domains", function()
+            mux.set_domain_spawnable("SSH:dead", false)
+
+            local workspace = mux.workspace("test")
+                :window("win")
+                    :tab("tab")
+                        :pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/remote", domain = "SSH:dead", is_active = true })
+                :build()
+
+            mux.set_active(workspace)
+
+            local tab = workspace.windows[1]:tabs()[1]
+            local panes_info = tab:panes_with_info()
+
+            -- Clear logs before test
+            wezterm._test.clear_logs()
+
+            local tree = pane_tree_mod.create_pane_tree(panes_info)
+
+            -- Should have logged a warning
+            local logs = wezterm._test.get_logs()
+            local found_warning = false
+            for _, log in ipairs(logs) do
+                if log.level == "warn" and log.message:match("SSH:dead") then
+                    found_warning = true
+                    break
+                end
+            end
+            expect(found_warning).to.equal(true)
+        end)
+
+    end)
+
+end)

--- a/plugin/resurrect/test/spec/events_spec.lua
+++ b/plugin/resurrect/test/spec/events_spec.lua
@@ -1,0 +1,483 @@
+-- Tests for events and integration (Critical User Journeys)
+-- Verifies event emission and end-to-end save/restore flows
+
+local mux = require("mux")
+local fixtures = require("pane_layouts")
+local fs = require("fs")
+
+-- Import modules under test
+local state_manager = require("resurrect.state_manager")
+local workspace_state_mod = require("resurrect.workspace_state")
+local tab_state_mod = require("resurrect.tab_state")
+
+--------------------------------------------------------------------------------
+-- Helper: Find event by name
+--------------------------------------------------------------------------------
+
+local function find_event(events, name)
+    for _, event in ipairs(events) do
+        if event.name == name then return event end
+    end
+    return nil
+end
+
+local function has_event(events, name)
+    return find_event(events, name) ~= nil
+end
+
+--------------------------------------------------------------------------------
+-- Setup / Teardown
+--------------------------------------------------------------------------------
+
+describe("Events & Integration", function()
+
+    before(function()
+        mux.reset()
+        wezterm._test.reset()
+        wezterm._test.set_mux(mux)
+        local test_root = fs.setup() .. "/"
+        state_manager.change_state_save_dir(test_root)
+    end)
+
+    after(function()
+        fs.teardown()
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Event Emission Tests
+    ---------------------------------------------------------------------------
+
+    describe("event emission", function()
+
+        describe("save events", function()
+
+            it("emits start and finished events with file path", function()
+                local workspace = mux.workspace("save-event-test")
+                    :window("main"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/home", is_active = true })
+                    :build()
+                mux.set_active(workspace)
+
+                wezterm._test.clear_emitted_events()
+                local state = workspace_state_mod.get_workspace_state()
+                state_manager.save_state(state)
+
+                local events = wezterm._test.get_emitted_events()
+                expect(has_event(events, "resurrect.file_io.write_state.start")).to.equal(true)
+                expect(has_event(events, "resurrect.file_io.write_state.finished")).to.equal(true)
+
+                local start_event = find_event(events, "resurrect.file_io.write_state.start")
+                expect(start_event).to.exist()
+                expect(start_event.args[1]).to.match("save%-event%-test")
+            end)
+
+        end)
+
+        describe("load events", function()
+
+            it("emits start and finished events with name and type", function()
+                fs.mkdir(fs.get_root() .. "/workspace")
+                fs.write(fs.get_root() .. "/workspace/load-event-test.json", '{"workspace":"load-event-test","window_states":[]}')
+
+                wezterm._test.clear_emitted_events()
+                state_manager.load_state("load-event-test", "workspace")
+
+                local events = wezterm._test.get_emitted_events()
+                expect(has_event(events, "resurrect.state_manager.load_state.start")).to.equal(true)
+                expect(has_event(events, "resurrect.state_manager.load_state.finished")).to.equal(true)
+
+                local start_event = find_event(events, "resurrect.state_manager.load_state.start")
+                expect(start_event).to.exist()
+                expect(start_event.args[1]).to.equal("load-event-test")
+                expect(start_event.args[2]).to.equal("workspace")
+            end)
+
+        end)
+
+        describe("restore events", function()
+
+            it("emits workspace, window, and tab restore events", function()
+                wezterm._test.clear_emitted_events()
+                local state = fixtures.to_workspace_state(fixtures.single_pane)
+                workspace_state_mod.restore_workspace(state, {})
+
+                local events = wezterm._test.get_emitted_events()
+                expect(has_event(events, "resurrect.workspace_state.restore_workspace.start")).to.equal(true)
+                expect(has_event(events, "resurrect.workspace_state.restore_workspace.finished")).to.equal(true)
+                expect(has_event(events, "resurrect.window_state.restore_window.start")).to.equal(true)
+                expect(has_event(events, "resurrect.tab_state.restore_tab.start")).to.equal(true)
+            end)
+
+        end)
+
+        describe("error events", function()
+
+            it("emits resurrect.error for invalid JSON", function()
+                fs.mkdir(fs.get_root() .. "/workspace")
+                fs.write(fs.get_root() .. "/workspace/bad-json.json", "not valid json {{{")
+
+                wezterm._test.clear_emitted_events()
+                state_manager.load_state("bad-json", "workspace")
+
+                local events = wezterm._test.get_emitted_events()
+                expect(has_event(events, "resurrect.error")).to.equal(true)
+            end)
+
+            it("emits resurrect.error with descriptive message for nil workspace state", function()
+                wezterm._test.clear_emitted_events()
+                workspace_state_mod.restore_workspace(nil, {})
+
+                local events = wezterm._test.get_emitted_events()
+                expect(has_event(events, "resurrect.error")).to.equal(true)
+
+                local error_event = find_event(events, "resurrect.error")
+                expect(error_event).to.exist()
+                expect(error_event.args[1]).to.match("empty")
+            end)
+
+            it("emits resurrect.error for empty window_states", function()
+                wezterm._test.clear_emitted_events()
+                workspace_state_mod.restore_workspace({ workspace = "empty", window_states = {} }, {})
+
+                local events = wezterm._test.get_emitted_events()
+                expect(has_event(events, "resurrect.error")).to.equal(true)
+            end)
+
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- CUJ-Level Integration Tests
+    ---------------------------------------------------------------------------
+
+    describe("integration", function()
+
+        describe("save and restore single window", function()
+
+            it("round-trips workspace state through file system", function()
+                local workspace = mux.workspace("cuj-single")
+                    :window("main"):tab("dev"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/project", is_active = true })
+                    :build()
+                mux.set_active(workspace)
+
+                -- Capture and save
+                local original = workspace_state_mod.get_workspace_state()
+                state_manager.save_state(original)
+
+                -- Verify file exists
+                local file_path = fs.get_root() .. "/workspace/cuj-single.json"
+                expect(fs.exists(file_path)).to.equal(true)
+
+                -- Load back
+                local loaded = state_manager.load_state("cuj-single", "workspace")
+
+                expect(loaded.workspace).to.equal("cuj-single")
+                expect(#loaded.window_states).to.equal(1)
+                expect(loaded.window_states[1].tabs[1].pane_tree.cwd).to.equal("/project")
+            end)
+
+            it("restores loaded state to mux", function()
+                -- Create and save
+                local workspace = mux.workspace("cuj-restore")
+                    :window("win"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/src", is_active = true })
+                    :build()
+                mux.set_active(workspace)
+
+                local original = workspace_state_mod.get_workspace_state()
+                state_manager.save_state(original)
+
+                -- Reset mux to simulate fresh start
+                mux.reset()
+                wezterm._test.set_mux(mux)
+
+                -- Load and restore
+                local loaded = state_manager.load_state("cuj-restore", "workspace")
+                workspace_state_mod.restore_workspace(loaded, { spawn_in_workspace = true })
+
+                -- Verify restoration
+                local windows = mux.all_windows()
+                expect(#windows >= 1).to.equal(true)
+            end)
+
+        end)
+
+        describe("preserve terminal content", function()
+
+            it("saves and restores scrollback text", function()
+                local workspace = mux.workspace("cuj-scrollback")
+                    :window("win"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/home", text = "$ ls\nfile1.txt\nfile2.txt\n$ ", is_active = true })
+                    :build()
+                mux.set_active(workspace)
+
+                -- Capture and save
+                local original = workspace_state_mod.get_workspace_state()
+                state_manager.save_state(original)
+
+                -- Load back
+                local loaded = state_manager.load_state("cuj-scrollback", "workspace")
+
+                expect(loaded.window_states[1].tabs[1].pane_tree.text).to.exist()
+                expect(loaded.window_states[1].tabs[1].pane_tree.text).to.match("file1.txt")
+            end)
+
+            it("injects text on restore via on_pane_restore", function()
+                local fake_pane = {
+                    injected_text = nil,
+                    inject_output = function(self, text) self.injected_text = text end,
+                    send_text = function() end,
+                }
+                local pane_tree = { pane = fake_pane, text = "$ whoami\nuser\n$ ", alt_screen_active = false }
+
+                tab_state_mod.default_on_pane_restore(pane_tree)
+
+                expect(fake_pane.injected_text).to.exist()
+                expect(fake_pane.injected_text).to.match("whoami")
+            end)
+
+        end)
+
+        describe("handle multiple tabs", function()
+
+            it("saves workspace with multiple tabs", function()
+                local workspace = mux.workspace("cuj-multi-tabs")
+                    :window("win")
+                        :tab("Tab 1"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/a", is_active = true })
+                        :tab("Tab 2"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/b", is_active = true })
+                        :tab("Tab 3"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/c", is_active = true })
+                    :build()
+                mux.set_active(workspace)
+
+                local original = workspace_state_mod.get_workspace_state()
+                state_manager.save_state(original)
+
+                local loaded = state_manager.load_state("cuj-multi-tabs", "workspace")
+
+                expect(#loaded.window_states[1].tabs).to.equal(3)
+                expect(loaded.window_states[1].tabs[1].title).to.equal("Tab 1")
+                expect(loaded.window_states[1].tabs[2].title).to.equal("Tab 2")
+                expect(loaded.window_states[1].tabs[3].title).to.equal("Tab 3")
+            end)
+
+            it("preserves tab cwds through round-trip", function()
+                local workspace = mux.workspace("cuj-tabs-cwd")
+                    :window("win")
+                        :tab("src"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/project/src", is_active = true })
+                        :tab("test"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/project/test", is_active = true })
+                    :build()
+                mux.set_active(workspace)
+
+                local original = workspace_state_mod.get_workspace_state()
+                state_manager.save_state(original)
+                local loaded = state_manager.load_state("cuj-tabs-cwd", "workspace")
+
+                expect(loaded.window_states[1].tabs[1].pane_tree.cwd).to.equal("/project/src")
+                expect(loaded.window_states[1].tabs[2].pane_tree.cwd).to.equal("/project/test")
+            end)
+
+            it("restores multiple tabs to mux", function()
+                local state = {
+                    workspace = "multi-tab-restore",
+                    window_states = {{
+                        title = "win",
+                        tabs = {
+                            { title = "Tab A", is_active = true, pane_tree = { cwd = "/a", width = 160, height = 48, left = 0, top = 0, is_active = true } },
+                            { title = "Tab B", pane_tree = { cwd = "/b", width = 160, height = 48, left = 0, top = 0, is_active = true } },
+                            { title = "Tab C", pane_tree = { cwd = "/c", width = 160, height = 48, left = 0, top = 0, is_active = true } },
+                        },
+                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+                    }},
+                }
+
+                workspace_state_mod.restore_workspace(state, {})
+
+                local windows = mux.all_windows()
+                expect(#windows >= 1).to.equal(true)
+            end)
+
+        end)
+
+        describe("complex layout round-trip", function()
+
+            it("preserves IDE layout structure", function()
+                local workspace = mux.workspace("cuj-ide")
+                    :window("IDE")
+                        :tab("dev")
+                            :pane(fixtures.ide_layout.panes[1])
+                            :hsplit(fixtures.ide_layout.panes[2])
+                            :vsplit(fixtures.ide_layout.panes[3])
+                    :build()
+                mux.set_active(workspace)
+
+                local original = workspace_state_mod.get_workspace_state()
+                state_manager.save_state(original)
+
+                local loaded = state_manager.load_state("cuj-ide", "workspace")
+
+                -- Verify nested structure
+                local tree = loaded.window_states[1].tabs[1].pane_tree
+                expect(tree).to.exist()
+                expect(tree.right).to.exist()
+                expect(tree.right.bottom).to.exist()
+            end)
+
+            it("preserves three-way horizontal split", function()
+                local workspace = mux.workspace("cuj-3way")
+                    :window("win")
+                        :tab("tab")
+                            :pane(fixtures.three_way_hsplit.panes[1])
+                            :hsplit(fixtures.three_way_hsplit.panes[2])
+                            :hsplit(fixtures.three_way_hsplit.panes[3])
+                    :build()
+                mux.set_active(workspace)
+
+                local original = workspace_state_mod.get_workspace_state()
+                state_manager.save_state(original)
+
+                local loaded = state_manager.load_state("cuj-3way", "workspace")
+
+                local tree = loaded.window_states[1].tabs[1].pane_tree
+                expect(tree.cwd).to.equal("/a")
+                expect(tree.right).to.exist()
+                expect(tree.right.cwd).to.equal("/b")
+                expect(tree.right.right).to.exist()
+                expect(tree.right.right.cwd).to.equal("/c")
+            end)
+
+            it("preserves 2x2 grid layout", function()
+                local workspace = mux.workspace("cuj-grid")
+                    :window("win")
+                        :tab("tab")
+                            :pane(fixtures.grid_2x2.panes[1])
+                            :hsplit(fixtures.grid_2x2.panes[2])
+                            :vsplit(fixtures.grid_2x2.panes[3])
+                            :vsplit(fixtures.grid_2x2.panes[4])
+                    :build()
+                mux.set_active(workspace)
+
+                local original = workspace_state_mod.get_workspace_state()
+                state_manager.save_state(original)
+
+                local loaded = state_manager.load_state("cuj-grid", "workspace")
+
+                local tree = loaded.window_states[1].tabs[1].pane_tree
+                expect(tree.cwd).to.equal("/tl")
+            end)
+
+            it("restores complex layout to mux", function()
+                local state = {
+                    workspace = "complex-restore",
+                    window_states = {{
+                        title = "win",
+                        tabs = {{
+                            title = "tab", is_active = true,
+                            pane_tree = {
+                                cwd = "/editor", width = 100, height = 48, left = 0, top = 0, is_active = true,
+                                right = {
+                                    cwd = "/term", width = 60, height = 24, left = 101, top = 0,
+                                    bottom = { cwd = "/output", width = 60, height = 24, left = 101, top = 25 },
+                                },
+                            },
+                        }},
+                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+                    }},
+                }
+
+                workspace_state_mod.restore_workspace(state, {})
+
+                local windows = mux.all_windows()
+                expect(#windows >= 1).to.equal(true)
+            end)
+
+        end)
+
+        describe("multiple windows", function()
+
+            it("saves and restores multiple windows", function()
+                local workspace = mux.workspace("cuj-multi-win")
+                    :window("Window 1"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/win1", is_active = true })
+                    :window("Window 2"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/win2", is_active = true })
+                    :build()
+                mux.set_active(workspace)
+
+                local original = workspace_state_mod.get_workspace_state()
+                state_manager.save_state(original)
+
+                local loaded = state_manager.load_state("cuj-multi-win", "workspace")
+
+                expect(#loaded.window_states).to.equal(2)
+            end)
+
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Periodic Save Behavior
+    ---------------------------------------------------------------------------
+
+    describe("periodic save", function()
+
+        it("schedules timer with call_after", function()
+            wezterm._test.reset()
+            wezterm._test.set_mux(mux)
+
+            state_manager.periodic_save({ interval_seconds = 60, save_workspaces = true })
+
+            local timers = wezterm._test._pending_timers
+            expect(#timers >= 1).to.equal(true)
+            expect(timers[1].seconds).to.equal(60)
+        end)
+
+        it("uses default interval when not specified", function()
+            wezterm._test.reset()
+            wezterm._test.set_mux(mux)
+
+            state_manager.periodic_save({ save_workspaces = true })
+
+            local timers = wezterm._test._pending_timers
+            expect(#timers >= 1).to.equal(true)
+            expect(timers[1].seconds).to.equal(60 * 15)
+        end)
+
+        it("emits start and finished events when timer fires", function()
+            wezterm._test.reset()
+            wezterm._test.set_mux(mux)
+
+            -- Create workspace so save has something to do
+            local workspace = mux.workspace("periodic-test")
+                :window("win"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/home", is_active = true })
+                :build()
+            mux.set_active(workspace)
+
+            state_manager.periodic_save({ interval_seconds = 1, save_workspaces = true })
+
+            wezterm._test.clear_emitted_events()
+            wezterm._test.tick_timers()
+
+            local events = wezterm._test.get_emitted_events()
+            expect(has_event(events, "resurrect.state_manager.periodic_save.start")).to.equal(true)
+            expect(has_event(events, "resurrect.state_manager.periodic_save.finished")).to.equal(true)
+        end)
+
+        it("reschedules after firing", function()
+            wezterm._test.reset()
+            wezterm._test.set_mux(mux)
+
+            local workspace = mux.workspace("periodic-resched-test")
+                :window("win"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/home", is_active = true })
+                :build()
+            mux.set_active(workspace)
+
+            state_manager.periodic_save({ interval_seconds = 5, save_workspaces = true })
+
+            -- Fire first timer
+            wezterm._test.tick_timers()
+
+            -- Should have rescheduled
+            local timers = wezterm._test._pending_timers
+            expect(#timers >= 1).to.equal(true)
+        end)
+
+    end)
+
+end)

--- a/plugin/resurrect/test/spec/events_spec.lua
+++ b/plugin/resurrect/test/spec/events_spec.lua
@@ -15,14 +15,16 @@ local tab_state_mod = require("resurrect.tab_state")
 --------------------------------------------------------------------------------
 
 local function find_event(events, name)
-    for _, event in ipairs(events) do
-        if event.name == name then return event end
-    end
-    return nil
+	for _, event in ipairs(events) do
+		if event.name == name then
+			return event
+		end
+	end
+	return nil
 end
 
 local function has_event(events, name)
-    return find_event(events, name) ~= nil
+	return find_event(events, name) ~= nil
 end
 
 --------------------------------------------------------------------------------
@@ -30,454 +32,591 @@ end
 --------------------------------------------------------------------------------
 
 describe("Events & Integration", function()
-
-    before(function()
-        mux.reset()
-        wezterm._test.reset()
-        wezterm._test.set_mux(mux)
-        local test_root = fs.setup() .. "/"
-        state_manager.change_state_save_dir(test_root)
-    end)
-
-    after(function()
-        fs.teardown()
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Event Emission Tests
-    ---------------------------------------------------------------------------
-
-    describe("event emission", function()
-
-        describe("save events", function()
-
-            it("emits start and finished events with file path", function()
-                local workspace = mux.workspace("save-event-test")
-                    :window("main"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/home", is_active = true })
-                    :build()
-                mux.set_active(workspace)
-
-                wezterm._test.clear_emitted_events()
-                local state = workspace_state_mod.get_workspace_state()
-                state_manager.save_state(state)
-
-                local events = wezterm._test.get_emitted_events()
-                expect(has_event(events, "resurrect.file_io.write_state.start")).to.equal(true)
-                expect(has_event(events, "resurrect.file_io.write_state.finished")).to.equal(true)
-
-                local start_event = find_event(events, "resurrect.file_io.write_state.start")
-                expect(start_event).to.exist()
-                expect(start_event.args[1]).to.match("save%-event%-test")
-            end)
-
-        end)
-
-        describe("load events", function()
-
-            it("emits start and finished events with name and type", function()
-                fs.mkdir(fs.get_root() .. "/workspace")
-                fs.write(fs.get_root() .. "/workspace/load-event-test.json", '{"workspace":"load-event-test","window_states":[]}')
-
-                wezterm._test.clear_emitted_events()
-                state_manager.load_state("load-event-test", "workspace")
-
-                local events = wezterm._test.get_emitted_events()
-                expect(has_event(events, "resurrect.state_manager.load_state.start")).to.equal(true)
-                expect(has_event(events, "resurrect.state_manager.load_state.finished")).to.equal(true)
-
-                local start_event = find_event(events, "resurrect.state_manager.load_state.start")
-                expect(start_event).to.exist()
-                expect(start_event.args[1]).to.equal("load-event-test")
-                expect(start_event.args[2]).to.equal("workspace")
-            end)
-
-        end)
-
-        describe("restore events", function()
-
-            it("emits workspace, window, and tab restore events", function()
-                wezterm._test.clear_emitted_events()
-                local state = fixtures.to_workspace_state(fixtures.single_pane)
-                workspace_state_mod.restore_workspace(state, {})
-
-                local events = wezterm._test.get_emitted_events()
-                expect(has_event(events, "resurrect.workspace_state.restore_workspace.start")).to.equal(true)
-                expect(has_event(events, "resurrect.workspace_state.restore_workspace.finished")).to.equal(true)
-                expect(has_event(events, "resurrect.window_state.restore_window.start")).to.equal(true)
-                expect(has_event(events, "resurrect.tab_state.restore_tab.start")).to.equal(true)
-            end)
-
-        end)
-
-        describe("error events", function()
-
-            it("emits resurrect.error for invalid JSON", function()
-                fs.mkdir(fs.get_root() .. "/workspace")
-                fs.write(fs.get_root() .. "/workspace/bad-json.json", "not valid json {{{")
-
-                wezterm._test.clear_emitted_events()
-                state_manager.load_state("bad-json", "workspace")
-
-                local events = wezterm._test.get_emitted_events()
-                expect(has_event(events, "resurrect.error")).to.equal(true)
-            end)
-
-            it("emits resurrect.error with descriptive message for nil workspace state", function()
-                wezterm._test.clear_emitted_events()
-                workspace_state_mod.restore_workspace(nil, {})
-
-                local events = wezterm._test.get_emitted_events()
-                expect(has_event(events, "resurrect.error")).to.equal(true)
-
-                local error_event = find_event(events, "resurrect.error")
-                expect(error_event).to.exist()
-                expect(error_event.args[1]).to.match("empty")
-            end)
-
-            it("emits resurrect.error for empty window_states", function()
-                wezterm._test.clear_emitted_events()
-                workspace_state_mod.restore_workspace({ workspace = "empty", window_states = {} }, {})
-
-                local events = wezterm._test.get_emitted_events()
-                expect(has_event(events, "resurrect.error")).to.equal(true)
-            end)
-
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- CUJ-Level Integration Tests
-    ---------------------------------------------------------------------------
-
-    describe("integration", function()
-
-        describe("save and restore single window", function()
-
-            it("round-trips workspace state through file system", function()
-                local workspace = mux.workspace("cuj-single")
-                    :window("main"):tab("dev"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/project", is_active = true })
-                    :build()
-                mux.set_active(workspace)
-
-                -- Capture and save
-                local original = workspace_state_mod.get_workspace_state()
-                state_manager.save_state(original)
-
-                -- Verify file exists
-                local file_path = fs.get_root() .. "/workspace/cuj-single.json"
-                expect(fs.exists(file_path)).to.equal(true)
-
-                -- Load back
-                local loaded = state_manager.load_state("cuj-single", "workspace")
-
-                expect(loaded.workspace).to.equal("cuj-single")
-                expect(#loaded.window_states).to.equal(1)
-                expect(loaded.window_states[1].tabs[1].pane_tree.cwd).to.equal("/project")
-            end)
-
-            it("restores loaded state to mux", function()
-                -- Create and save
-                local workspace = mux.workspace("cuj-restore")
-                    :window("win"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/src", is_active = true })
-                    :build()
-                mux.set_active(workspace)
-
-                local original = workspace_state_mod.get_workspace_state()
-                state_manager.save_state(original)
-
-                -- Reset mux to simulate fresh start
-                mux.reset()
-                wezterm._test.set_mux(mux)
-
-                -- Load and restore
-                local loaded = state_manager.load_state("cuj-restore", "workspace")
-                workspace_state_mod.restore_workspace(loaded, { spawn_in_workspace = true })
-
-                -- Verify restoration
-                local windows = mux.all_windows()
-                expect(#windows >= 1).to.equal(true)
-            end)
-
-        end)
-
-        describe("preserve terminal content", function()
-
-            it("saves and restores scrollback text", function()
-                local workspace = mux.workspace("cuj-scrollback")
-                    :window("win"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/home", text = "$ ls\nfile1.txt\nfile2.txt\n$ ", is_active = true })
-                    :build()
-                mux.set_active(workspace)
-
-                -- Capture and save
-                local original = workspace_state_mod.get_workspace_state()
-                state_manager.save_state(original)
-
-                -- Load back
-                local loaded = state_manager.load_state("cuj-scrollback", "workspace")
-
-                expect(loaded.window_states[1].tabs[1].pane_tree.text).to.exist()
-                expect(loaded.window_states[1].tabs[1].pane_tree.text).to.match("file1.txt")
-            end)
-
-            it("injects text on restore via on_pane_restore", function()
-                local fake_pane = {
-                    injected_text = nil,
-                    inject_output = function(self, text) self.injected_text = text end,
-                    send_text = function() end,
-                }
-                local pane_tree = { pane = fake_pane, text = "$ whoami\nuser\n$ ", alt_screen_active = false }
-
-                tab_state_mod.default_on_pane_restore(pane_tree)
-
-                expect(fake_pane.injected_text).to.exist()
-                expect(fake_pane.injected_text).to.match("whoami")
-            end)
-
-        end)
-
-        describe("handle multiple tabs", function()
-
-            it("saves workspace with multiple tabs", function()
-                local workspace = mux.workspace("cuj-multi-tabs")
-                    :window("win")
-                        :tab("Tab 1"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/a", is_active = true })
-                        :tab("Tab 2"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/b", is_active = true })
-                        :tab("Tab 3"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/c", is_active = true })
-                    :build()
-                mux.set_active(workspace)
-
-                local original = workspace_state_mod.get_workspace_state()
-                state_manager.save_state(original)
-
-                local loaded = state_manager.load_state("cuj-multi-tabs", "workspace")
-
-                expect(#loaded.window_states[1].tabs).to.equal(3)
-                expect(loaded.window_states[1].tabs[1].title).to.equal("Tab 1")
-                expect(loaded.window_states[1].tabs[2].title).to.equal("Tab 2")
-                expect(loaded.window_states[1].tabs[3].title).to.equal("Tab 3")
-            end)
-
-            it("preserves tab cwds through round-trip", function()
-                local workspace = mux.workspace("cuj-tabs-cwd")
-                    :window("win")
-                        :tab("src"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/project/src", is_active = true })
-                        :tab("test"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/project/test", is_active = true })
-                    :build()
-                mux.set_active(workspace)
-
-                local original = workspace_state_mod.get_workspace_state()
-                state_manager.save_state(original)
-                local loaded = state_manager.load_state("cuj-tabs-cwd", "workspace")
-
-                expect(loaded.window_states[1].tabs[1].pane_tree.cwd).to.equal("/project/src")
-                expect(loaded.window_states[1].tabs[2].pane_tree.cwd).to.equal("/project/test")
-            end)
-
-            it("restores multiple tabs to mux", function()
-                local state = {
-                    workspace = "multi-tab-restore",
-                    window_states = {{
-                        title = "win",
-                        tabs = {
-                            { title = "Tab A", is_active = true, pane_tree = { cwd = "/a", width = 160, height = 48, left = 0, top = 0, is_active = true } },
-                            { title = "Tab B", pane_tree = { cwd = "/b", width = 160, height = 48, left = 0, top = 0, is_active = true } },
-                            { title = "Tab C", pane_tree = { cwd = "/c", width = 160, height = 48, left = 0, top = 0, is_active = true } },
-                        },
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    }},
-                }
-
-                workspace_state_mod.restore_workspace(state, {})
-
-                local windows = mux.all_windows()
-                expect(#windows >= 1).to.equal(true)
-            end)
-
-        end)
-
-        describe("complex layout round-trip", function()
-
-            it("preserves IDE layout structure", function()
-                local workspace = mux.workspace("cuj-ide")
-                    :window("IDE")
-                        :tab("dev")
-                            :pane(fixtures.ide_layout.panes[1])
-                            :hsplit(fixtures.ide_layout.panes[2])
-                            :vsplit(fixtures.ide_layout.panes[3])
-                    :build()
-                mux.set_active(workspace)
-
-                local original = workspace_state_mod.get_workspace_state()
-                state_manager.save_state(original)
-
-                local loaded = state_manager.load_state("cuj-ide", "workspace")
-
-                -- Verify nested structure
-                local tree = loaded.window_states[1].tabs[1].pane_tree
-                expect(tree).to.exist()
-                expect(tree.right).to.exist()
-                expect(tree.right.bottom).to.exist()
-            end)
-
-            it("preserves three-way horizontal split", function()
-                local workspace = mux.workspace("cuj-3way")
-                    :window("win")
-                        :tab("tab")
-                            :pane(fixtures.three_way_hsplit.panes[1])
-                            :hsplit(fixtures.three_way_hsplit.panes[2])
-                            :hsplit(fixtures.three_way_hsplit.panes[3])
-                    :build()
-                mux.set_active(workspace)
-
-                local original = workspace_state_mod.get_workspace_state()
-                state_manager.save_state(original)
-
-                local loaded = state_manager.load_state("cuj-3way", "workspace")
-
-                local tree = loaded.window_states[1].tabs[1].pane_tree
-                expect(tree.cwd).to.equal("/a")
-                expect(tree.right).to.exist()
-                expect(tree.right.cwd).to.equal("/b")
-                expect(tree.right.right).to.exist()
-                expect(tree.right.right.cwd).to.equal("/c")
-            end)
-
-            it("preserves 2x2 grid layout", function()
-                local workspace = mux.workspace("cuj-grid")
-                    :window("win")
-                        :tab("tab")
-                            :pane(fixtures.grid_2x2.panes[1])
-                            :hsplit(fixtures.grid_2x2.panes[2])
-                            :vsplit(fixtures.grid_2x2.panes[3])
-                            :vsplit(fixtures.grid_2x2.panes[4])
-                    :build()
-                mux.set_active(workspace)
-
-                local original = workspace_state_mod.get_workspace_state()
-                state_manager.save_state(original)
-
-                local loaded = state_manager.load_state("cuj-grid", "workspace")
-
-                local tree = loaded.window_states[1].tabs[1].pane_tree
-                expect(tree.cwd).to.equal("/tl")
-            end)
-
-            it("restores complex layout to mux", function()
-                local state = {
-                    workspace = "complex-restore",
-                    window_states = {{
-                        title = "win",
-                        tabs = {{
-                            title = "tab", is_active = true,
-                            pane_tree = {
-                                cwd = "/editor", width = 100, height = 48, left = 0, top = 0, is_active = true,
-                                right = {
-                                    cwd = "/term", width = 60, height = 24, left = 101, top = 0,
-                                    bottom = { cwd = "/output", width = 60, height = 24, left = 101, top = 25 },
-                                },
-                            },
-                        }},
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    }},
-                }
-
-                workspace_state_mod.restore_workspace(state, {})
-
-                local windows = mux.all_windows()
-                expect(#windows >= 1).to.equal(true)
-            end)
-
-        end)
-
-        describe("multiple windows", function()
-
-            it("saves and restores multiple windows", function()
-                local workspace = mux.workspace("cuj-multi-win")
-                    :window("Window 1"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/win1", is_active = true })
-                    :window("Window 2"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/win2", is_active = true })
-                    :build()
-                mux.set_active(workspace)
-
-                local original = workspace_state_mod.get_workspace_state()
-                state_manager.save_state(original)
-
-                local loaded = state_manager.load_state("cuj-multi-win", "workspace")
-
-                expect(#loaded.window_states).to.equal(2)
-            end)
-
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Periodic Save Behavior
-    ---------------------------------------------------------------------------
-
-    describe("periodic save", function()
-
-        it("schedules timer with call_after", function()
-            wezterm._test.reset()
-            wezterm._test.set_mux(mux)
-
-            state_manager.periodic_save({ interval_seconds = 60, save_workspaces = true })
-
-            local timers = wezterm._test._pending_timers
-            expect(#timers >= 1).to.equal(true)
-            expect(timers[1].seconds).to.equal(60)
-        end)
-
-        it("uses default interval when not specified", function()
-            wezterm._test.reset()
-            wezterm._test.set_mux(mux)
-
-            state_manager.periodic_save({ save_workspaces = true })
-
-            local timers = wezterm._test._pending_timers
-            expect(#timers >= 1).to.equal(true)
-            expect(timers[1].seconds).to.equal(60 * 15)
-        end)
-
-        it("emits start and finished events when timer fires", function()
-            wezterm._test.reset()
-            wezterm._test.set_mux(mux)
-
-            -- Create workspace so save has something to do
-            local workspace = mux.workspace("periodic-test")
-                :window("win"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/home", is_active = true })
-                :build()
-            mux.set_active(workspace)
-
-            state_manager.periodic_save({ interval_seconds = 1, save_workspaces = true })
-
-            wezterm._test.clear_emitted_events()
-            wezterm._test.tick_timers()
-
-            local events = wezterm._test.get_emitted_events()
-            expect(has_event(events, "resurrect.state_manager.periodic_save.start")).to.equal(true)
-            expect(has_event(events, "resurrect.state_manager.periodic_save.finished")).to.equal(true)
-        end)
-
-        it("reschedules after firing", function()
-            wezterm._test.reset()
-            wezterm._test.set_mux(mux)
-
-            local workspace = mux.workspace("periodic-resched-test")
-                :window("win"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/home", is_active = true })
-                :build()
-            mux.set_active(workspace)
-
-            state_manager.periodic_save({ interval_seconds = 5, save_workspaces = true })
-
-            -- Fire first timer
-            wezterm._test.tick_timers()
-
-            -- Should have rescheduled
-            local timers = wezterm._test._pending_timers
-            expect(#timers >= 1).to.equal(true)
-        end)
-
-    end)
-
+	before(function()
+		mux.reset()
+		wezterm._test.reset()
+		wezterm._test.set_mux(mux)
+		local test_root = fs.setup() .. "/"
+		state_manager.change_state_save_dir(test_root)
+	end)
+
+	after(function()
+		fs.teardown()
+	end)
+
+	---------------------------------------------------------------------------
+	-- Event Emission Tests
+	---------------------------------------------------------------------------
+
+	describe("event emission", function()
+		describe("save events", function()
+			it("emits start and finished events with file path", function()
+				local workspace = mux.workspace("save-event-test")
+					:window("main")
+					:tab("tab")
+					:pane({
+						left = 0,
+						top = 0,
+						width = 160,
+						height = 48,
+						cwd = "/home",
+						is_active = true,
+					})
+					:build()
+				mux.set_active(workspace)
+
+				wezterm._test.clear_emitted_events()
+				local state = workspace_state_mod.get_workspace_state()
+				state_manager.save_state(state)
+
+				local events = wezterm._test.get_emitted_events()
+				expect(has_event(events, "resurrect.file_io.write_state.start")).to.equal(true)
+				expect(has_event(events, "resurrect.file_io.write_state.finished")).to.equal(true)
+
+				local start_event = find_event(events, "resurrect.file_io.write_state.start")
+				expect(start_event).to.exist()
+				expect(start_event.args[1]).to.match("save%-event%-test")
+			end)
+		end)
+
+		describe("load events", function()
+			it("emits start and finished events with name and type", function()
+				fs.mkdir(fs.get_root() .. "/workspace")
+				local json_data = '{"workspace":"load-event-test","window_states":[]}'
+				fs.write(fs.get_root() .. "/workspace/load-event-test.json", json_data)
+
+				wezterm._test.clear_emitted_events()
+				state_manager.load_state("load-event-test", "workspace")
+
+				local events = wezterm._test.get_emitted_events()
+				expect(has_event(events, "resurrect.state_manager.load_state.start")).to.equal(true)
+				expect(has_event(events, "resurrect.state_manager.load_state.finished")).to.equal(true)
+
+				local start_event = find_event(events, "resurrect.state_manager.load_state.start")
+				expect(start_event).to.exist()
+				expect(start_event.args[1]).to.equal("load-event-test")
+				expect(start_event.args[2]).to.equal("workspace")
+			end)
+		end)
+
+		describe("restore events", function()
+			it("emits workspace, window, and tab restore events", function()
+				wezterm._test.clear_emitted_events()
+				local state = fixtures.to_workspace_state(fixtures.single_pane)
+				workspace_state_mod.restore_workspace(state, {})
+
+				local events = wezterm._test.get_emitted_events()
+				expect(has_event(events, "resurrect.workspace_state.restore_workspace.start")).to.equal(true)
+				expect(has_event(events, "resurrect.workspace_state.restore_workspace.finished")).to.equal(true)
+				expect(has_event(events, "resurrect.window_state.restore_window.start")).to.equal(true)
+				expect(has_event(events, "resurrect.tab_state.restore_tab.start")).to.equal(true)
+			end)
+		end)
+
+		describe("error events", function()
+			it("emits resurrect.error for invalid JSON", function()
+				fs.mkdir(fs.get_root() .. "/workspace")
+				fs.write(fs.get_root() .. "/workspace/bad-json.json", "not valid json {{{")
+
+				wezterm._test.clear_emitted_events()
+				state_manager.load_state("bad-json", "workspace")
+
+				local events = wezterm._test.get_emitted_events()
+				expect(has_event(events, "resurrect.error")).to.equal(true)
+			end)
+
+			it("emits resurrect.error with descriptive message for nil workspace state", function()
+				wezterm._test.clear_emitted_events()
+				workspace_state_mod.restore_workspace(nil, {})
+
+				local events = wezterm._test.get_emitted_events()
+				expect(has_event(events, "resurrect.error")).to.equal(true)
+
+				local error_event = find_event(events, "resurrect.error")
+				expect(error_event).to.exist()
+				expect(error_event.args[1]).to.match("empty")
+			end)
+
+			it("emits resurrect.error for empty window_states", function()
+				wezterm._test.clear_emitted_events()
+				workspace_state_mod.restore_workspace({ workspace = "empty", window_states = {} }, {})
+
+				local events = wezterm._test.get_emitted_events()
+				expect(has_event(events, "resurrect.error")).to.equal(true)
+			end)
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- CUJ-Level Integration Tests
+	---------------------------------------------------------------------------
+
+	describe("integration", function()
+		describe("save and restore single window", function()
+			it("round-trips workspace state through file system", function()
+				local workspace = mux.workspace("cuj-single")
+					:window("main")
+					:tab("dev")
+					:pane({
+						left = 0,
+						top = 0,
+						width = 160,
+						height = 48,
+						cwd = "/project",
+						is_active = true,
+					})
+					:build()
+				mux.set_active(workspace)
+
+				-- Capture and save
+				local original = workspace_state_mod.get_workspace_state()
+				state_manager.save_state(original)
+
+				-- Verify file exists
+				local file_path = fs.get_root() .. "/workspace/cuj-single.json"
+				expect(fs.exists(file_path)).to.equal(true)
+
+				-- Load back
+				local loaded = state_manager.load_state("cuj-single", "workspace")
+
+				expect(loaded.workspace).to.equal("cuj-single")
+				expect(#loaded.window_states).to.equal(1)
+				expect(loaded.window_states[1].tabs[1].pane_tree.cwd).to.equal("/project")
+			end)
+
+			it("restores loaded state to mux", function()
+				-- Create and save
+				local workspace = mux.workspace("cuj-restore")
+					:window("win")
+					:tab("tab")
+					:pane({
+						left = 0,
+						top = 0,
+						width = 160,
+						height = 48,
+						cwd = "/src",
+						is_active = true,
+					})
+					:build()
+				mux.set_active(workspace)
+
+				local original = workspace_state_mod.get_workspace_state()
+				state_manager.save_state(original)
+
+				-- Reset mux to simulate fresh start
+				mux.reset()
+				wezterm._test.set_mux(mux)
+
+				-- Load and restore
+				local loaded = state_manager.load_state("cuj-restore", "workspace")
+				workspace_state_mod.restore_workspace(loaded, { spawn_in_workspace = true })
+
+				-- Verify restoration
+				local windows = mux.all_windows()
+				expect(#windows >= 1).to.equal(true)
+			end)
+		end)
+
+		describe("preserve terminal content", function()
+			it("saves and restores scrollback text", function()
+				local workspace = mux.workspace("cuj-scrollback")
+					:window("win")
+					:tab("tab")
+					:pane({
+						left = 0,
+						top = 0,
+						width = 160,
+						height = 48,
+						cwd = "/home",
+						text = "$ ls\nfile1.txt\nfile2.txt\n$ ",
+						is_active = true,
+					})
+					:build()
+				mux.set_active(workspace)
+
+				-- Capture and save
+				local original = workspace_state_mod.get_workspace_state()
+				state_manager.save_state(original)
+
+				-- Load back
+				local loaded = state_manager.load_state("cuj-scrollback", "workspace")
+
+				expect(loaded.window_states[1].tabs[1].pane_tree.text).to.exist()
+				expect(loaded.window_states[1].tabs[1].pane_tree.text).to.match("file1.txt")
+			end)
+
+			it("injects text on restore via on_pane_restore", function()
+				local fake_pane = {
+					injected_text = nil,
+					inject_output = function(self, text)
+						self.injected_text = text
+					end,
+					send_text = function() end,
+				}
+				local pane_tree = { pane = fake_pane, text = "$ whoami\nuser\n$ ", alt_screen_active = false }
+
+				tab_state_mod.default_on_pane_restore(pane_tree)
+
+				expect(fake_pane.injected_text).to.exist()
+				expect(fake_pane.injected_text).to.match("whoami")
+			end)
+		end)
+
+		describe("handle multiple tabs", function()
+			it("saves workspace with multiple tabs", function()
+				local workspace = mux.workspace("cuj-multi-tabs")
+					:window("win")
+					:tab("Tab 1")
+					:pane({
+						left = 0,
+						top = 0,
+						width = 160,
+						height = 48,
+						cwd = "/a",
+						is_active = true,
+					})
+					:tab("Tab 2")
+					:pane({
+						left = 0,
+						top = 0,
+						width = 160,
+						height = 48,
+						cwd = "/b",
+						is_active = true,
+					})
+					:tab("Tab 3")
+					:pane({
+						left = 0,
+						top = 0,
+						width = 160,
+						height = 48,
+						cwd = "/c",
+						is_active = true,
+					})
+					:build()
+				mux.set_active(workspace)
+
+				local original = workspace_state_mod.get_workspace_state()
+				state_manager.save_state(original)
+
+				local loaded = state_manager.load_state("cuj-multi-tabs", "workspace")
+
+				expect(#loaded.window_states[1].tabs).to.equal(3)
+				expect(loaded.window_states[1].tabs[1].title).to.equal("Tab 1")
+				expect(loaded.window_states[1].tabs[2].title).to.equal("Tab 2")
+				expect(loaded.window_states[1].tabs[3].title).to.equal("Tab 3")
+			end)
+
+			it("preserves tab cwds through round-trip", function()
+				local workspace = mux.workspace("cuj-tabs-cwd")
+					:window("win")
+					:tab("src")
+					:pane({
+						left = 0,
+						top = 0,
+						width = 160,
+						height = 48,
+						cwd = "/project/src",
+						is_active = true,
+					})
+					:tab("test")
+					:pane({
+						left = 0,
+						top = 0,
+						width = 160,
+						height = 48,
+						cwd = "/project/test",
+						is_active = true,
+					})
+					:build()
+				mux.set_active(workspace)
+
+				local original = workspace_state_mod.get_workspace_state()
+				state_manager.save_state(original)
+				local loaded = state_manager.load_state("cuj-tabs-cwd", "workspace")
+
+				expect(loaded.window_states[1].tabs[1].pane_tree.cwd).to.equal("/project/src")
+				expect(loaded.window_states[1].tabs[2].pane_tree.cwd).to.equal("/project/test")
+			end)
+
+			it("restores multiple tabs to mux", function()
+				local state = {
+					workspace = "multi-tab-restore",
+					window_states = {
+						{
+							title = "win",
+							tabs = {
+								{
+									title = "Tab A",
+									is_active = true,
+									pane_tree = {
+										cwd = "/a",
+										width = 160,
+										height = 48,
+										left = 0,
+										top = 0,
+										is_active = true,
+									},
+								},
+								{
+									title = "Tab B",
+									pane_tree = {
+										cwd = "/b",
+										width = 160,
+										height = 48,
+										left = 0,
+										top = 0,
+										is_active = true,
+									},
+								},
+								{
+									title = "Tab C",
+									pane_tree = {
+										cwd = "/c",
+										width = 160,
+										height = 48,
+										left = 0,
+										top = 0,
+										is_active = true,
+									},
+								},
+							},
+							size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+						},
+					},
+				}
+
+				workspace_state_mod.restore_workspace(state, {})
+
+				local windows = mux.all_windows()
+				expect(#windows >= 1).to.equal(true)
+			end)
+		end)
+
+		describe("complex layout round-trip", function()
+			it("preserves IDE layout structure", function()
+				local workspace = mux.workspace("cuj-ide")
+					:window("IDE")
+					:tab("dev")
+					:pane(fixtures.ide_layout.panes[1])
+					:hsplit(fixtures.ide_layout.panes[2])
+					:vsplit(fixtures.ide_layout.panes[3])
+					:build()
+				mux.set_active(workspace)
+
+				local original = workspace_state_mod.get_workspace_state()
+				state_manager.save_state(original)
+
+				local loaded = state_manager.load_state("cuj-ide", "workspace")
+
+				-- Verify nested structure
+				local tree = loaded.window_states[1].tabs[1].pane_tree
+				expect(tree).to.exist()
+				expect(tree.right).to.exist()
+				expect(tree.right.bottom).to.exist()
+			end)
+
+			it("preserves three-way horizontal split", function()
+				local workspace = mux.workspace("cuj-3way")
+					:window("win")
+					:tab("tab")
+					:pane(fixtures.three_way_hsplit.panes[1])
+					:hsplit(fixtures.three_way_hsplit.panes[2])
+					:hsplit(fixtures.three_way_hsplit.panes[3])
+					:build()
+				mux.set_active(workspace)
+
+				local original = workspace_state_mod.get_workspace_state()
+				state_manager.save_state(original)
+
+				local loaded = state_manager.load_state("cuj-3way", "workspace")
+
+				local tree = loaded.window_states[1].tabs[1].pane_tree
+				expect(tree.cwd).to.equal("/a")
+				expect(tree.right).to.exist()
+				expect(tree.right.cwd).to.equal("/b")
+				expect(tree.right.right).to.exist()
+				expect(tree.right.right.cwd).to.equal("/c")
+			end)
+
+			it("preserves 2x2 grid layout", function()
+				local workspace = mux.workspace("cuj-grid")
+					:window("win")
+					:tab("tab")
+					:pane(fixtures.grid_2x2.panes[1])
+					:hsplit(fixtures.grid_2x2.panes[2])
+					:vsplit(fixtures.grid_2x2.panes[3])
+					:vsplit(fixtures.grid_2x2.panes[4])
+					:build()
+				mux.set_active(workspace)
+
+				local original = workspace_state_mod.get_workspace_state()
+				state_manager.save_state(original)
+
+				local loaded = state_manager.load_state("cuj-grid", "workspace")
+
+				local tree = loaded.window_states[1].tabs[1].pane_tree
+				expect(tree.cwd).to.equal("/tl")
+			end)
+
+			it("restores complex layout to mux", function()
+				local state = {
+					workspace = "complex-restore",
+					window_states = {
+						{
+							title = "win",
+							tabs = {
+								{
+									title = "tab",
+									is_active = true,
+									pane_tree = {
+										cwd = "/editor",
+										width = 100,
+										height = 48,
+										left = 0,
+										top = 0,
+										is_active = true,
+										right = {
+											cwd = "/term",
+											width = 60,
+											height = 24,
+											left = 101,
+											top = 0,
+											bottom = { cwd = "/output", width = 60, height = 24, left = 101, top = 25 },
+										},
+									},
+								},
+							},
+							size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+						},
+					},
+				}
+
+				workspace_state_mod.restore_workspace(state, {})
+
+				local windows = mux.all_windows()
+				expect(#windows >= 1).to.equal(true)
+			end)
+		end)
+
+		describe("multiple windows", function()
+			it("saves and restores multiple windows", function()
+				local workspace = mux.workspace("cuj-multi-win")
+					:window("Window 1")
+					:tab("tab")
+					:pane({
+						left = 0,
+						top = 0,
+						width = 160,
+						height = 48,
+						cwd = "/win1",
+						is_active = true,
+					})
+					:window("Window 2")
+					:tab("tab")
+					:pane({
+						left = 0,
+						top = 0,
+						width = 160,
+						height = 48,
+						cwd = "/win2",
+						is_active = true,
+					})
+					:build()
+				mux.set_active(workspace)
+
+				local original = workspace_state_mod.get_workspace_state()
+				state_manager.save_state(original)
+
+				local loaded = state_manager.load_state("cuj-multi-win", "workspace")
+
+				expect(#loaded.window_states).to.equal(2)
+			end)
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Periodic Save Behavior
+	---------------------------------------------------------------------------
+
+	describe("periodic save", function()
+		it("schedules timer with call_after", function()
+			wezterm._test.reset()
+			wezterm._test.set_mux(mux)
+
+			state_manager.periodic_save({ interval_seconds = 60, save_workspaces = true })
+
+			local timers = wezterm._test._pending_timers
+			expect(#timers >= 1).to.equal(true)
+			expect(timers[1].seconds).to.equal(60)
+		end)
+
+		it("uses default interval when not specified", function()
+			wezterm._test.reset()
+			wezterm._test.set_mux(mux)
+
+			state_manager.periodic_save({ save_workspaces = true })
+
+			local timers = wezterm._test._pending_timers
+			expect(#timers >= 1).to.equal(true)
+			expect(timers[1].seconds).to.equal(60 * 15)
+		end)
+
+		it("emits start and finished events when timer fires", function()
+			wezterm._test.reset()
+			wezterm._test.set_mux(mux)
+
+			-- Create workspace so save has something to do
+			local workspace = mux.workspace("periodic-test")
+				:window("win")
+				:tab("tab")
+				:pane({
+					left = 0,
+					top = 0,
+					width = 160,
+					height = 48,
+					cwd = "/home",
+					is_active = true,
+				})
+				:build()
+			mux.set_active(workspace)
+
+			state_manager.periodic_save({ interval_seconds = 1, save_workspaces = true })
+
+			wezterm._test.clear_emitted_events()
+			wezterm._test.tick_timers()
+
+			local events = wezterm._test.get_emitted_events()
+			expect(has_event(events, "resurrect.state_manager.periodic_save.start")).to.equal(true)
+			expect(has_event(events, "resurrect.state_manager.periodic_save.finished")).to.equal(true)
+		end)
+
+		it("reschedules after firing", function()
+			wezterm._test.reset()
+			wezterm._test.set_mux(mux)
+
+			local workspace = mux.workspace("periodic-resched-test")
+				:window("win")
+				:tab("tab")
+				:pane({
+					left = 0,
+					top = 0,
+					width = 160,
+					height = 48,
+					cwd = "/home",
+					is_active = true,
+				})
+				:build()
+			mux.set_active(workspace)
+
+			state_manager.periodic_save({ interval_seconds = 5, save_workspaces = true })
+
+			-- Fire first timer
+			wezterm._test.tick_timers()
+
+			-- Should have rescheduled
+			local timers = wezterm._test._pending_timers
+			expect(#timers >= 1).to.equal(true)
+		end)
+	end)
 end)

--- a/plugin/resurrect/test/spec/persistence_spec.lua
+++ b/plugin/resurrect/test/spec/persistence_spec.lua
@@ -1,0 +1,348 @@
+-- Tests for state persistence (save/load round-trip)
+-- Verifies that state can be saved to disk and loaded back correctly
+
+local mux = require("mux")
+local fixtures = require("pane_layouts")
+local fs = require("fs")
+
+-- Import modules under test
+local state_manager = require("resurrect.state_manager")
+local pane_tree_mod = require("resurrect.pane_tree")
+local workspace_state_mod = require("resurrect.workspace_state")
+
+--------------------------------------------------------------------------------
+-- Setup / Teardown
+--------------------------------------------------------------------------------
+
+describe("Persistence", function()
+
+    before(function()
+        mux.reset()
+        wezterm._test.reset()
+        wezterm._test.set_mux(mux)
+        -- Setup temp directory for tests
+        -- Note: state_manager expects save_state_dir to end with separator
+        local test_root = fs.setup() .. "/"
+        state_manager.change_state_save_dir(test_root)
+    end)
+
+    after(function()
+        fs.teardown()
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Save Tests
+    ---------------------------------------------------------------------------
+
+    describe("save", function()
+
+        it("writes JSON file for workspace state", function()
+            local workspace = mux.workspace("myproject")
+                :window("main"):tab("dev"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/project", is_active = true })
+                :build()
+
+            mux.set_active(workspace)
+
+            local state = workspace_state_mod.get_workspace_state()
+            state_manager.save_state(state)
+
+            local file_path = fs.get_root() .. "/workspace" .. "/myproject.json"
+            expect(fs.exists(file_path)).to.equal(true)
+        end)
+
+        it("creates valid JSON content", function()
+            local workspace = mux.workspace("jsontest")
+                :window("main"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/home", is_active = true })
+                :build()
+
+            mux.set_active(workspace)
+
+            local state = workspace_state_mod.get_workspace_state()
+            state_manager.save_state(state)
+
+            local file_path = fs.get_root() .. "/workspace" .. "/jsontest.json"
+            local content = fs.read(file_path)
+            expect(content).to.exist()
+
+            -- Should be valid JSON (parseable)
+            local parsed = wezterm.json_parse(content)
+            expect(parsed).to.exist()
+            expect(parsed.workspace).to.equal("jsontest")
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Filename Sanitization Tests
+    ---------------------------------------------------------------------------
+
+    describe("filename sanitization", function()
+
+        it("replaces forward slashes with plus", function()
+            local result = state_manager.sanitize_filename("my/project/name")
+            expect(result).to.equal("my+project+name")
+        end)
+
+        it("replaces backslashes with plus", function()
+            local result = state_manager.sanitize_filename("my\\project\\name")
+            expect(result).to.equal("my+project+name")
+        end)
+
+        it("replaces double dots with underscore", function()
+            local result = state_manager.sanitize_filename("name..test")
+            expect(result).to.equal("name_test")
+        end)
+
+        it("replaces Windows-invalid characters", function()
+            local result = state_manager.sanitize_filename('file<>:"|?*name')
+            expect(result:match('[<>:"|%?%*]')).to_not.exist()
+        end)
+
+        it("trims trailing dots and spaces", function()
+            local result = state_manager.sanitize_filename("filename.  .")
+            expect(result).to.equal("filename")
+        end)
+
+        it("returns _unnamed_ for nil input", function()
+            local result = state_manager.sanitize_filename(nil)
+            expect(result).to.equal("_unnamed_")
+        end)
+
+        it("returns _unnamed_ for empty string", function()
+            local result = state_manager.sanitize_filename("")
+            expect(result).to.equal("_unnamed_")
+        end)
+
+        it("handles complex path-like names", function()
+            local result = state_manager.sanitize_filename("/home/user/project/src")
+            expect(result).to.equal("+home+user+project+src")
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Load Tests
+    ---------------------------------------------------------------------------
+
+    describe("load", function()
+
+        it("parses saved JSON correctly", function()
+            -- Write a test file directly
+            fs.mkdir(fs.get_root() .. "/workspace")
+            local file_path = fs.get_root() .. "/workspace" .. "/loadtest.json"
+            fs.write(file_path, '{"workspace":"loadtest","window_states":[]}')
+
+            local state = state_manager.load_state("loadtest", "workspace")
+
+            expect(state).to.exist()
+            expect(state.workspace).to.equal("loadtest")
+        end)
+
+        it("emits error for missing file", function()
+            wezterm._test.clear_emitted_events()
+
+            -- file_io.load_json throws for missing files
+            -- state_manager should emit an error event
+            local success, result = pcall(function()
+                return state_manager.load_state("nonexistent", "workspace")
+            end)
+
+            -- Either returns empty table or throws - both are acceptable
+            if success then
+                expect(result).to.exist()
+            end
+        end)
+
+        it("emits start event", function()
+            fs.mkdir(fs.get_root() .. "/workspace")
+            fs.write(fs.get_root() .. "/workspace" .. "/eventtest.json", '{"workspace":"eventtest","window_states":[]}')
+
+            wezterm._test.clear_emitted_events()
+
+            state_manager.load_state("eventtest", "workspace")
+
+            local events = wezterm._test.get_emitted_events()
+            local found = false
+            for _, event in ipairs(events) do
+                if event.name == "resurrect.state_manager.load_state.start" then
+                    found = true
+                    break
+                end
+            end
+            expect(found).to.equal(true)
+        end)
+
+        it("emits finished event on success", function()
+            fs.mkdir(fs.get_root() .. "/workspace")
+            fs.write(fs.get_root() .. "/workspace" .. "/finishtest.json", '{"workspace":"finishtest","window_states":[]}')
+
+            wezterm._test.clear_emitted_events()
+
+            state_manager.load_state("finishtest", "workspace")
+
+            local events = wezterm._test.get_emitted_events()
+            local found = false
+            for _, event in ipairs(events) do
+                if event.name == "resurrect.state_manager.load_state.finished" then
+                    found = true
+                    break
+                end
+            end
+            expect(found).to.equal(true)
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Round-Trip Tests
+    ---------------------------------------------------------------------------
+
+    describe("round-trip", function()
+
+        it("preserves single pane state", function()
+            local workspace = mux.workspace("roundtrip-single")
+                :window("main"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/project", is_active = true })
+                :build()
+
+            mux.set_active(workspace)
+
+            -- Capture and save
+            local original = workspace_state_mod.get_workspace_state()
+            state_manager.save_state(original)
+
+            -- Load back
+            local loaded = state_manager.load_state("roundtrip-single", "workspace")
+
+            expect(loaded.workspace).to.equal(original.workspace)
+            expect(#loaded.window_states).to.equal(#original.window_states)
+        end)
+
+        it("preserves split layout structure", function()
+            local workspace = mux.workspace("roundtrip-split")
+                :window("main")
+                    :tab("editor")
+                        :pane(fixtures.hsplit.panes[1])
+                        :hsplit(fixtures.hsplit.panes[2])
+                :build()
+
+            mux.set_active(workspace)
+
+            -- Capture and save
+            local original = workspace_state_mod.get_workspace_state()
+            state_manager.save_state(original)
+
+            -- Load back
+            local loaded = state_manager.load_state("roundtrip-split", "workspace")
+
+            expect(loaded.workspace).to.equal("roundtrip-split")
+            expect(#loaded.window_states).to.equal(1)
+            expect(#loaded.window_states[1].tabs).to.equal(1)
+
+            -- Verify pane tree structure preserved
+            local original_tree = original.window_states[1].tabs[1].pane_tree
+            local loaded_tree = loaded.window_states[1].tabs[1].pane_tree
+
+            expect(loaded_tree.cwd).to.equal(original_tree.cwd)
+            if original_tree.right then
+                expect(loaded_tree.right).to.exist()
+                expect(loaded_tree.right.cwd).to.equal(original_tree.right.cwd)
+            end
+        end)
+
+        it("preserves complex IDE layout through round-trip", function()
+            local workspace = mux.workspace("roundtrip-ide")
+                :window("main")
+                    :tab("dev")
+                        :pane(fixtures.ide_layout.panes[1])
+                        :hsplit(fixtures.ide_layout.panes[2])
+                        :vsplit(fixtures.ide_layout.panes[3])
+                :build()
+
+            mux.set_active(workspace)
+
+            -- Capture and save
+            local original = workspace_state_mod.get_workspace_state()
+            state_manager.save_state(original)
+
+            -- Load back
+            local loaded = state_manager.load_state("roundtrip-ide", "workspace")
+
+            -- Verify nested structure preserved
+            local loaded_tree = loaded.window_states[1].tabs[1].pane_tree
+
+            expect(loaded_tree).to.exist()
+            expect(loaded_tree.right).to.exist()
+            if loaded_tree.right.bottom then
+                expect(loaded_tree.right.bottom).to.exist()
+            end
+        end)
+
+        it("preserves multiple tabs through round-trip", function()
+            local workspace = mux.workspace("roundtrip-tabs")
+                :window("main")
+                    :tab("Tab 1"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/a", is_active = true })
+                    :tab("Tab 2"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/b", is_active = true })
+                :build()
+
+            mux.set_active(workspace)
+
+            -- Capture and save
+            local original = workspace_state_mod.get_workspace_state()
+            state_manager.save_state(original)
+
+            -- Load back
+            local loaded = state_manager.load_state("roundtrip-tabs", "workspace")
+
+            expect(#loaded.window_states[1].tabs).to.equal(2)
+            expect(loaded.window_states[1].tabs[1].title).to.equal("Tab 1")
+            expect(loaded.window_states[1].tabs[2].title).to.equal("Tab 2")
+        end)
+
+        it("preserves multiple windows through round-trip", function()
+            local workspace = mux.workspace("roundtrip-windows")
+                :window("Window 1"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/a", is_active = true })
+                :window("Window 2"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/b", is_active = true })
+                :build()
+
+            mux.set_active(workspace)
+
+            -- Capture and save
+            local original = workspace_state_mod.get_workspace_state()
+            state_manager.save_state(original)
+
+            -- Load back
+            local loaded = state_manager.load_state("roundtrip-windows", "workspace")
+
+            expect(#loaded.window_states).to.equal(2)
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Error Handling Tests
+    ---------------------------------------------------------------------------
+
+    describe("error handling", function()
+
+        it("emits error for invalid JSON", function()
+            fs.mkdir(fs.get_root() .. "/workspace")
+            fs.write(fs.get_root() .. "/workspace" .. "/invalid.json", "not valid json {{{")
+
+            wezterm._test.clear_emitted_events()
+
+            local state = state_manager.load_state("invalid", "workspace")
+
+            local events = wezterm._test.get_emitted_events()
+            local found_error = false
+            for _, event in ipairs(events) do
+                if event.name == "resurrect.error" then
+                    found_error = true
+                    break
+                end
+            end
+            expect(found_error).to.equal(true)
+        end)
+
+    end)
+
+end)

--- a/plugin/resurrect/test/spec/persistence_spec.lua
+++ b/plugin/resurrect/test/spec/persistence_spec.lua
@@ -15,377 +15,413 @@ local workspace_state_mod = require("resurrect.workspace_state")
 --------------------------------------------------------------------------------
 
 describe("Persistence", function()
-
-    before(function()
-        mux.reset()
-        wezterm._test.reset()
-        wezterm._test.set_mux(mux)
-        -- Setup temp directory for tests
-        -- Note: state_manager expects save_state_dir to end with separator
-        local test_root = fs.setup() .. "/"
-        state_manager.change_state_save_dir(test_root)
-    end)
-
-    after(function()
-        fs.teardown()
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Save Tests
-    ---------------------------------------------------------------------------
-
-    describe("save", function()
-
-        it("writes JSON file for workspace state", function()
-            local workspace = mux.workspace("myproject")
-                :window("main"):tab("dev"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/project", is_active = true })
-                :build()
-
-            mux.set_active(workspace)
-
-            local state = workspace_state_mod.get_workspace_state()
-            state_manager.save_state(state)
-
-            local file_path = fs.get_root() .. "/workspace" .. "/myproject.json"
-            expect(fs.exists(file_path)).to.equal(true)
-        end)
-
-        it("creates valid JSON content", function()
-            local workspace = mux.workspace("jsontest")
-                :window("main"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/home", is_active = true })
-                :build()
-
-            mux.set_active(workspace)
-
-            local state = workspace_state_mod.get_workspace_state()
-            state_manager.save_state(state)
-
-            local file_path = fs.get_root() .. "/workspace" .. "/jsontest.json"
-            local content = fs.read(file_path)
-            expect(content).to.exist()
-
-            -- Should be valid JSON (parseable)
-            local parsed = wezterm.json_parse(content)
-            expect(parsed).to.exist()
-            expect(parsed.workspace).to.equal("jsontest")
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Filename Sanitization Tests
-    ---------------------------------------------------------------------------
-
-    describe("filename sanitization", function()
-
-        it("replaces forward slashes with plus", function()
-            local result = state_manager.sanitize_filename("my/project/name")
-            expect(result).to.equal("my+project+name")
-        end)
-
-        it("replaces backslashes with plus", function()
-            local result = state_manager.sanitize_filename("my\\project\\name")
-            expect(result).to.equal("my+project+name")
-        end)
-
-        it("replaces double dots with underscore", function()
-            local result = state_manager.sanitize_filename("name..test")
-            expect(result).to.equal("name_test")
-        end)
-
-        it("replaces Windows-invalid characters", function()
-            local result = state_manager.sanitize_filename('file<>:"|?*name')
-            expect(result:match('[<>:"|%?%*]')).to_not.exist()
-        end)
-
-        it("trims trailing dots and spaces", function()
-            local result = state_manager.sanitize_filename("filename.  .")
-            expect(result).to.equal("filename")
-        end)
-
-        it("returns _unnamed_ for nil input", function()
-            local result = state_manager.sanitize_filename(nil)
-            expect(result).to.equal("_unnamed_")
-        end)
-
-        it("returns _unnamed_ for empty string", function()
-            local result = state_manager.sanitize_filename("")
-            expect(result).to.equal("_unnamed_")
-        end)
-
-        it("handles complex path-like names", function()
-            local result = state_manager.sanitize_filename("/home/user/project/src")
-            expect(result).to.equal("+home+user+project+src")
-        end)
-
-        it("prevents path traversal attacks", function()
-            local result = state_manager.sanitize_filename("../../../etc/passwd")
-            expect(result:match("%.%.")).to.equal(nil)
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Load Tests
-    ---------------------------------------------------------------------------
-
-    describe("load", function()
-
-        it("parses saved JSON correctly", function()
-            -- Write a test file directly
-            fs.mkdir(fs.get_root() .. "/workspace")
-            local file_path = fs.get_root() .. "/workspace" .. "/loadtest.json"
-            fs.write(file_path, '{"workspace":"loadtest","window_states":[]}')
-
-            local state = state_manager.load_state("loadtest", "workspace")
-
-            expect(state).to.exist()
-            expect(state.workspace).to.equal("loadtest")
-        end)
-
-        it("emits error for missing file", function()
-            wezterm._test.clear_emitted_events()
-
-            -- file_io.load_json throws for missing files
-            -- state_manager should emit an error event
-            local success, result = pcall(function()
-                return state_manager.load_state("nonexistent", "workspace")
-            end)
-
-            -- Either returns empty table or throws - both are acceptable
-            if success then
-                expect(result).to.exist()
-            end
-        end)
-
-        it("emits start event", function()
-            fs.mkdir(fs.get_root() .. "/workspace")
-            fs.write(fs.get_root() .. "/workspace" .. "/eventtest.json", '{"workspace":"eventtest","window_states":[]}')
-
-            wezterm._test.clear_emitted_events()
-
-            state_manager.load_state("eventtest", "workspace")
-
-            local events = wezterm._test.get_emitted_events()
-            local found = false
-            for _, event in ipairs(events) do
-                if event.name == "resurrect.state_manager.load_state.start" then
-                    found = true
-                    break
-                end
-            end
-            expect(found).to.equal(true)
-        end)
-
-        it("emits finished event on success", function()
-            fs.mkdir(fs.get_root() .. "/workspace")
-            fs.write(fs.get_root() .. "/workspace" .. "/finishtest.json", '{"workspace":"finishtest","window_states":[]}')
-
-            wezterm._test.clear_emitted_events()
-
-            state_manager.load_state("finishtest", "workspace")
-
-            local events = wezterm._test.get_emitted_events()
-            local found = false
-            for _, event in ipairs(events) do
-                if event.name == "resurrect.state_manager.load_state.finished" then
-                    found = true
-                    break
-                end
-            end
-            expect(found).to.equal(true)
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Round-Trip Tests
-    ---------------------------------------------------------------------------
-
-    describe("round-trip", function()
-
-        it("preserves single pane state", function()
-            local workspace = mux.workspace("roundtrip-single")
-                :window("main"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/project", is_active = true })
-                :build()
-
-            mux.set_active(workspace)
-
-            -- Capture and save
-            local original = workspace_state_mod.get_workspace_state()
-            state_manager.save_state(original)
-
-            -- Load back
-            local loaded = state_manager.load_state("roundtrip-single", "workspace")
-
-            expect(loaded.workspace).to.equal(original.workspace)
-            expect(#loaded.window_states).to.equal(#original.window_states)
-        end)
-
-        it("preserves split layout structure", function()
-            local workspace = mux.workspace("roundtrip-split")
-                :window("main")
-                    :tab("editor")
-                        :pane(fixtures.hsplit.panes[1])
-                        :hsplit(fixtures.hsplit.panes[2])
-                :build()
-
-            mux.set_active(workspace)
-
-            -- Capture and save
-            local original = workspace_state_mod.get_workspace_state()
-            state_manager.save_state(original)
-
-            -- Load back
-            local loaded = state_manager.load_state("roundtrip-split", "workspace")
-
-            expect(loaded.workspace).to.equal("roundtrip-split")
-            expect(#loaded.window_states).to.equal(1)
-            expect(#loaded.window_states[1].tabs).to.equal(1)
-
-            -- Verify pane tree structure preserved
-            local original_tree = original.window_states[1].tabs[1].pane_tree
-            local loaded_tree = loaded.window_states[1].tabs[1].pane_tree
-
-            expect(loaded_tree.cwd).to.equal(original_tree.cwd)
-            if original_tree.right then
-                expect(loaded_tree.right).to.exist()
-                expect(loaded_tree.right.cwd).to.equal(original_tree.right.cwd)
-            end
-        end)
-
-        it("preserves complex IDE layout through round-trip", function()
-            local workspace = mux.workspace("roundtrip-ide")
-                :window("main")
-                    :tab("dev")
-                        :pane(fixtures.ide_layout.panes[1])
-                        :hsplit(fixtures.ide_layout.panes[2])
-                        :vsplit(fixtures.ide_layout.panes[3])
-                :build()
-
-            mux.set_active(workspace)
-
-            -- Capture and save
-            local original = workspace_state_mod.get_workspace_state()
-            state_manager.save_state(original)
-
-            -- Load back
-            local loaded = state_manager.load_state("roundtrip-ide", "workspace")
-
-            -- Verify nested structure preserved
-            local loaded_tree = loaded.window_states[1].tabs[1].pane_tree
-
-            expect(loaded_tree).to.exist()
-            expect(loaded_tree.right).to.exist()
-            if loaded_tree.right.bottom then
-                expect(loaded_tree.right.bottom).to.exist()
-            end
-        end)
-
-        it("preserves multiple tabs through round-trip", function()
-            local workspace = mux.workspace("roundtrip-tabs")
-                :window("main")
-                    :tab("Tab 1"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/a", is_active = true })
-                    :tab("Tab 2"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/b", is_active = true })
-                :build()
-
-            mux.set_active(workspace)
-
-            -- Capture and save
-            local original = workspace_state_mod.get_workspace_state()
-            state_manager.save_state(original)
-
-            -- Load back
-            local loaded = state_manager.load_state("roundtrip-tabs", "workspace")
-
-            expect(#loaded.window_states[1].tabs).to.equal(2)
-            expect(loaded.window_states[1].tabs[1].title).to.equal("Tab 1")
-            expect(loaded.window_states[1].tabs[2].title).to.equal("Tab 2")
-        end)
-
-        it("preserves multiple windows through round-trip", function()
-            local workspace = mux.workspace("roundtrip-windows")
-                :window("Window 1"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/a", is_active = true })
-                :window("Window 2"):tab("tab"):pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/b", is_active = true })
-                :build()
-
-            mux.set_active(workspace)
-
-            -- Capture and save
-            local original = workspace_state_mod.get_workspace_state()
-            state_manager.save_state(original)
-
-            -- Load back
-            local loaded = state_manager.load_state("roundtrip-windows", "workspace")
-
-            expect(#loaded.window_states).to.equal(2)
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Error Handling Tests
-    ---------------------------------------------------------------------------
-
-    describe("error handling", function()
-
-        it("emits error for invalid JSON", function()
-            fs.mkdir(fs.get_root() .. "/workspace")
-            fs.write(fs.get_root() .. "/workspace" .. "/invalid.json", "not valid json {{{")
-
-            wezterm._test.clear_emitted_events()
-
-            local state = state_manager.load_state("invalid", "workspace")
-
-            local events = wezterm._test.get_emitted_events()
-            local found_error = false
-            for _, event in ipairs(events) do
-                if event.name == "resurrect.error" then
-                    found_error = true
-                    break
-                end
-            end
-            expect(found_error).to.equal(true)
-        end)
-
-        it("returns empty table for invalid JSON", function()
-            fs.mkdir(fs.get_root() .. "/workspace")
-            fs.write(fs.get_root() .. "/workspace" .. "/bad.json", "{{{{")
-
-            local result = state_manager.load_state("bad", "workspace")
-            expect(next(result)).to.equal(nil)
-        end)
-
-        it("loads state with wrong structure gracefully", function()
-            fs.mkdir(fs.get_root() .. "/workspace")
-            fs.write(fs.get_root() .. "/workspace" .. "/wrong.json", '{"foo": "bar", "baz": 123}')
-
-            local result = state_manager.load_state("wrong", "workspace")
-
-            expect(result.foo).to.equal("bar")
-            expect(result.workspace).to.equal(nil)
-        end)
-
-        it("handles empty JSON object", function()
-            fs.mkdir(fs.get_root() .. "/workspace")
-            fs.write(fs.get_root() .. "/workspace" .. "/empty.json", '{}')
-
-            local result = state_manager.load_state("empty", "workspace")
-
-            expect(type(result)).to.equal("table")
-            expect(result.workspace).to.equal(nil)
-        end)
-
-        it("handles JSON array instead of object", function()
-            fs.mkdir(fs.get_root() .. "/workspace")
-            fs.write(fs.get_root() .. "/workspace" .. "/array.json", '[1, 2, 3]')
-
-            local result = state_manager.load_state("array", "workspace")
-
-            expect(type(result)).to.equal("table")
-            expect(result[1]).to.equal(1)
-        end)
-
-    end)
-
+	before(function()
+		mux.reset()
+		wezterm._test.reset()
+		wezterm._test.set_mux(mux)
+		-- Setup temp directory for tests
+		-- Note: state_manager expects save_state_dir to end with separator
+		local test_root = fs.setup() .. "/"
+		state_manager.change_state_save_dir(test_root)
+	end)
+
+	after(function()
+		fs.teardown()
+	end)
+
+	---------------------------------------------------------------------------
+	-- Save Tests
+	---------------------------------------------------------------------------
+
+	describe("save", function()
+		it("writes JSON file for workspace state", function()
+			local workspace = mux.workspace("myproject")
+				:window("main")
+				:tab("dev")
+				:pane({
+					left = 0,
+					top = 0,
+					width = 160,
+					height = 48,
+					cwd = "/project",
+					is_active = true,
+				})
+				:build()
+
+			mux.set_active(workspace)
+
+			local state = workspace_state_mod.get_workspace_state()
+			state_manager.save_state(state)
+
+			local file_path = fs.get_root() .. "/workspace" .. "/myproject.json"
+			expect(fs.exists(file_path)).to.equal(true)
+		end)
+
+		it("creates valid JSON content", function()
+			local workspace = mux.workspace("jsontest")
+				:window("main")
+				:tab("tab")
+				:pane({
+					left = 0,
+					top = 0,
+					width = 160,
+					height = 48,
+					cwd = "/home",
+					is_active = true,
+				})
+				:build()
+
+			mux.set_active(workspace)
+
+			local state = workspace_state_mod.get_workspace_state()
+			state_manager.save_state(state)
+
+			local file_path = fs.get_root() .. "/workspace" .. "/jsontest.json"
+			local content = fs.read(file_path)
+			expect(content).to.exist()
+
+			-- Should be valid JSON (parseable)
+			local parsed = wezterm.json_parse(content)
+			expect(parsed).to.exist()
+			expect(parsed.workspace).to.equal("jsontest")
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Filename Sanitization Tests
+	---------------------------------------------------------------------------
+
+	describe("filename sanitization", function()
+		it("replaces forward slashes with plus", function()
+			local result = state_manager.sanitize_filename("my/project/name")
+			expect(result).to.equal("my+project+name")
+		end)
+
+		it("replaces backslashes with plus", function()
+			local result = state_manager.sanitize_filename("my\\project\\name")
+			expect(result).to.equal("my+project+name")
+		end)
+
+		it("replaces double dots with underscore", function()
+			local result = state_manager.sanitize_filename("name..test")
+			expect(result).to.equal("name_test")
+		end)
+
+		it("replaces Windows-invalid characters", function()
+			local result = state_manager.sanitize_filename('file<>:"|?*name')
+			expect(result:match('[<>:"|%?%*]')).to_not.exist()
+		end)
+
+		it("trims trailing dots and spaces", function()
+			local result = state_manager.sanitize_filename("filename.  .")
+			expect(result).to.equal("filename")
+		end)
+
+		it("returns _unnamed_ for nil input", function()
+			local result = state_manager.sanitize_filename(nil)
+			expect(result).to.equal("_unnamed_")
+		end)
+
+		it("returns _unnamed_ for empty string", function()
+			local result = state_manager.sanitize_filename("")
+			expect(result).to.equal("_unnamed_")
+		end)
+
+		it("handles complex path-like names", function()
+			local result = state_manager.sanitize_filename("/home/user/project/src")
+			expect(result).to.equal("+home+user+project+src")
+		end)
+
+		it("prevents path traversal attacks", function()
+			local result = state_manager.sanitize_filename("../../../etc/passwd")
+			expect(result:match("%.%.")).to.equal(nil)
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Load Tests
+	---------------------------------------------------------------------------
+
+	describe("load", function()
+		it("parses saved JSON correctly", function()
+			-- Write a test file directly
+			fs.mkdir(fs.get_root() .. "/workspace")
+			local file_path = fs.get_root() .. "/workspace" .. "/loadtest.json"
+			fs.write(file_path, '{"workspace":"loadtest","window_states":[]}')
+
+			local state = state_manager.load_state("loadtest", "workspace")
+
+			expect(state).to.exist()
+			expect(state.workspace).to.equal("loadtest")
+		end)
+
+		it("emits error for missing file", function()
+			wezterm._test.clear_emitted_events()
+
+			-- file_io.load_json throws for missing files
+			-- state_manager should emit an error event
+			local success, result = pcall(function()
+				return state_manager.load_state("nonexistent", "workspace")
+			end)
+
+			-- Either returns empty table or throws - both are acceptable
+			if success then
+				expect(result).to.exist()
+			end
+		end)
+
+		it("emits start event", function()
+			fs.mkdir(fs.get_root() .. "/workspace")
+			fs.write(fs.get_root() .. "/workspace" .. "/eventtest.json", '{"workspace":"eventtest","window_states":[]}')
+
+			wezterm._test.clear_emitted_events()
+
+			state_manager.load_state("eventtest", "workspace")
+
+			local events = wezterm._test.get_emitted_events()
+			local found = false
+			for _, event in ipairs(events) do
+				if event.name == "resurrect.state_manager.load_state.start" then
+					found = true
+					break
+				end
+			end
+			expect(found).to.equal(true)
+		end)
+
+		it("emits finished event on success", function()
+			fs.mkdir(fs.get_root() .. "/workspace")
+			local json_data = '{"workspace":"finishtest","window_states":[]}'
+			fs.write(fs.get_root() .. "/workspace" .. "/finishtest.json", json_data)
+
+			wezterm._test.clear_emitted_events()
+
+			state_manager.load_state("finishtest", "workspace")
+
+			local events = wezterm._test.get_emitted_events()
+			local found = false
+			for _, event in ipairs(events) do
+				if event.name == "resurrect.state_manager.load_state.finished" then
+					found = true
+					break
+				end
+			end
+			expect(found).to.equal(true)
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Round-Trip Tests
+	---------------------------------------------------------------------------
+
+	describe("round-trip", function()
+		it("preserves single pane state", function()
+			local workspace = mux.workspace("roundtrip-single")
+				:window("main")
+				:tab("tab")
+				:pane({
+					left = 0,
+					top = 0,
+					width = 160,
+					height = 48,
+					cwd = "/project",
+					is_active = true,
+				})
+				:build()
+
+			mux.set_active(workspace)
+
+			-- Capture and save
+			local original = workspace_state_mod.get_workspace_state()
+			state_manager.save_state(original)
+
+			-- Load back
+			local loaded = state_manager.load_state("roundtrip-single", "workspace")
+
+			expect(loaded.workspace).to.equal(original.workspace)
+			expect(#loaded.window_states).to.equal(#original.window_states)
+		end)
+
+		it("preserves split layout structure", function()
+			local workspace = mux.workspace("roundtrip-split")
+				:window("main")
+				:tab("editor")
+				:pane(fixtures.hsplit.panes[1])
+				:hsplit(fixtures.hsplit.panes[2])
+				:build()
+
+			mux.set_active(workspace)
+
+			-- Capture and save
+			local original = workspace_state_mod.get_workspace_state()
+			state_manager.save_state(original)
+
+			-- Load back
+			local loaded = state_manager.load_state("roundtrip-split", "workspace")
+
+			expect(loaded.workspace).to.equal("roundtrip-split")
+			expect(#loaded.window_states).to.equal(1)
+			expect(#loaded.window_states[1].tabs).to.equal(1)
+
+			-- Verify pane tree structure preserved
+			local original_tree = original.window_states[1].tabs[1].pane_tree
+			local loaded_tree = loaded.window_states[1].tabs[1].pane_tree
+
+			expect(loaded_tree.cwd).to.equal(original_tree.cwd)
+			if original_tree.right then
+				expect(loaded_tree.right).to.exist()
+				expect(loaded_tree.right.cwd).to.equal(original_tree.right.cwd)
+			end
+		end)
+
+		it("preserves complex IDE layout through round-trip", function()
+			local workspace = mux.workspace("roundtrip-ide")
+				:window("main")
+				:tab("dev")
+				:pane(fixtures.ide_layout.panes[1])
+				:hsplit(fixtures.ide_layout.panes[2])
+				:vsplit(fixtures.ide_layout.panes[3])
+				:build()
+
+			mux.set_active(workspace)
+
+			-- Capture and save
+			local original = workspace_state_mod.get_workspace_state()
+			state_manager.save_state(original)
+
+			-- Load back
+			local loaded = state_manager.load_state("roundtrip-ide", "workspace")
+
+			-- Verify nested structure preserved
+			local loaded_tree = loaded.window_states[1].tabs[1].pane_tree
+
+			expect(loaded_tree).to.exist()
+			expect(loaded_tree.right).to.exist()
+			if loaded_tree.right.bottom then
+				expect(loaded_tree.right.bottom).to.exist()
+			end
+		end)
+
+		it("preserves multiple tabs through round-trip", function()
+			local workspace = mux.workspace("roundtrip-tabs")
+				:window("main")
+				:tab("Tab 1")
+				:pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/a", is_active = true })
+				:tab("Tab 2")
+				:pane({ left = 0, top = 0, width = 160, height = 48, cwd = "/b", is_active = true })
+				:build()
+
+			mux.set_active(workspace)
+
+			-- Capture and save
+			local original = workspace_state_mod.get_workspace_state()
+			state_manager.save_state(original)
+
+			-- Load back
+			local loaded = state_manager.load_state("roundtrip-tabs", "workspace")
+
+			expect(#loaded.window_states[1].tabs).to.equal(2)
+			expect(loaded.window_states[1].tabs[1].title).to.equal("Tab 1")
+			expect(loaded.window_states[1].tabs[2].title).to.equal("Tab 2")
+		end)
+
+		it("preserves multiple windows through round-trip", function()
+			local workspace = mux.workspace("roundtrip-windows")
+				:window("Window 1")
+				:tab("tab")
+				:pane({
+					left = 0,
+					top = 0,
+					width = 160,
+					height = 48,
+					cwd = "/a",
+					is_active = true,
+				})
+				:window("Window 2")
+				:tab("tab")
+				:pane({
+					left = 0,
+					top = 0,
+					width = 160,
+					height = 48,
+					cwd = "/b",
+					is_active = true,
+				})
+				:build()
+
+			mux.set_active(workspace)
+
+			-- Capture and save
+			local original = workspace_state_mod.get_workspace_state()
+			state_manager.save_state(original)
+
+			-- Load back
+			local loaded = state_manager.load_state("roundtrip-windows", "workspace")
+
+			expect(#loaded.window_states).to.equal(2)
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Error Handling Tests
+	---------------------------------------------------------------------------
+
+	describe("error handling", function()
+		it("emits error for invalid JSON", function()
+			fs.mkdir(fs.get_root() .. "/workspace")
+			fs.write(fs.get_root() .. "/workspace" .. "/invalid.json", "not valid json {{{")
+
+			wezterm._test.clear_emitted_events()
+
+			local state = state_manager.load_state("invalid", "workspace")
+
+			local events = wezterm._test.get_emitted_events()
+			local found_error = false
+			for _, event in ipairs(events) do
+				if event.name == "resurrect.error" then
+					found_error = true
+					break
+				end
+			end
+			expect(found_error).to.equal(true)
+		end)
+
+		it("returns empty table for invalid JSON", function()
+			fs.mkdir(fs.get_root() .. "/workspace")
+			fs.write(fs.get_root() .. "/workspace" .. "/bad.json", "{{{{")
+
+			local result = state_manager.load_state("bad", "workspace")
+			expect(next(result)).to.equal(nil)
+		end)
+
+		it("loads state with wrong structure gracefully", function()
+			fs.mkdir(fs.get_root() .. "/workspace")
+			fs.write(fs.get_root() .. "/workspace" .. "/wrong.json", '{"foo": "bar", "baz": 123}')
+
+			local result = state_manager.load_state("wrong", "workspace")
+
+			expect(result.foo).to.equal("bar")
+			expect(result.workspace).to.equal(nil)
+		end)
+
+		it("handles empty JSON object", function()
+			fs.mkdir(fs.get_root() .. "/workspace")
+			fs.write(fs.get_root() .. "/workspace" .. "/empty.json", "{}")
+
+			local result = state_manager.load_state("empty", "workspace")
+
+			expect(type(result)).to.equal("table")
+			expect(result.workspace).to.equal(nil)
+		end)
+
+		it("handles JSON array instead of object", function()
+			fs.mkdir(fs.get_root() .. "/workspace")
+			fs.write(fs.get_root() .. "/workspace" .. "/array.json", "[1, 2, 3]")
+
+			local result = state_manager.load_state("array", "workspace")
+
+			expect(type(result)).to.equal("table")
+			expect(result[1]).to.equal(1)
+		end)
+	end)
 end)

--- a/plugin/resurrect/test/spec/restore_spec.lua
+++ b/plugin/resurrect/test/spec/restore_spec.lua
@@ -1,0 +1,534 @@
+-- Tests for state restore functionality
+-- Verifies that workspace/window/tab/pane state is correctly restored
+
+local mux = require("mux")
+local fixtures = require("pane_layouts")
+
+-- Import modules under test
+local tab_state_mod = require("resurrect.tab_state")
+local window_state_mod = require("resurrect.window_state")
+local workspace_state_mod = require("resurrect.workspace_state")
+
+--------------------------------------------------------------------------------
+-- Setup / Teardown
+--------------------------------------------------------------------------------
+
+describe("State Restore", function()
+
+    before(function()
+        mux.reset()
+        wezterm._test.reset()
+        -- Inject mux fake into wezterm
+        wezterm._test.set_mux(mux)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Workspace Restore Tests
+    ---------------------------------------------------------------------------
+
+    describe("workspace restore", function()
+
+        describe("single pane", function()
+            it("spawns window with correct workspace", function()
+                local state = {
+                    workspace = "test-workspace",
+                    window_states = {
+                        {
+                            title = "main",
+                            tabs = {
+                                {
+                                    title = "tab", is_active = true,
+                                    pane_tree = { cwd = "/project", width = 160, height = 48, left = 0, top = 0, is_active = true },
+                                },
+                            },
+                            size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+                        },
+                    },
+                }
+
+                workspace_state_mod.restore_workspace(state, { spawn_in_workspace = true })
+
+                local windows = mux.all_windows()
+                expect(#windows).to.be.truthy()
+
+                -- Check workspace was set
+                local found = false
+                for _, win in ipairs(windows) do
+                    if win:get_workspace() == "test-workspace" then
+                        found = true
+                        break
+                    end
+                end
+                expect(found).to.equal(true)
+            end)
+
+            it("creates window with correct cwd", function()
+                local state = {
+                    workspace = "test",
+                    window_states = {
+                        {
+                            title = "main",
+                            tabs = {
+                                {
+                                    title = "tab", is_active = true,
+                                    pane_tree = { cwd = "/my/project", width = 160, height = 48, left = 0, top = 0, is_active = true },
+                                },
+                            },
+                            size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+                        },
+                    },
+                }
+
+                workspace_state_mod.restore_workspace(state, {})
+
+                local windows = mux.all_windows()
+                expect(#windows).to.be.truthy()
+            end)
+        end)
+
+        describe("error handling", function()
+            it("emits error for nil state", function()
+                wezterm._test.clear_emitted_events()
+
+                workspace_state_mod.restore_workspace(nil, {})
+
+                local events = wezterm._test.get_emitted_events()
+                local found_error = false
+                for _, event in ipairs(events) do
+                    if event.name == "resurrect.error" then
+                        found_error = true
+                        break
+                    end
+                end
+                expect(found_error).to.equal(true)
+            end)
+
+            it("emits error for empty window_states", function()
+                wezterm._test.clear_emitted_events()
+
+                local state = {
+                    workspace = "empty",
+                    window_states = {},
+                }
+
+                workspace_state_mod.restore_workspace(state, {})
+
+                local events = wezterm._test.get_emitted_events()
+                local found_error = false
+                for _, event in ipairs(events) do
+                    if event.name == "resurrect.error" then
+                        found_error = true
+                        break
+                    end
+                end
+                expect(found_error).to.equal(true)
+            end)
+
+            it("emits error for missing window_states", function()
+                wezterm._test.clear_emitted_events()
+
+                local state = {
+                    workspace = "incomplete",
+                }
+
+                workspace_state_mod.restore_workspace(state, {})
+
+                local events = wezterm._test.get_emitted_events()
+                local found_error = false
+                for _, event in ipairs(events) do
+                    if event.name == "resurrect.error" then
+                        found_error = true
+                        break
+                    end
+                end
+                expect(found_error).to.equal(true)
+            end)
+        end)
+
+        describe("events", function()
+            it("emits start event", function()
+                wezterm._test.clear_emitted_events()
+
+                local state = fixtures.to_workspace_state(fixtures.single_pane)
+                workspace_state_mod.restore_workspace(state, {})
+
+                local events = wezterm._test.get_emitted_events()
+                local found_start = false
+                for _, event in ipairs(events) do
+                    if event.name == "resurrect.workspace_state.restore_workspace.start" then
+                        found_start = true
+                        break
+                    end
+                end
+                expect(found_start).to.equal(true)
+            end)
+
+            it("emits finished event", function()
+                wezterm._test.clear_emitted_events()
+
+                local state = fixtures.to_workspace_state(fixtures.single_pane)
+                workspace_state_mod.restore_workspace(state, {})
+
+                local events = wezterm._test.get_emitted_events()
+                local found_finished = false
+                for _, event in ipairs(events) do
+                    if event.name == "resurrect.workspace_state.restore_workspace.finished" then
+                        found_finished = true
+                        break
+                    end
+                end
+                expect(found_finished).to.equal(true)
+            end)
+        end)
+
+        describe("multiple windows", function()
+            it("creates multiple windows", function()
+                local state = {
+                    workspace = "multi",
+                    window_states = {
+                        {
+                            title = "Window 1",
+                            tabs = {
+                                {
+                                    title = "tab1", is_active = true,
+                                    pane_tree = { cwd = "/project1", width = 160, height = 48, left = 0, top = 0, is_active = true },
+                                },
+                            },
+                            size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+                        },
+                        {
+                            title = "Window 2",
+                            tabs = {
+                                {
+                                    title = "tab2", is_active = true,
+                                    pane_tree = { cwd = "/project2", width = 160, height = 48, left = 0, top = 0, is_active = true },
+                                },
+                            },
+                            size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+                        },
+                    },
+                }
+
+                workspace_state_mod.restore_workspace(state, {})
+
+                local windows = mux.all_windows()
+                expect(#windows >= 2).to.equal(true)
+            end)
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Split Restoration Tests
+    ---------------------------------------------------------------------------
+
+    describe("splits", function()
+
+        it("creates horizontal split structure", function()
+            local state = {
+                workspace = "test",
+                window_states = {
+                    {
+                        title = "win",
+                        tabs = {
+                            {
+                                title = "tab", is_active = true,
+                                pane_tree = {
+                                    cwd = "/left", width = 80, height = 48, left = 0, top = 0, is_active = true,
+                                    right = { cwd = "/right", width = 80, height = 48, left = 81, top = 0 },
+                                },
+                            },
+                        },
+                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+                    },
+                },
+            }
+
+            workspace_state_mod.restore_workspace(state, {})
+
+            -- Verify structure was created
+            local windows = mux.all_windows()
+            expect(#windows >= 1).to.equal(true)
+        end)
+
+        it("creates vertical split structure", function()
+            local state = {
+                workspace = "test",
+                window_states = {
+                    {
+                        title = "win",
+                        tabs = {
+                            {
+                                title = "tab", is_active = true,
+                                pane_tree = {
+                                    cwd = "/top", width = 160, height = 24, left = 0, top = 0, is_active = true,
+                                    bottom = { cwd = "/bottom", width = 160, height = 24, left = 0, top = 25 },
+                                },
+                            },
+                        },
+                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+                    },
+                },
+            }
+
+            workspace_state_mod.restore_workspace(state, {})
+
+            local windows = mux.all_windows()
+            expect(#windows >= 1).to.equal(true)
+        end)
+
+        it("creates nested split structure (IDE layout)", function()
+            local state = {
+                workspace = "test",
+                window_states = {
+                    {
+                        title = "win",
+                        tabs = {
+                            {
+                                title = "tab", is_active = true,
+                                pane_tree = {
+                                    cwd = "/editor", width = 100, height = 48, left = 0, top = 0, is_active = true,
+                                    right = {
+                                        cwd = "/terminal", width = 60, height = 24, left = 101, top = 0,
+                                        bottom = { cwd = "/output", width = 60, height = 24, left = 101, top = 25 },
+                                    },
+                                },
+                            },
+                        },
+                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+                    },
+                },
+            }
+
+            workspace_state_mod.restore_workspace(state, {})
+
+            local windows = mux.all_windows()
+            expect(#windows >= 1).to.equal(true)
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Tab Restoration Tests
+    ---------------------------------------------------------------------------
+
+    describe("tabs", function()
+
+        it("restores tab title", function()
+            local state = {
+                workspace = "test",
+                window_states = {
+                    {
+                        title = "win",
+                        tabs = {
+                            {
+                                title = "My Custom Tab", is_active = true,
+                                pane_tree = { cwd = "/home", width = 160, height = 48, left = 0, top = 0, is_active = true },
+                            },
+                        },
+                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+                    },
+                },
+            }
+
+            workspace_state_mod.restore_workspace(state, {})
+
+            -- The state contains tab title - verify it was in the state
+            expect(state.window_states[1].tabs[1].title).to.equal("My Custom Tab")
+        end)
+
+        it("restores multiple tabs", function()
+            local state = {
+                workspace = "test",
+                window_states = {
+                    {
+                        title = "win",
+                        tabs = {
+                            {
+                                title = "Tab 1",
+                                is_active = true,
+                                pane_tree = { cwd = "/a", width = 160, height = 48, left = 0, top = 0, is_active = true },
+                            },
+                            {
+                                title = "Tab 2",
+                                pane_tree = { cwd = "/b", width = 160, height = 48, left = 0, top = 0, is_active = true },
+                            },
+                            {
+                                title = "Tab 3",
+                                pane_tree = { cwd = "/c", width = 160, height = 48, left = 0, top = 0, is_active = true },
+                            },
+                        },
+                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+                    },
+                },
+            }
+
+            workspace_state_mod.restore_workspace(state, {})
+
+            -- Verify we had 3 tabs in the state
+            expect(#state.window_states[1].tabs).to.equal(3)
+        end)
+
+        it("activates correct tab", function()
+            local state = {
+                workspace = "test",
+                window_states = {
+                    {
+                        title = "win",
+                        tabs = {
+                            {
+                                title = "Tab 1",
+                                is_active = false,
+                                pane_tree = { cwd = "/a", width = 160, height = 48, left = 0, top = 0, is_active = true },
+                            },
+                            {
+                                title = "Tab 2",
+                                is_active = true,
+                                pane_tree = { cwd = "/b", width = 160, height = 48, left = 0, top = 0, is_active = true },
+                            },
+                        },
+                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+                    },
+                },
+            }
+
+            workspace_state_mod.restore_workspace(state, {})
+
+            -- Tab 2 was marked as active
+            expect(state.window_states[1].tabs[2].is_active).to.equal(true)
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Active Pane Tests
+    ---------------------------------------------------------------------------
+
+    describe("active pane", function()
+
+        it("state contains active pane marker", function()
+            local state = {
+                workspace = "test",
+                window_states = {
+                    {
+                        title = "win",
+                        tabs = {
+                            {
+                                title = "tab",
+                                pane_tree = {
+                                    cwd = "/a", width = 80, height = 48, left = 0, top = 0, is_active = false,
+                                    right = { cwd = "/b", width = 80, height = 48, left = 81, top = 0, is_active = true },
+                                },
+                            },
+                        },
+                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+                    },
+                },
+            }
+
+            -- Right pane marked as active
+            expect(state.window_states[1].tabs[1].pane_tree.right.is_active).to.equal(true)
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Options Tests
+    ---------------------------------------------------------------------------
+
+    describe("restore options", function()
+
+        it("accepts relative sizing option", function()
+            local state = fixtures.to_workspace_state(fixtures.hsplit)
+
+            -- Should not throw with relative option
+            workspace_state_mod.restore_workspace(state, { relative = true })
+        end)
+
+        it("accepts absolute sizing option", function()
+            local state = fixtures.to_workspace_state(fixtures.hsplit)
+
+            -- Should not throw with absolute option
+            workspace_state_mod.restore_workspace(state, { absolute = true })
+        end)
+
+        it("accepts spawn_in_workspace option", function()
+            local state = fixtures.to_workspace_state(fixtures.single_pane, "my-workspace")
+
+            workspace_state_mod.restore_workspace(state, { spawn_in_workspace = true })
+
+            -- Windows should be in the specified workspace
+            local windows = mux.all_windows()
+            if #windows > 0 then
+                -- At least one window should be in the workspace
+                local found = false
+                for _, win in ipairs(windows) do
+                    if win:get_workspace() == "my-workspace" then
+                        found = true
+                        break
+                    end
+                end
+                expect(found).to.equal(true)
+            end
+        end)
+
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Default on_pane_restore Tests
+    ---------------------------------------------------------------------------
+
+    describe("default_on_pane_restore", function()
+
+        it("injects text for normal panes", function()
+            local fake_pane = {
+                injected_text = nil,
+                inject_output = function(self, text) self.injected_text = text end,
+                send_text = function(self, text) self.sent_text = text end,
+            }
+
+            local pane_tree = { pane = fake_pane, text = "$ ls\nfile.txt\n$ ", alt_screen_active = false }
+
+            tab_state_mod.default_on_pane_restore(pane_tree)
+
+            expect(fake_pane.injected_text).to.exist()
+            expect(fake_pane.injected_text).to.match("file.txt")
+        end)
+
+        it("sends command for alt screen panes", function()
+            local fake_pane = {
+                injected_text = nil,
+                inject_output = function(self, text) self.injected_text = text end,
+                send_text = function(self, text) self.sent_text = text end,
+            }
+
+            local pane_tree = {
+                pane = fake_pane,
+                alt_screen_active = true,
+                process = { name = "vim", argv = { "vim", "file.txt" }, cwd = "/project", executable = "/usr/bin/vim" },
+            }
+
+            tab_state_mod.default_on_pane_restore(pane_tree)
+
+            expect(fake_pane.sent_text).to.exist()
+            expect(fake_pane.sent_text).to.match("vim")
+        end)
+
+        it("does nothing for panes without text or process", function()
+            local fake_pane = {
+                injected_text = nil,
+                inject_output = function(self, text) self.injected_text = text end,
+                send_text = function(self, text) self.sent_text = text end,
+            }
+
+            local pane_tree = { pane = fake_pane, alt_screen_active = false, text = nil }
+
+            tab_state_mod.default_on_pane_restore(pane_tree)
+
+            expect(fake_pane.injected_text).to_not.exist()
+            expect(fake_pane.sent_text).to_not.exist()
+        end)
+
+    end)
+
+end)

--- a/plugin/resurrect/test/spec/restore_spec.lua
+++ b/plugin/resurrect/test/spec/restore_spec.lua
@@ -14,759 +14,961 @@ local workspace_state_mod = require("resurrect.workspace_state")
 --------------------------------------------------------------------------------
 
 describe("State Restore", function()
-
-    before(function()
-        mux.reset()
-        wezterm._test.reset()
-        -- Inject mux fake into wezterm
-        wezterm._test.set_mux(mux)
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Workspace Restore Tests
-    ---------------------------------------------------------------------------
-
-    describe("workspace restore", function()
-
-        describe("single pane", function()
-            it("spawns window with correct workspace", function()
-                local state = {
-                    workspace = "test-workspace",
-                    window_states = {
-                        {
-                            title = "main",
-                            tabs = {
-                                {
-                                    title = "tab", is_active = true,
-                                    pane_tree = { cwd = "/project", width = 160, height = 48, left = 0, top = 0, is_active = true },
-                                },
-                            },
-                            size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                        },
-                    },
-                }
-
-                workspace_state_mod.restore_workspace(state, { spawn_in_workspace = true })
-
-                local windows = mux.all_windows()
-                expect(#windows).to.be.truthy()
-
-                -- Check workspace was set
-                local found = false
-                for _, win in ipairs(windows) do
-                    if win:get_workspace() == "test-workspace" then
-                        found = true
-                        break
-                    end
-                end
-                expect(found).to.equal(true)
-            end)
-
-            it("creates window with correct cwd", function()
-                local state = {
-                    workspace = "test",
-                    window_states = {
-                        {
-                            title = "main",
-                            tabs = {
-                                {
-                                    title = "tab", is_active = true,
-                                    pane_tree = { cwd = "/my/project", width = 160, height = 48, left = 0, top = 0, is_active = true },
-                                },
-                            },
-                            size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                        },
-                    },
-                }
-
-                workspace_state_mod.restore_workspace(state, {})
-
-                local windows = mux.all_windows()
-                expect(#windows).to.be.truthy()
-            end)
-        end)
-
-        describe("error handling", function()
-            it("emits error for nil state", function()
-                wezterm._test.clear_emitted_events()
-
-                workspace_state_mod.restore_workspace(nil, {})
-
-                local events = wezterm._test.get_emitted_events()
-                local found_error = false
-                for _, event in ipairs(events) do
-                    if event.name == "resurrect.error" then
-                        found_error = true
-                        break
-                    end
-                end
-                expect(found_error).to.equal(true)
-            end)
-
-            it("emits error for empty window_states", function()
-                wezterm._test.clear_emitted_events()
-
-                local state = {
-                    workspace = "empty",
-                    window_states = {},
-                }
-
-                workspace_state_mod.restore_workspace(state, {})
-
-                local events = wezterm._test.get_emitted_events()
-                local found_error = false
-                for _, event in ipairs(events) do
-                    if event.name == "resurrect.error" then
-                        found_error = true
-                        break
-                    end
-                end
-                expect(found_error).to.equal(true)
-            end)
-
-            it("emits error for missing window_states", function()
-                wezterm._test.clear_emitted_events()
-
-                local state = {
-                    workspace = "incomplete",
-                }
-
-                workspace_state_mod.restore_workspace(state, {})
-
-                local events = wezterm._test.get_emitted_events()
-                local found_error = false
-                for _, event in ipairs(events) do
-                    if event.name == "resurrect.error" then
-                        found_error = true
-                        break
-                    end
-                end
-                expect(found_error).to.equal(true)
-            end)
-        end)
-
-        describe("events", function()
-            it("emits start event", function()
-                wezterm._test.clear_emitted_events()
-
-                local state = fixtures.to_workspace_state(fixtures.single_pane)
-                workspace_state_mod.restore_workspace(state, {})
-
-                local events = wezterm._test.get_emitted_events()
-                local found_start = false
-                for _, event in ipairs(events) do
-                    if event.name == "resurrect.workspace_state.restore_workspace.start" then
-                        found_start = true
-                        break
-                    end
-                end
-                expect(found_start).to.equal(true)
-            end)
-
-            it("emits finished event", function()
-                wezterm._test.clear_emitted_events()
-
-                local state = fixtures.to_workspace_state(fixtures.single_pane)
-                workspace_state_mod.restore_workspace(state, {})
-
-                local events = wezterm._test.get_emitted_events()
-                local found_finished = false
-                for _, event in ipairs(events) do
-                    if event.name == "resurrect.workspace_state.restore_workspace.finished" then
-                        found_finished = true
-                        break
-                    end
-                end
-                expect(found_finished).to.equal(true)
-            end)
-        end)
-
-        describe("multiple windows", function()
-            it("creates multiple windows", function()
-                local state = {
-                    workspace = "multi",
-                    window_states = {
-                        {
-                            title = "Window 1",
-                            tabs = {
-                                {
-                                    title = "tab1", is_active = true,
-                                    pane_tree = { cwd = "/project1", width = 160, height = 48, left = 0, top = 0, is_active = true },
-                                },
-                            },
-                            size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                        },
-                        {
-                            title = "Window 2",
-                            tabs = {
-                                {
-                                    title = "tab2", is_active = true,
-                                    pane_tree = { cwd = "/project2", width = 160, height = 48, left = 0, top = 0, is_active = true },
-                                },
-                            },
-                            size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                        },
-                    },
-                }
-
-                workspace_state_mod.restore_workspace(state, {})
-
-                local windows = mux.all_windows()
-                expect(#windows >= 2).to.equal(true)
-            end)
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Split Restoration Tests
-    ---------------------------------------------------------------------------
-
-    describe("splits", function()
-
-        it("creates horizontal split structure", function()
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        title = "win",
-                        tabs = {
-                            {
-                                title = "tab", is_active = true,
-                                pane_tree = {
-                                    cwd = "/left", width = 80, height = 48, left = 0, top = 0, is_active = true,
-                                    right = { cwd = "/right", width = 80, height = 48, left = 81, top = 0 },
-                                },
-                            },
-                        },
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            workspace_state_mod.restore_workspace(state, {})
-
-            -- Verify structure was created
-            local windows = mux.all_windows()
-            expect(#windows >= 1).to.equal(true)
-        end)
-
-        it("creates vertical split structure", function()
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        title = "win",
-                        tabs = {
-                            {
-                                title = "tab", is_active = true,
-                                pane_tree = {
-                                    cwd = "/top", width = 160, height = 24, left = 0, top = 0, is_active = true,
-                                    bottom = { cwd = "/bottom", width = 160, height = 24, left = 0, top = 25 },
-                                },
-                            },
-                        },
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            workspace_state_mod.restore_workspace(state, {})
-
-            local windows = mux.all_windows()
-            expect(#windows >= 1).to.equal(true)
-        end)
-
-        it("creates nested split structure (IDE layout)", function()
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        title = "win",
-                        tabs = {
-                            {
-                                title = "tab", is_active = true,
-                                pane_tree = {
-                                    cwd = "/editor", width = 100, height = 48, left = 0, top = 0, is_active = true,
-                                    right = {
-                                        cwd = "/terminal", width = 60, height = 24, left = 101, top = 0,
-                                        bottom = { cwd = "/output", width = 60, height = 24, left = 101, top = 25 },
-                                    },
-                                },
-                            },
-                        },
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            workspace_state_mod.restore_workspace(state, {})
-
-            local windows = mux.all_windows()
-            expect(#windows >= 1).to.equal(true)
-        end)
-
-        it("creates three-way horizontal split", function()
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        title = "win",
-                        tabs = {
-                            {
-                                title = "tab", is_active = true,
-                                pane_tree = {
-                                    cwd = "/a", width = 53, height = 48, left = 0, top = 0, is_active = true,
-                                    right = {
-                                        cwd = "/b", width = 53, height = 48, left = 54, top = 0,
-                                        right = { cwd = "/c", width = 53, height = 48, left = 108, top = 0 },
-                                    },
-                                },
-                            },
-                        },
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            workspace_state_mod.restore_workspace(state, {})
-
-            local windows = mux.all_windows()
-            expect(#windows >= 1).to.equal(true)
-        end)
-
-        it("restores grid 2x2 layout", function()
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        title = "win",
-                        tabs = {
-                            {
-                                title = "tab", is_active = true,
-                                pane_tree = {
-                                    cwd = "/tl", width = 80, height = 24, left = 0, top = 0, is_active = true,
-                                    right = { cwd = "/tr", width = 80, height = 24, left = 81, top = 0 },
-                                    bottom = {
-                                        cwd = "/bl", width = 80, height = 24, left = 0, top = 25,
-                                        right = { cwd = "/br", width = 80, height = 24, left = 81, top = 25 },
-                                    },
-                                },
-                            },
-                        },
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            workspace_state_mod.restore_workspace(state, {})
-
-            local windows = mux.all_windows()
-            expect(#windows >= 1).to.equal(true)
-        end)
-
-        it("preserves pane cwd values in state", function()
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        title = "win",
-                        tabs = {
-                            {
-                                title = "tab", is_active = true,
-                                pane_tree = {
-                                    cwd = "/project/src", width = 80, height = 48, left = 0, top = 0, is_active = true,
-                                    right = { cwd = "/project/tests", width = 80, height = 48, left = 81, top = 0 },
-                                },
-                            },
-                        },
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            -- Verify the state has the correct cwd values
-            expect(state.window_states[1].tabs[1].pane_tree.cwd).to.equal("/project/src")
-            expect(state.window_states[1].tabs[1].pane_tree.right.cwd).to.equal("/project/tests")
-
-            workspace_state_mod.restore_workspace(state, {})
-
-            local windows = mux.all_windows()
-            expect(#windows >= 1).to.equal(true)
-        end)
-
-        it("preserves pane position values in nested splits", function()
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        title = "win",
-                        tabs = {
-                            {
-                                title = "tab", is_active = true,
-                                pane_tree = {
-                                    cwd = "/a", width = 100, height = 48, left = 0, top = 0, is_active = true,
-                                    right = {
-                                        cwd = "/b", width = 60, height = 24, left = 101, top = 0,
-                                        bottom = { cwd = "/c", width = 60, height = 24, left = 101, top = 25 },
-                                    },
-                                },
-                            },
-                        },
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            -- Verify pane positions in state
-            expect(state.window_states[1].tabs[1].pane_tree.left).to.equal(0)
-            expect(state.window_states[1].tabs[1].pane_tree.right.left).to.equal(101)
-            expect(state.window_states[1].tabs[1].pane_tree.right.bottom.top).to.equal(25)
-
-            workspace_state_mod.restore_workspace(state, {})
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Tab Restoration Tests
-    ---------------------------------------------------------------------------
-
-    describe("tabs", function()
-
-        it("restores tab title", function()
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        title = "win",
-                        tabs = {
-                            {
-                                title = "My Custom Tab", is_active = true,
-                                pane_tree = { cwd = "/home", width = 160, height = 48, left = 0, top = 0, is_active = true },
-                            },
-                        },
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            workspace_state_mod.restore_workspace(state, {})
-
-            -- The state contains tab title - verify it was in the state
-            expect(state.window_states[1].tabs[1].title).to.equal("My Custom Tab")
-        end)
-
-        it("restores multiple tabs", function()
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        title = "win",
-                        tabs = {
-                            {
-                                title = "Tab 1",
-                                is_active = true,
-                                pane_tree = { cwd = "/a", width = 160, height = 48, left = 0, top = 0, is_active = true },
-                            },
-                            {
-                                title = "Tab 2",
-                                pane_tree = { cwd = "/b", width = 160, height = 48, left = 0, top = 0, is_active = true },
-                            },
-                            {
-                                title = "Tab 3",
-                                pane_tree = { cwd = "/c", width = 160, height = 48, left = 0, top = 0, is_active = true },
-                            },
-                        },
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            workspace_state_mod.restore_workspace(state, {})
-
-            -- Verify we had 3 tabs in the state
-            expect(#state.window_states[1].tabs).to.equal(3)
-        end)
-
-        it("activates correct tab", function()
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        title = "win",
-                        tabs = {
-                            {
-                                title = "Tab 1",
-                                is_active = false,
-                                pane_tree = { cwd = "/a", width = 160, height = 48, left = 0, top = 0, is_active = true },
-                            },
-                            {
-                                title = "Tab 2",
-                                is_active = true,
-                                pane_tree = { cwd = "/b", width = 160, height = 48, left = 0, top = 0, is_active = true },
-                            },
-                        },
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            workspace_state_mod.restore_workspace(state, {})
-
-            -- Tab 2 was marked as active
-            expect(state.window_states[1].tabs[2].is_active).to.equal(true)
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Active Pane Tests
-    ---------------------------------------------------------------------------
-
-    describe("active pane", function()
-
-        it("state contains active pane marker", function()
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        title = "win",
-                        tabs = {
-                            {
-                                title = "tab",
-                                pane_tree = {
-                                    cwd = "/a", width = 80, height = 48, left = 0, top = 0, is_active = false,
-                                    right = { cwd = "/b", width = 80, height = 48, left = 81, top = 0, is_active = true },
-                                },
-                            },
-                        },
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            -- Right pane marked as active
-            expect(state.window_states[1].tabs[1].pane_tree.right.is_active).to.equal(true)
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Options Tests
-    ---------------------------------------------------------------------------
-
-    describe("restore options", function()
-
-        it("accepts relative sizing option", function()
-            local state = fixtures.to_workspace_state(fixtures.hsplit)
-
-            -- Should not throw with relative option
-            workspace_state_mod.restore_workspace(state, { relative = true })
-        end)
-
-        it("accepts absolute sizing option", function()
-            local state = fixtures.to_workspace_state(fixtures.hsplit)
-
-            -- Should not throw with absolute option
-            workspace_state_mod.restore_workspace(state, { absolute = true })
-        end)
-
-        it("accepts spawn_in_workspace option", function()
-            local state = fixtures.to_workspace_state(fixtures.single_pane, "my-workspace")
-
-            workspace_state_mod.restore_workspace(state, { spawn_in_workspace = true })
-
-            -- Windows should be in the specified workspace
-            local windows = mux.all_windows()
-            if #windows > 0 then
-                -- At least one window should be in the workspace
-                local found = false
-                for _, win in ipairs(windows) do
-                    if win:get_workspace() == "my-workspace" then
-                        found = true
-                        break
-                    end
-                end
-                expect(found).to.equal(true)
-            end
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Default on_pane_restore Tests
-    ---------------------------------------------------------------------------
-
-    describe("default_on_pane_restore", function()
-
-        it("injects text for normal panes", function()
-            local fake_pane = {
-                injected_text = nil,
-                inject_output = function(self, text) self.injected_text = text end,
-                send_text = function(self, text) self.sent_text = text end,
-            }
-
-            local pane_tree = { pane = fake_pane, text = "$ ls\nfile.txt\n$ ", alt_screen_active = false }
-
-            tab_state_mod.default_on_pane_restore(pane_tree)
-
-            expect(fake_pane.injected_text).to.exist()
-            expect(fake_pane.injected_text).to.match("file.txt")
-        end)
-
-        it("sends command for alt screen panes", function()
-            local fake_pane = {
-                injected_text = nil,
-                inject_output = function(self, text) self.injected_text = text end,
-                send_text = function(self, text) self.sent_text = text end,
-            }
-
-            local pane_tree = {
-                pane = fake_pane,
-                alt_screen_active = true,
-                process = { name = "vim", argv = { "vim", "file.txt" }, cwd = "/project", executable = "/usr/bin/vim" },
-            }
-
-            tab_state_mod.default_on_pane_restore(pane_tree)
-
-            expect(fake_pane.sent_text).to.exist()
-            expect(fake_pane.sent_text).to.match("vim")
-        end)
-
-        it("does nothing for panes without text or process", function()
-            local fake_pane = {
-                injected_text = nil,
-                inject_output = function(self, text) self.injected_text = text end,
-                send_text = function(self, text) self.sent_text = text end,
-            }
-
-            local pane_tree = { pane = fake_pane, alt_screen_active = false, text = nil }
-
-            tab_state_mod.default_on_pane_restore(pane_tree)
-
-            expect(fake_pane.injected_text).to_not.exist()
-            expect(fake_pane.sent_text).to_not.exist()
-        end)
-
-        it("handles empty text", function()
-            local fake_pane = {
-                injected_text = nil,
-                inject_output = function(self, text) self.injected_text = text end,
-            }
-            local pane_tree = { pane = fake_pane, alt_screen_active = false, text = "" }
-
-            tab_state_mod.default_on_pane_restore(pane_tree)
-
-            expect(fake_pane.injected_text).to.equal("")
-        end)
-
-    end)
-
-    ---------------------------------------------------------------------------
-    -- Malformed Data Tests
-    ---------------------------------------------------------------------------
-
-    describe("malformed data", function()
-
-        it("handles pane tree with missing cwd", function()
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        title = "win",
-                        tabs = {{ title = "tab", is_active = true, pane_tree = { width = 160, height = 48, left = 0, top = 0, is_active = true } }},
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            local success = pcall(function()
-                workspace_state_mod.restore_workspace(state, {})
-            end)
-            expect(success).to.equal(true)
-        end)
-
-        it("handles pane tree with missing dimensions", function()
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        title = "win",
-                        tabs = {{ title = "tab", is_active = true, pane_tree = { cwd = "/home", left = 0, top = 0, is_active = true } }},
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            local success = pcall(function()
-                workspace_state_mod.restore_workspace(state, {})
-            end)
-            expect(success).to.equal(true)
-        end)
-
-        it("handles tab state with missing title", function()
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        title = "win",
-                        tabs = {{ is_active = true, pane_tree = { cwd = "/home", width = 160, height = 48, left = 0, top = 0, is_active = true } }},
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            local success = pcall(function()
-                workspace_state_mod.restore_workspace(state, {})
-            end)
-            expect(success).to.equal(true)
-        end)
-
-        it("handles window state with missing title", function()
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        tabs = {{ title = "tab", is_active = true, pane_tree = { cwd = "/home", width = 160, height = 48, left = 0, top = 0, is_active = true } }},
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            local success = pcall(function()
-                workspace_state_mod.restore_workspace(state, {})
-            end)
-            expect(success).to.equal(true)
-        end)
-
-        it("handles mixed spawnable domains with fallback", function()
-            mux.set_domain_spawnable("SSH:dev", false)
-            mux.set_domain_spawnable("local", true)
-
-            local state = {
-                workspace = "test",
-                window_states = {
-                    {
-                        title = "win",
-                        tabs = {{
-                            title = "tab", is_active = true,
-                            pane_tree = {
-                                cwd = "/local", width = 80, height = 48, left = 0, top = 0, is_active = true, domain = "local",
-                                right = { cwd = "/remote", width = 80, height = 48, left = 81, top = 0, domain = "SSH:dev" },
-                            },
-                        }},
-                        size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
-                    },
-                },
-            }
-
-            local success = pcall(function()
-                workspace_state_mod.restore_workspace(state, {})
-            end)
-            expect(success).to.equal(true)
-        end)
-
-    end)
-
+	before(function()
+		mux.reset()
+		wezterm._test.reset()
+		-- Inject mux fake into wezterm
+		wezterm._test.set_mux(mux)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Workspace Restore Tests
+	---------------------------------------------------------------------------
+
+	describe("workspace restore", function()
+		describe("single pane", function()
+			it("spawns window with correct workspace", function()
+				local state = {
+					workspace = "test-workspace",
+					window_states = {
+						{
+							title = "main",
+							tabs = {
+								{
+									title = "tab",
+									is_active = true,
+									pane_tree = {
+										cwd = "/project",
+										width = 160,
+										height = 48,
+										left = 0,
+										top = 0,
+										is_active = true,
+									},
+								},
+							},
+							size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+						},
+					},
+				}
+
+				workspace_state_mod.restore_workspace(state, { spawn_in_workspace = true })
+
+				local windows = mux.all_windows()
+				expect(#windows).to.be.truthy()
+
+				-- Check workspace was set
+				local found = false
+				for _, win in ipairs(windows) do
+					if win:get_workspace() == "test-workspace" then
+						found = true
+						break
+					end
+				end
+				expect(found).to.equal(true)
+			end)
+
+			it("creates window with correct cwd", function()
+				local state = {
+					workspace = "test",
+					window_states = {
+						{
+							title = "main",
+							tabs = {
+								{
+									title = "tab",
+									is_active = true,
+									pane_tree = {
+										cwd = "/my/project",
+										width = 160,
+										height = 48,
+										left = 0,
+										top = 0,
+										is_active = true,
+									},
+								},
+							},
+							size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+						},
+					},
+				}
+
+				workspace_state_mod.restore_workspace(state, {})
+
+				local windows = mux.all_windows()
+				expect(#windows).to.be.truthy()
+			end)
+		end)
+
+		describe("error handling", function()
+			it("emits error for nil state", function()
+				wezterm._test.clear_emitted_events()
+
+				workspace_state_mod.restore_workspace(nil, {})
+
+				local events = wezterm._test.get_emitted_events()
+				local found_error = false
+				for _, event in ipairs(events) do
+					if event.name == "resurrect.error" then
+						found_error = true
+						break
+					end
+				end
+				expect(found_error).to.equal(true)
+			end)
+
+			it("emits error for empty window_states", function()
+				wezterm._test.clear_emitted_events()
+
+				local state = {
+					workspace = "empty",
+					window_states = {},
+				}
+
+				workspace_state_mod.restore_workspace(state, {})
+
+				local events = wezterm._test.get_emitted_events()
+				local found_error = false
+				for _, event in ipairs(events) do
+					if event.name == "resurrect.error" then
+						found_error = true
+						break
+					end
+				end
+				expect(found_error).to.equal(true)
+			end)
+
+			it("emits error for missing window_states", function()
+				wezterm._test.clear_emitted_events()
+
+				local state = {
+					workspace = "incomplete",
+				}
+
+				workspace_state_mod.restore_workspace(state, {})
+
+				local events = wezterm._test.get_emitted_events()
+				local found_error = false
+				for _, event in ipairs(events) do
+					if event.name == "resurrect.error" then
+						found_error = true
+						break
+					end
+				end
+				expect(found_error).to.equal(true)
+			end)
+		end)
+
+		describe("events", function()
+			it("emits start event", function()
+				wezterm._test.clear_emitted_events()
+
+				local state = fixtures.to_workspace_state(fixtures.single_pane)
+				workspace_state_mod.restore_workspace(state, {})
+
+				local events = wezterm._test.get_emitted_events()
+				local found_start = false
+				for _, event in ipairs(events) do
+					if event.name == "resurrect.workspace_state.restore_workspace.start" then
+						found_start = true
+						break
+					end
+				end
+				expect(found_start).to.equal(true)
+			end)
+
+			it("emits finished event", function()
+				wezterm._test.clear_emitted_events()
+
+				local state = fixtures.to_workspace_state(fixtures.single_pane)
+				workspace_state_mod.restore_workspace(state, {})
+
+				local events = wezterm._test.get_emitted_events()
+				local found_finished = false
+				for _, event in ipairs(events) do
+					if event.name == "resurrect.workspace_state.restore_workspace.finished" then
+						found_finished = true
+						break
+					end
+				end
+				expect(found_finished).to.equal(true)
+			end)
+		end)
+
+		describe("multiple windows", function()
+			it("creates multiple windows", function()
+				local state = {
+					workspace = "multi",
+					window_states = {
+						{
+							title = "Window 1",
+							tabs = {
+								{
+									title = "tab1",
+									is_active = true,
+									pane_tree = {
+										cwd = "/project1",
+										width = 160,
+										height = 48,
+										left = 0,
+										top = 0,
+										is_active = true,
+									},
+								},
+							},
+							size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+						},
+						{
+							title = "Window 2",
+							tabs = {
+								{
+									title = "tab2",
+									is_active = true,
+									pane_tree = {
+										cwd = "/project2",
+										width = 160,
+										height = 48,
+										left = 0,
+										top = 0,
+										is_active = true,
+									},
+								},
+							},
+							size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+						},
+					},
+				}
+
+				workspace_state_mod.restore_workspace(state, {})
+
+				local windows = mux.all_windows()
+				expect(#windows >= 2).to.equal(true)
+			end)
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Split Restoration Tests
+	---------------------------------------------------------------------------
+
+	describe("splits", function()
+		it("creates horizontal split structure", function()
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						title = "win",
+						tabs = {
+							{
+								title = "tab",
+								is_active = true,
+								pane_tree = {
+									cwd = "/left",
+									width = 80,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = true,
+									right = { cwd = "/right", width = 80, height = 48, left = 81, top = 0 },
+								},
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			workspace_state_mod.restore_workspace(state, {})
+
+			-- Verify structure was created
+			local windows = mux.all_windows()
+			expect(#windows >= 1).to.equal(true)
+		end)
+
+		it("creates vertical split structure", function()
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						title = "win",
+						tabs = {
+							{
+								title = "tab",
+								is_active = true,
+								pane_tree = {
+									cwd = "/top",
+									width = 160,
+									height = 24,
+									left = 0,
+									top = 0,
+									is_active = true,
+									bottom = { cwd = "/bottom", width = 160, height = 24, left = 0, top = 25 },
+								},
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			workspace_state_mod.restore_workspace(state, {})
+
+			local windows = mux.all_windows()
+			expect(#windows >= 1).to.equal(true)
+		end)
+
+		it("creates nested split structure (IDE layout)", function()
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						title = "win",
+						tabs = {
+							{
+								title = "tab",
+								is_active = true,
+								pane_tree = {
+									cwd = "/editor",
+									width = 100,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = true,
+									right = {
+										cwd = "/terminal",
+										width = 60,
+										height = 24,
+										left = 101,
+										top = 0,
+										bottom = { cwd = "/output", width = 60, height = 24, left = 101, top = 25 },
+									},
+								},
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			workspace_state_mod.restore_workspace(state, {})
+
+			local windows = mux.all_windows()
+			expect(#windows >= 1).to.equal(true)
+		end)
+
+		it("creates three-way horizontal split", function()
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						title = "win",
+						tabs = {
+							{
+								title = "tab",
+								is_active = true,
+								pane_tree = {
+									cwd = "/a",
+									width = 53,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = true,
+									right = {
+										cwd = "/b",
+										width = 53,
+										height = 48,
+										left = 54,
+										top = 0,
+										right = { cwd = "/c", width = 53, height = 48, left = 108, top = 0 },
+									},
+								},
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			workspace_state_mod.restore_workspace(state, {})
+
+			local windows = mux.all_windows()
+			expect(#windows >= 1).to.equal(true)
+		end)
+
+		it("restores grid 2x2 layout", function()
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						title = "win",
+						tabs = {
+							{
+								title = "tab",
+								is_active = true,
+								pane_tree = {
+									cwd = "/tl",
+									width = 80,
+									height = 24,
+									left = 0,
+									top = 0,
+									is_active = true,
+									right = { cwd = "/tr", width = 80, height = 24, left = 81, top = 0 },
+									bottom = {
+										cwd = "/bl",
+										width = 80,
+										height = 24,
+										left = 0,
+										top = 25,
+										right = { cwd = "/br", width = 80, height = 24, left = 81, top = 25 },
+									},
+								},
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			workspace_state_mod.restore_workspace(state, {})
+
+			local windows = mux.all_windows()
+			expect(#windows >= 1).to.equal(true)
+		end)
+
+		it("preserves pane cwd values in state", function()
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						title = "win",
+						tabs = {
+							{
+								title = "tab",
+								is_active = true,
+								pane_tree = {
+									cwd = "/project/src",
+									width = 80,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = true,
+									right = { cwd = "/project/tests", width = 80, height = 48, left = 81, top = 0 },
+								},
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			-- Verify the state has the correct cwd values
+			expect(state.window_states[1].tabs[1].pane_tree.cwd).to.equal("/project/src")
+			expect(state.window_states[1].tabs[1].pane_tree.right.cwd).to.equal("/project/tests")
+
+			workspace_state_mod.restore_workspace(state, {})
+
+			local windows = mux.all_windows()
+			expect(#windows >= 1).to.equal(true)
+		end)
+
+		it("preserves pane position values in nested splits", function()
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						title = "win",
+						tabs = {
+							{
+								title = "tab",
+								is_active = true,
+								pane_tree = {
+									cwd = "/a",
+									width = 100,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = true,
+									right = {
+										cwd = "/b",
+										width = 60,
+										height = 24,
+										left = 101,
+										top = 0,
+										bottom = { cwd = "/c", width = 60, height = 24, left = 101, top = 25 },
+									},
+								},
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			-- Verify pane positions in state
+			expect(state.window_states[1].tabs[1].pane_tree.left).to.equal(0)
+			expect(state.window_states[1].tabs[1].pane_tree.right.left).to.equal(101)
+			expect(state.window_states[1].tabs[1].pane_tree.right.bottom.top).to.equal(25)
+
+			workspace_state_mod.restore_workspace(state, {})
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Tab Restoration Tests
+	---------------------------------------------------------------------------
+
+	describe("tabs", function()
+		it("restores tab title", function()
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						title = "win",
+						tabs = {
+							{
+								title = "My Custom Tab",
+								is_active = true,
+								pane_tree = {
+									cwd = "/home",
+									width = 160,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = true,
+								},
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			workspace_state_mod.restore_workspace(state, {})
+
+			-- The state contains tab title - verify it was in the state
+			expect(state.window_states[1].tabs[1].title).to.equal("My Custom Tab")
+		end)
+
+		it("restores multiple tabs", function()
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						title = "win",
+						tabs = {
+							{
+								title = "Tab 1",
+								is_active = true,
+								pane_tree = {
+									cwd = "/a",
+									width = 160,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = true,
+								},
+							},
+							{
+								title = "Tab 2",
+								pane_tree = {
+									cwd = "/b",
+									width = 160,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = true,
+								},
+							},
+							{
+								title = "Tab 3",
+								pane_tree = {
+									cwd = "/c",
+									width = 160,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = true,
+								},
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			workspace_state_mod.restore_workspace(state, {})
+
+			-- Verify we had 3 tabs in the state
+			expect(#state.window_states[1].tabs).to.equal(3)
+		end)
+
+		it("activates correct tab", function()
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						title = "win",
+						tabs = {
+							{
+								title = "Tab 1",
+								is_active = false,
+								pane_tree = {
+									cwd = "/a",
+									width = 160,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = true,
+								},
+							},
+							{
+								title = "Tab 2",
+								is_active = true,
+								pane_tree = {
+									cwd = "/b",
+									width = 160,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = true,
+								},
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			workspace_state_mod.restore_workspace(state, {})
+
+			-- Tab 2 was marked as active
+			expect(state.window_states[1].tabs[2].is_active).to.equal(true)
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Active Pane Tests
+	---------------------------------------------------------------------------
+
+	describe("active pane", function()
+		it("state contains active pane marker", function()
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						title = "win",
+						tabs = {
+							{
+								title = "tab",
+								pane_tree = {
+									cwd = "/a",
+									width = 80,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = false,
+									right = {
+										cwd = "/b",
+										width = 80,
+										height = 48,
+										left = 81,
+										top = 0,
+										is_active = true,
+									},
+								},
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			-- Right pane marked as active
+			expect(state.window_states[1].tabs[1].pane_tree.right.is_active).to.equal(true)
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Options Tests
+	---------------------------------------------------------------------------
+
+	describe("restore options", function()
+		it("accepts relative sizing option", function()
+			local state = fixtures.to_workspace_state(fixtures.hsplit)
+
+			-- Should not throw with relative option
+			workspace_state_mod.restore_workspace(state, { relative = true })
+		end)
+
+		it("accepts absolute sizing option", function()
+			local state = fixtures.to_workspace_state(fixtures.hsplit)
+
+			-- Should not throw with absolute option
+			workspace_state_mod.restore_workspace(state, { absolute = true })
+		end)
+
+		it("accepts spawn_in_workspace option", function()
+			local state = fixtures.to_workspace_state(fixtures.single_pane, "my-workspace")
+
+			workspace_state_mod.restore_workspace(state, { spawn_in_workspace = true })
+
+			-- Windows should be in the specified workspace
+			local windows = mux.all_windows()
+			if #windows > 0 then
+				-- At least one window should be in the workspace
+				local found = false
+				for _, win in ipairs(windows) do
+					if win:get_workspace() == "my-workspace" then
+						found = true
+						break
+					end
+				end
+				expect(found).to.equal(true)
+			end
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Default on_pane_restore Tests
+	---------------------------------------------------------------------------
+
+	describe("default_on_pane_restore", function()
+		it("injects text for normal panes", function()
+			local fake_pane = {
+				injected_text = nil,
+				inject_output = function(self, text)
+					self.injected_text = text
+				end,
+				send_text = function(self, text)
+					self.sent_text = text
+				end,
+			}
+
+			local pane_tree = { pane = fake_pane, text = "$ ls\nfile.txt\n$ ", alt_screen_active = false }
+
+			tab_state_mod.default_on_pane_restore(pane_tree)
+
+			expect(fake_pane.injected_text).to.exist()
+			expect(fake_pane.injected_text).to.match("file.txt")
+		end)
+
+		it("sends command for alt screen panes", function()
+			local fake_pane = {
+				injected_text = nil,
+				inject_output = function(self, text)
+					self.injected_text = text
+				end,
+				send_text = function(self, text)
+					self.sent_text = text
+				end,
+			}
+
+			local pane_tree = {
+				pane = fake_pane,
+				alt_screen_active = true,
+				process = { name = "vim", argv = { "vim", "file.txt" }, cwd = "/project", executable = "/usr/bin/vim" },
+			}
+
+			tab_state_mod.default_on_pane_restore(pane_tree)
+
+			expect(fake_pane.sent_text).to.exist()
+			expect(fake_pane.sent_text).to.match("vim")
+		end)
+
+		it("does nothing for panes without text or process", function()
+			local fake_pane = {
+				injected_text = nil,
+				inject_output = function(self, text)
+					self.injected_text = text
+				end,
+				send_text = function(self, text)
+					self.sent_text = text
+				end,
+			}
+
+			local pane_tree = { pane = fake_pane, alt_screen_active = false, text = nil }
+
+			tab_state_mod.default_on_pane_restore(pane_tree)
+
+			expect(fake_pane.injected_text).to_not.exist()
+			expect(fake_pane.sent_text).to_not.exist()
+		end)
+
+		it("handles empty text", function()
+			local fake_pane = {
+				injected_text = nil,
+				inject_output = function(self, text)
+					self.injected_text = text
+				end,
+			}
+			local pane_tree = { pane = fake_pane, alt_screen_active = false, text = "" }
+
+			tab_state_mod.default_on_pane_restore(pane_tree)
+
+			expect(fake_pane.injected_text).to.equal("")
+		end)
+	end)
+
+	---------------------------------------------------------------------------
+	-- Malformed Data Tests
+	---------------------------------------------------------------------------
+
+	describe("malformed data", function()
+		it("handles pane tree with missing cwd", function()
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						title = "win",
+						tabs = {
+							{
+								title = "tab",
+								is_active = true,
+								pane_tree = {
+									width = 160,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = true,
+								},
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			local success = pcall(function()
+				workspace_state_mod.restore_workspace(state, {})
+			end)
+			expect(success).to.equal(true)
+		end)
+
+		it("handles pane tree with missing dimensions", function()
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						title = "win",
+						tabs = {
+							{
+								title = "tab",
+								is_active = true,
+								pane_tree = { cwd = "/home", left = 0, top = 0, is_active = true },
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			local success = pcall(function()
+				workspace_state_mod.restore_workspace(state, {})
+			end)
+			expect(success).to.equal(true)
+		end)
+
+		it("handles tab state with missing title", function()
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						title = "win",
+						tabs = {
+							{
+								is_active = true,
+								pane_tree = {
+									cwd = "/home",
+									width = 160,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = true,
+								},
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			local success = pcall(function()
+				workspace_state_mod.restore_workspace(state, {})
+			end)
+			expect(success).to.equal(true)
+		end)
+
+		it("handles window state with missing title", function()
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						tabs = {
+							{
+								title = "tab",
+								is_active = true,
+								pane_tree = {
+									cwd = "/home",
+									width = 160,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = true,
+								},
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			local success = pcall(function()
+				workspace_state_mod.restore_workspace(state, {})
+			end)
+			expect(success).to.equal(true)
+		end)
+
+		it("handles mixed spawnable domains with fallback", function()
+			mux.set_domain_spawnable("SSH:dev", false)
+			mux.set_domain_spawnable("local", true)
+
+			local state = {
+				workspace = "test",
+				window_states = {
+					{
+						title = "win",
+						tabs = {
+							{
+								title = "tab",
+								is_active = true,
+								pane_tree = {
+									cwd = "/local",
+									width = 80,
+									height = 48,
+									left = 0,
+									top = 0,
+									is_active = true,
+									domain = "local",
+									right = {
+										cwd = "/remote",
+										width = 80,
+										height = 48,
+										left = 81,
+										top = 0,
+										domain = "SSH:dev",
+									},
+								},
+							},
+						},
+						size = { cols = 160, rows = 48, pixel_width = 1600, pixel_height = 960 },
+					},
+				},
+			}
+
+			local success = pcall(function()
+				workspace_state_mod.restore_workspace(state, {})
+			end)
+			expect(success).to.equal(true)
+		end)
+	end)
 end)

--- a/plugin/resurrect/test/test_state_manager.lua
+++ b/plugin/resurrect/test/test_state_manager.lua
@@ -27,6 +27,6 @@ describe("sanitize_filename()", function()
 	it("returns _unnamed_ for empty/nil input", function()
 		expect(state_manager.sanitize_filename(nil)).to.equal("_unnamed_")
 		expect(state_manager.sanitize_filename("")).to.equal("_unnamed_")
-		expect(state_manager.sanitize_filename("   ")).to.equal("_unnamed_")  -- whitespace only
+		expect(state_manager.sanitize_filename("   ")).to.equal("_unnamed_") -- whitespace only
 	end)
 end)

--- a/plugin/resurrect/test/test_state_manager.lua
+++ b/plugin/resurrect/test/test_state_manager.lua
@@ -1,0 +1,32 @@
+-- Tests for state_manager.lua sanitize_filename()
+-- Verifies fix for GitHub issue #107 (Windows paths with colons)
+
+local state_manager = require("resurrect.state_manager")
+
+describe("sanitize_filename()", function()
+	it("passes through normal names unchanged", function()
+		expect(state_manager.sanitize_filename("myworkspace")).to.equal("myworkspace")
+		expect(state_manager.sanitize_filename("file.name")).to.equal("file.name")
+	end)
+
+	it("handles Windows drive letter paths (issue #107)", function()
+		expect(state_manager.sanitize_filename("C:\\Users\\foo")).to.equal("C_+Users+foo")
+		expect(state_manager.sanitize_filename("/home/user/project")).to.equal("+home+user+project")
+	end)
+
+	it("sanitizes path traversal sequences", function()
+		expect(state_manager.sanitize_filename("../../../etc")).to.equal("_+_+_+etc")
+		expect(state_manager.sanitize_filename("foo/../bar")).to.equal("foo+_+bar")
+	end)
+
+	it("sanitizes control characters", function()
+		expect(state_manager.sanitize_filename("name\x00null")).to.equal("name_null")
+		expect(state_manager.sanitize_filename("tab\ttab")).to.equal("tab_tab")
+	end)
+
+	it("returns _unnamed_ for empty/nil input", function()
+		expect(state_manager.sanitize_filename(nil)).to.equal("_unnamed_")
+		expect(state_manager.sanitize_filename("")).to.equal("_unnamed_")
+		expect(state_manager.sanitize_filename("   ")).to.equal("_unnamed_")  -- whitespace only
+	end)
+end)

--- a/plugin/resurrect/test/test_utils.lua
+++ b/plugin/resurrect/test/test_utils.lua
@@ -6,32 +6,32 @@
 --------------------------------------------------------------------------------
 
 describe("is_windows_path", function()
-    -- Load utils fresh to get the functions
-    local utils = require("resurrect.utils")
+	-- Load utils fresh to get the functions
+	local utils = require("resurrect.utils")
 
-    it("should detect Windows drive letter paths", function()
-        expect(utils.is_windows_path("C:\\Users\\test")).to.equal(true)
-        expect(utils.is_windows_path("D:\\")).to.equal(true)
-        expect(utils.is_windows_path("C:")).to.equal(true)
-        expect(utils.is_windows_path("c:\\lowercase")).to.equal(true)
-    end)
+	it("should detect Windows drive letter paths", function()
+		expect(utils.is_windows_path("C:\\Users\\test")).to.equal(true)
+		expect(utils.is_windows_path("D:\\")).to.equal(true)
+		expect(utils.is_windows_path("C:")).to.equal(true)
+		expect(utils.is_windows_path("c:\\lowercase")).to.equal(true)
+	end)
 
-    it("should detect paths with backslashes", function()
-        expect(utils.is_windows_path("foo\\bar\\baz")).to.equal(true)
-        expect(utils.is_windows_path("\\\\network\\share")).to.equal(true)
-    end)
+	it("should detect paths with backslashes", function()
+		expect(utils.is_windows_path("foo\\bar\\baz")).to.equal(true)
+		expect(utils.is_windows_path("\\\\network\\share")).to.equal(true)
+	end)
 
-    it("should return false for Unix paths", function()
-        expect(utils.is_windows_path("/home/user")).to.equal(false)
-        expect(utils.is_windows_path("/")).to.equal(false)
-        expect(utils.is_windows_path("./relative/path")).to.equal(false)
-        expect(utils.is_windows_path("relative/path")).to.equal(false)
-    end)
+	it("should return false for Unix paths", function()
+		expect(utils.is_windows_path("/home/user")).to.equal(false)
+		expect(utils.is_windows_path("/")).to.equal(false)
+		expect(utils.is_windows_path("./relative/path")).to.equal(false)
+		expect(utils.is_windows_path("relative/path")).to.equal(false)
+	end)
 
-    it("should handle empty and nil inputs", function()
-        expect(utils.is_windows_path("")).to.equal(false)
-        expect(utils.is_windows_path(nil)).to.equal(false)
-    end)
+	it("should handle empty and nil inputs", function()
+		expect(utils.is_windows_path("")).to.equal(false)
+		expect(utils.is_windows_path(nil)).to.equal(false)
+	end)
 end)
 
 --------------------------------------------------------------------------------
@@ -39,34 +39,34 @@ end)
 --------------------------------------------------------------------------------
 
 describe("normalize_path_separators", function()
-    local utils = require("resurrect.utils")
+	local utils = require("resurrect.utils")
 
-    it("should convert forward slashes to backslashes when to_windows is true", function()
-        expect(utils.normalize_path_separators("C:/Users/test", true)).to.equal("C:\\Users\\test")
-        expect(utils.normalize_path_separators("foo/bar/baz", true)).to.equal("foo\\bar\\baz")
-    end)
+	it("should convert forward slashes to backslashes when to_windows is true", function()
+		expect(utils.normalize_path_separators("C:/Users/test", true)).to.equal("C:\\Users\\test")
+		expect(utils.normalize_path_separators("foo/bar/baz", true)).to.equal("foo\\bar\\baz")
+	end)
 
-    it("should convert backslashes to forward slashes when to_windows is false", function()
-        expect(utils.normalize_path_separators("C:\\Users\\test", false)).to.equal("C:/Users/test")
-        expect(utils.normalize_path_separators("foo\\bar\\baz", false)).to.equal("foo/bar/baz")
-    end)
+	it("should convert backslashes to forward slashes when to_windows is false", function()
+		expect(utils.normalize_path_separators("C:\\Users\\test", false)).to.equal("C:/Users/test")
+		expect(utils.normalize_path_separators("foo\\bar\\baz", false)).to.equal("foo/bar/baz")
+	end)
 
-    it("should handle mixed separators", function()
-        expect(utils.normalize_path_separators("C:/Users\\test/data", true)).to.equal("C:\\Users\\test\\data")
-        expect(utils.normalize_path_separators("C:/Users\\test/data", false)).to.equal("C:/Users/test/data")
-    end)
+	it("should handle mixed separators", function()
+		expect(utils.normalize_path_separators("C:/Users\\test/data", true)).to.equal("C:\\Users\\test\\data")
+		expect(utils.normalize_path_separators("C:/Users\\test/data", false)).to.equal("C:/Users/test/data")
+	end)
 
-    it("should handle empty and nil inputs", function()
-        expect(utils.normalize_path_separators("", true)).to.equal("")
-        expect(utils.normalize_path_separators("", false)).to.equal("")
-        expect(utils.normalize_path_separators(nil, true)).to_not.exist()
-        expect(utils.normalize_path_separators(nil, false)).to_not.exist()
-    end)
+	it("should handle empty and nil inputs", function()
+		expect(utils.normalize_path_separators("", true)).to.equal("")
+		expect(utils.normalize_path_separators("", false)).to.equal("")
+		expect(utils.normalize_path_separators(nil, true)).to_not.exist()
+		expect(utils.normalize_path_separators(nil, false)).to_not.exist()
+	end)
 
-    it("should leave paths unchanged if already in correct format", function()
-        expect(utils.normalize_path_separators("C:\\Users\\test", true)).to.equal("C:\\Users\\test")
-        expect(utils.normalize_path_separators("/home/user", false)).to.equal("/home/user")
-    end)
+	it("should leave paths unchanged if already in correct format", function()
+		expect(utils.normalize_path_separators("C:\\Users\\test", true)).to.equal("C:\\Users\\test")
+		expect(utils.normalize_path_separators("/home/user", false)).to.equal("/home/user")
+	end)
 end)
 
 --------------------------------------------------------------------------------
@@ -74,85 +74,85 @@ end)
 --------------------------------------------------------------------------------
 
 describe("path_components", function()
-    local utils = require("resurrect.utils")
+	local utils = require("resurrect.utils")
 
-    it("should parse Unix absolute paths", function()
-        local components, root = utils.path_components("/home/user/docs")
-        expect(root).to.equal("/")
-        expect(#components).to.equal(3)
-        expect(components[1]).to.equal("home")
-        expect(components[2]).to.equal("user")
-        expect(components[3]).to.equal("docs")
-    end)
+	it("should parse Unix absolute paths", function()
+		local components, root = utils.path_components("/home/user/docs")
+		expect(root).to.equal("/")
+		expect(#components).to.equal(3)
+		expect(components[1]).to.equal("home")
+		expect(components[2]).to.equal("user")
+		expect(components[3]).to.equal("docs")
+	end)
 
-    it("should parse Unix root path", function()
-        local components, root = utils.path_components("/")
-        expect(root).to.equal("/")
-        expect(#components).to.equal(0)
-    end)
+	it("should parse Unix root path", function()
+		local components, root = utils.path_components("/")
+		expect(root).to.equal("/")
+		expect(#components).to.equal(0)
+	end)
 
-    it("should parse Unix relative paths", function()
-        local components, root = utils.path_components("relative/path/to/file")
-        expect(root).to_not.exist()
-        expect(#components).to.equal(4)
-        expect(components[1]).to.equal("relative")
-        expect(components[4]).to.equal("file")
-    end)
+	it("should parse Unix relative paths", function()
+		local components, root = utils.path_components("relative/path/to/file")
+		expect(root).to_not.exist()
+		expect(#components).to.equal(4)
+		expect(components[1]).to.equal("relative")
+		expect(components[4]).to.equal("file")
+	end)
 
-    it("should parse Windows paths with drive letters", function()
-        local components, root = utils.path_components("C:\\Users\\test\\Documents")
-        expect(root).to.equal("C:")
-        expect(#components).to.equal(3)
-        expect(components[1]).to.equal("Users")
-        expect(components[2]).to.equal("test")
-        expect(components[3]).to.equal("Documents")
-    end)
+	it("should parse Windows paths with drive letters", function()
+		local components, root = utils.path_components("C:\\Users\\test\\Documents")
+		expect(root).to.equal("C:")
+		expect(#components).to.equal(3)
+		expect(components[1]).to.equal("Users")
+		expect(components[2]).to.equal("test")
+		expect(components[3]).to.equal("Documents")
+	end)
 
-    it("should parse Windows paths with forward slashes", function()
-        local components, root = utils.path_components("C:/Users/test")
-        expect(root).to.equal("C:")
-        expect(#components).to.equal(2)
-        expect(components[1]).to.equal("Users")
-        expect(components[2]).to.equal("test")
-    end)
+	it("should parse Windows paths with forward slashes", function()
+		local components, root = utils.path_components("C:/Users/test")
+		expect(root).to.equal("C:")
+		expect(#components).to.equal(2)
+		expect(components[1]).to.equal("Users")
+		expect(components[2]).to.equal("test")
+	end)
 
-    it("should handle Windows drive letter only", function()
-        local components, root = utils.path_components("C:")
-        expect(root).to.equal("C:")
-        expect(#components).to.equal(0)
-    end)
+	it("should handle Windows drive letter only", function()
+		local components, root = utils.path_components("C:")
+		expect(root).to.equal("C:")
+		expect(#components).to.equal(0)
+	end)
 
-    it("should handle Windows drive letter with trailing slash", function()
-        local components, root = utils.path_components("C:\\")
-        expect(root).to.equal("C:")
-        expect(#components).to.equal(0)
-    end)
+	it("should handle Windows drive letter with trailing slash", function()
+		local components, root = utils.path_components("C:\\")
+		expect(root).to.equal("C:")
+		expect(#components).to.equal(0)
+	end)
 
-    it("should handle lowercase drive letters", function()
-        local components, root = utils.path_components("d:\\data")
-        expect(root).to.equal("d:")
-        expect(#components).to.equal(1)
-        expect(components[1]).to.equal("data")
-    end)
+	it("should handle lowercase drive letters", function()
+		local components, root = utils.path_components("d:\\data")
+		expect(root).to.equal("d:")
+		expect(#components).to.equal(1)
+		expect(components[1]).to.equal("data")
+	end)
 
-    it("should handle empty and nil inputs", function()
-        local components, root = utils.path_components("")
-        expect(#components).to.equal(0)
-        expect(root).to_not.exist()
+	it("should handle empty and nil inputs", function()
+		local components, root = utils.path_components("")
+		expect(#components).to.equal(0)
+		expect(root).to_not.exist()
 
-        components, root = utils.path_components(nil)
-        expect(#components).to.equal(0)
-        expect(root).to_not.exist()
-    end)
+		components, root = utils.path_components(nil)
+		expect(#components).to.equal(0)
+		expect(root).to_not.exist()
+	end)
 
-    it("should skip empty components from multiple consecutive separators", function()
-        local components, root = utils.path_components("/home//user///docs")
-        expect(root).to.equal("/")
-        expect(#components).to.equal(3)
-        expect(components[1]).to.equal("home")
-        expect(components[2]).to.equal("user")
-        expect(components[3]).to.equal("docs")
-    end)
+	it("should skip empty components from multiple consecutive separators", function()
+		local components, root = utils.path_components("/home//user///docs")
+		expect(root).to.equal("/")
+		expect(#components).to.equal(3)
+		expect(components[1]).to.equal("home")
+		expect(components[2]).to.equal("user")
+		expect(components[3]).to.equal("docs")
+	end)
 end)
 
 --------------------------------------------------------------------------------
@@ -160,32 +160,32 @@ end)
 --------------------------------------------------------------------------------
 
 describe("join_path_components", function()
-    local utils = require("resurrect.utils")
+	local utils = require("resurrect.utils")
 
-    it("should join Unix path components", function()
-        local path = utils.join_path_components({"home", "user", "docs"}, "/", false)
-        expect(path).to.equal("/home/user/docs")
-    end)
+	it("should join Unix path components", function()
+		local path = utils.join_path_components({ "home", "user", "docs" }, "/", false)
+		expect(path).to.equal("/home/user/docs")
+	end)
 
-    it("should join Windows path components", function()
-        local path = utils.join_path_components({"Users", "test"}, "C:", true)
-        expect(path).to.equal("C:\\Users\\test")
-    end)
+	it("should join Windows path components", function()
+		local path = utils.join_path_components({ "Users", "test" }, "C:", true)
+		expect(path).to.equal("C:\\Users\\test")
+	end)
 
-    it("should handle empty components", function()
-        local path = utils.join_path_components({}, "/", false)
-        expect(path).to.equal("/")
-    end)
+	it("should handle empty components", function()
+		local path = utils.join_path_components({}, "/", false)
+		expect(path).to.equal("/")
+	end)
 
-    it("should handle nil root for relative paths", function()
-        local path = utils.join_path_components({"relative", "path"}, nil, false)
-        expect(path).to.equal("relative/path")
-    end)
+	it("should handle nil root for relative paths", function()
+		local path = utils.join_path_components({ "relative", "path" }, nil, false)
+		expect(path).to.equal("relative/path")
+	end)
 
-    it("should handle root slash on Windows style", function()
-        local path = utils.join_path_components({"home", "user"}, "/", true)
-        expect(path).to.equal("\\home\\user")
-    end)
+	it("should handle root slash on Windows style", function()
+		local path = utils.join_path_components({ "home", "user" }, "/", true)
+		expect(path).to.equal("\\home\\user")
+	end)
 end)
 
 --------------------------------------------------------------------------------
@@ -193,40 +193,40 @@ end)
 --------------------------------------------------------------------------------
 
 describe("build_partial_path", function()
-    local utils = require("resurrect.utils")
+	local utils = require("resurrect.utils")
 
-    it("should build partial Unix paths", function()
-        local components = {"home", "user", "docs", "file"}
+	it("should build partial Unix paths", function()
+		local components = { "home", "user", "docs", "file" }
 
-        expect(utils.build_partial_path(components, 1, "/", false)).to.equal("/home")
-        expect(utils.build_partial_path(components, 2, "/", false)).to.equal("/home/user")
-        expect(utils.build_partial_path(components, 3, "/", false)).to.equal("/home/user/docs")
-        expect(utils.build_partial_path(components, 4, "/", false)).to.equal("/home/user/docs/file")
-    end)
+		expect(utils.build_partial_path(components, 1, "/", false)).to.equal("/home")
+		expect(utils.build_partial_path(components, 2, "/", false)).to.equal("/home/user")
+		expect(utils.build_partial_path(components, 3, "/", false)).to.equal("/home/user/docs")
+		expect(utils.build_partial_path(components, 4, "/", false)).to.equal("/home/user/docs/file")
+	end)
 
-    it("should build partial Windows paths", function()
-        local components = {"Users", "test", "Documents"}
+	it("should build partial Windows paths", function()
+		local components = { "Users", "test", "Documents" }
 
-        expect(utils.build_partial_path(components, 1, "C:", true)).to.equal("C:\\Users")
-        expect(utils.build_partial_path(components, 2, "C:", true)).to.equal("C:\\Users\\test")
-        expect(utils.build_partial_path(components, 3, "C:", true)).to.equal("C:\\Users\\test\\Documents")
-    end)
+		expect(utils.build_partial_path(components, 1, "C:", true)).to.equal("C:\\Users")
+		expect(utils.build_partial_path(components, 2, "C:", true)).to.equal("C:\\Users\\test")
+		expect(utils.build_partial_path(components, 3, "C:", true)).to.equal("C:\\Users\\test\\Documents")
+	end)
 
-    it("should handle count greater than components length", function()
-        local components = {"a", "b"}
-        expect(utils.build_partial_path(components, 10, "/", false)).to.equal("/a/b")
-    end)
+	it("should handle count greater than components length", function()
+		local components = { "a", "b" }
+		expect(utils.build_partial_path(components, 10, "/", false)).to.equal("/a/b")
+	end)
 
-    it("should handle zero count", function()
-        local components = {"a", "b"}
-        expect(utils.build_partial_path(components, 0, "/", false)).to.equal("/")
-    end)
+	it("should handle zero count", function()
+		local components = { "a", "b" }
+		expect(utils.build_partial_path(components, 0, "/", false)).to.equal("/")
+	end)
 
-    it("should handle relative paths", function()
-        local components = {"relative", "path"}
-        expect(utils.build_partial_path(components, 1, nil, false)).to.equal("relative")
-        expect(utils.build_partial_path(components, 2, nil, false)).to.equal("relative/path")
-    end)
+	it("should handle relative paths", function()
+		local components = { "relative", "path" }
+		expect(utils.build_partial_path(components, 1, nil, false)).to.equal("relative")
+		expect(utils.build_partial_path(components, 2, nil, false)).to.equal("relative/path")
+	end)
 end)
 
 --------------------------------------------------------------------------------
@@ -234,49 +234,49 @@ end)
 --------------------------------------------------------------------------------
 
 describe("normalize_path with different platforms", function()
-    it("should normalize to forward slashes on macOS", function()
-        wezterm._test.set_target_triple("x86_64-apple-darwin")
-        -- Reload utils to pick up new target_triple
-        package.loaded["resurrect.utils"] = nil
-        local utils = require("resurrect.utils")
+	it("should normalize to forward slashes on macOS", function()
+		wezterm._test.set_target_triple("x86_64-apple-darwin")
+		-- Reload utils to pick up new target_triple
+		package.loaded["resurrect.utils"] = nil
+		local utils = require("resurrect.utils")
 
-        expect(utils.normalize_path("/home/user/docs")).to.equal("/home/user/docs")
-        expect(utils.normalize_path("C:\\Users\\test")).to.equal("C:/Users/test")
-    end)
+		expect(utils.normalize_path("/home/user/docs")).to.equal("/home/user/docs")
+		expect(utils.normalize_path("C:\\Users\\test")).to.equal("C:/Users/test")
+	end)
 
-    it("should normalize to forward slashes on Linux", function()
-        wezterm._test.set_target_triple("x86_64-unknown-linux-gnu")
-        package.loaded["resurrect.utils"] = nil
-        local utils = require("resurrect.utils")
+	it("should normalize to forward slashes on Linux", function()
+		wezterm._test.set_target_triple("x86_64-unknown-linux-gnu")
+		package.loaded["resurrect.utils"] = nil
+		local utils = require("resurrect.utils")
 
-        expect(utils.normalize_path("/home/user/docs")).to.equal("/home/user/docs")
-        expect(utils.normalize_path("relative\\path")).to.equal("relative/path")
-    end)
+		expect(utils.normalize_path("/home/user/docs")).to.equal("/home/user/docs")
+		expect(utils.normalize_path("relative\\path")).to.equal("relative/path")
+	end)
 
-    it("should normalize to backslashes on Windows", function()
-        wezterm._test.set_target_triple("x86_64-pc-windows-msvc")
-        package.loaded["resurrect.utils"] = nil
-        local utils = require("resurrect.utils")
+	it("should normalize to backslashes on Windows", function()
+		wezterm._test.set_target_triple("x86_64-pc-windows-msvc")
+		package.loaded["resurrect.utils"] = nil
+		local utils = require("resurrect.utils")
 
-        expect(utils.normalize_path("C:/Users/test")).to.equal("C:\\Users\\test")
-        expect(utils.normalize_path("/home/user")).to.equal("\\home\\user")
-    end)
+		expect(utils.normalize_path("C:/Users/test")).to.equal("C:\\Users\\test")
+		expect(utils.normalize_path("/home/user")).to.equal("\\home\\user")
+	end)
 
-    it("should handle ARM macOS", function()
-        wezterm._test.set_target_triple("aarch64-apple-darwin")
-        package.loaded["resurrect.utils"] = nil
-        local utils = require("resurrect.utils")
+	it("should handle ARM macOS", function()
+		wezterm._test.set_target_triple("aarch64-apple-darwin")
+		package.loaded["resurrect.utils"] = nil
+		local utils = require("resurrect.utils")
 
-        expect(utils.is_mac).to.equal(true)
-        expect(utils.is_windows).to.equal(false)
-        expect(utils.separator).to.equal("/")
-    end)
+		expect(utils.is_mac).to.equal(true)
+		expect(utils.is_windows).to.equal(false)
+		expect(utils.separator).to.equal("/")
+	end)
 
-    -- Reset to default after platform tests
-    it("cleanup: reset to default platform", function()
-        wezterm._test.set_target_triple("x86_64-apple-darwin")
-        package.loaded["resurrect.utils"] = nil
-    end)
+	-- Reset to default after platform tests
+	it("cleanup: reset to default platform", function()
+		wezterm._test.set_target_triple("x86_64-apple-darwin")
+		package.loaded["resurrect.utils"] = nil
+	end)
 end)
 
 --------------------------------------------------------------------------------
@@ -284,24 +284,24 @@ end)
 --------------------------------------------------------------------------------
 
 describe("directory_exists", function()
-    local utils = require("resurrect.utils")
+	local utils = require("resurrect.utils")
 
-    it("should return true for existing directories", function()
-        -- Test with known existing directories
-        local home = os.getenv("HOME") or "/tmp"
-        expect(utils.directory_exists(home)).to.equal(true)
-    end)
+	it("should return true for existing directories", function()
+		-- Test with known existing directories
+		local home = os.getenv("HOME") or "/tmp"
+		expect(utils.directory_exists(home)).to.equal(true)
+	end)
 
-    it("should return false for non-existent directories", function()
-        expect(utils.directory_exists("/nonexistent/path/that/should/not/exist/12345")).to.equal(false)
-    end)
+	it("should return false for non-existent directories", function()
+		expect(utils.directory_exists("/nonexistent/path/that/should/not/exist/12345")).to.equal(false)
+	end)
 
-    it("should handle root directory", function()
-        -- Root directory should always exist on Unix systems
-        if not utils.is_windows then
-            expect(utils.directory_exists("/")).to.equal(true)
-        end
-    end)
+	it("should handle root directory", function()
+		-- Root directory should always exist on Unix systems
+		if not utils.is_windows then
+			expect(utils.directory_exists("/")).to.equal(true)
+		end
+	end)
 end)
 
 --------------------------------------------------------------------------------
@@ -309,41 +309,41 @@ end)
 --------------------------------------------------------------------------------
 
 describe("ensure_folder_exists", function()
-    local utils = require("resurrect.utils")
-    local test_base = os.getenv("TMPDIR") or os.getenv("TEMP") or "/tmp"
+	local utils = require("resurrect.utils")
+	local test_base = os.getenv("TMPDIR") or os.getenv("TEMP") or "/tmp"
 
-    it("should return false for empty path", function()
-        local success, err = utils.ensure_folder_exists("")
-        expect(success).to.equal(false)
-        expect(err).to.exist()
-    end)
+	it("should return false for empty path", function()
+		local success, err = utils.ensure_folder_exists("")
+		expect(success).to.equal(false)
+		expect(err).to.exist()
+	end)
 
-    it("should return false for nil path", function()
-        local success, err = utils.ensure_folder_exists(nil)
-        expect(success).to.equal(false)
-        expect(err).to.exist()
-    end)
+	it("should return false for nil path", function()
+		local success, err = utils.ensure_folder_exists(nil)
+		expect(success).to.equal(false)
+		expect(err).to.exist()
+	end)
 
-    it("should succeed for existing directory", function()
-        local success, err = utils.ensure_folder_exists(test_base)
-        expect(success).to.equal(true)
-        expect(err).to_not.exist()
-    end)
+	it("should succeed for existing directory", function()
+		local success, err = utils.ensure_folder_exists(test_base)
+		expect(success).to.equal(true)
+		expect(err).to_not.exist()
+	end)
 
-    it("should create nested directories", function()
-        -- Use a unique test directory to avoid conflicts
-        local unique_id = tostring(os.time()) .. "_" .. tostring(math.random(10000))
-        local test_path = test_base .. "/resurrect_test_" .. unique_id .. "/nested/path"
+	it("should create nested directories", function()
+		-- Use a unique test directory to avoid conflicts
+		local unique_id = tostring(os.time()) .. "_" .. tostring(math.random(10000))
+		local test_path = test_base .. "/resurrect_test_" .. unique_id .. "/nested/path"
 
-        local success, err = utils.ensure_folder_exists(test_path)
-        expect(success).to.equal(true)
+		local success, err = utils.ensure_folder_exists(test_path)
+		expect(success).to.equal(true)
 
-        -- Verify the directory exists
-        expect(utils.directory_exists(test_path)).to.equal(true)
+		-- Verify the directory exists
+		expect(utils.directory_exists(test_path)).to.equal(true)
 
-        -- Cleanup: remove test directories
-        os.execute('rm -rf "' .. test_base .. '/resurrect_test_' .. unique_id .. '" 2>/dev/null')
-    end)
+		-- Cleanup: remove test directories
+		os.execute('rm -rf "' .. test_base .. "/resurrect_test_" .. unique_id .. '" 2>/dev/null')
+	end)
 end)
 
 --------------------------------------------------------------------------------
@@ -351,17 +351,17 @@ end)
 --------------------------------------------------------------------------------
 
 describe("path_exists", function()
-    local utils = require("resurrect.utils")
+	local utils = require("resurrect.utils")
 
-    it("should return true for existing files", function()
-        -- Test with a file we know exists (this test file itself)
-        local this_file = debug.getinfo(1, "S").source:match("@?(.*)")
-        if this_file then
-            expect(utils.path_exists(this_file)).to.equal(true)
-        end
-    end)
+	it("should return true for existing files", function()
+		-- Test with a file we know exists (this test file itself)
+		local this_file = debug.getinfo(1, "S").source:match("@?(.*)")
+		if this_file then
+			expect(utils.path_exists(this_file)).to.equal(true)
+		end
+	end)
 
-    it("should return false for non-existent paths", function()
-        expect(utils.path_exists("/nonexistent/file/that/should/not/exist.txt")).to.equal(false)
-    end)
+	it("should return false for non-existent paths", function()
+		expect(utils.path_exists("/nonexistent/file/that/should/not/exist.txt")).to.equal(false)
+	end)
 end)

--- a/plugin/resurrect/test/test_utils.lua
+++ b/plugin/resurrect/test/test_utils.lua
@@ -1,0 +1,367 @@
+-- Tests for utils.lua path normalization and directory creation functions
+-- Run with: lua plugin/resurrect/test/init.lua plugin/resurrect/test/test_utils.lua
+
+--------------------------------------------------------------------------------
+-- Test: is_windows_path
+--------------------------------------------------------------------------------
+
+describe("is_windows_path", function()
+    -- Load utils fresh to get the functions
+    local utils = require("resurrect.utils")
+
+    it("should detect Windows drive letter paths", function()
+        expect(utils.is_windows_path("C:\\Users\\test")).to.equal(true)
+        expect(utils.is_windows_path("D:\\")).to.equal(true)
+        expect(utils.is_windows_path("C:")).to.equal(true)
+        expect(utils.is_windows_path("c:\\lowercase")).to.equal(true)
+    end)
+
+    it("should detect paths with backslashes", function()
+        expect(utils.is_windows_path("foo\\bar\\baz")).to.equal(true)
+        expect(utils.is_windows_path("\\\\network\\share")).to.equal(true)
+    end)
+
+    it("should return false for Unix paths", function()
+        expect(utils.is_windows_path("/home/user")).to.equal(false)
+        expect(utils.is_windows_path("/")).to.equal(false)
+        expect(utils.is_windows_path("./relative/path")).to.equal(false)
+        expect(utils.is_windows_path("relative/path")).to.equal(false)
+    end)
+
+    it("should handle empty and nil inputs", function()
+        expect(utils.is_windows_path("")).to.equal(false)
+        expect(utils.is_windows_path(nil)).to.equal(false)
+    end)
+end)
+
+--------------------------------------------------------------------------------
+-- Test: normalize_path_separators
+--------------------------------------------------------------------------------
+
+describe("normalize_path_separators", function()
+    local utils = require("resurrect.utils")
+
+    it("should convert forward slashes to backslashes when to_windows is true", function()
+        expect(utils.normalize_path_separators("C:/Users/test", true)).to.equal("C:\\Users\\test")
+        expect(utils.normalize_path_separators("foo/bar/baz", true)).to.equal("foo\\bar\\baz")
+    end)
+
+    it("should convert backslashes to forward slashes when to_windows is false", function()
+        expect(utils.normalize_path_separators("C:\\Users\\test", false)).to.equal("C:/Users/test")
+        expect(utils.normalize_path_separators("foo\\bar\\baz", false)).to.equal("foo/bar/baz")
+    end)
+
+    it("should handle mixed separators", function()
+        expect(utils.normalize_path_separators("C:/Users\\test/data", true)).to.equal("C:\\Users\\test\\data")
+        expect(utils.normalize_path_separators("C:/Users\\test/data", false)).to.equal("C:/Users/test/data")
+    end)
+
+    it("should handle empty and nil inputs", function()
+        expect(utils.normalize_path_separators("", true)).to.equal("")
+        expect(utils.normalize_path_separators("", false)).to.equal("")
+        expect(utils.normalize_path_separators(nil, true)).to_not.exist()
+        expect(utils.normalize_path_separators(nil, false)).to_not.exist()
+    end)
+
+    it("should leave paths unchanged if already in correct format", function()
+        expect(utils.normalize_path_separators("C:\\Users\\test", true)).to.equal("C:\\Users\\test")
+        expect(utils.normalize_path_separators("/home/user", false)).to.equal("/home/user")
+    end)
+end)
+
+--------------------------------------------------------------------------------
+-- Test: path_components
+--------------------------------------------------------------------------------
+
+describe("path_components", function()
+    local utils = require("resurrect.utils")
+
+    it("should parse Unix absolute paths", function()
+        local components, root = utils.path_components("/home/user/docs")
+        expect(root).to.equal("/")
+        expect(#components).to.equal(3)
+        expect(components[1]).to.equal("home")
+        expect(components[2]).to.equal("user")
+        expect(components[3]).to.equal("docs")
+    end)
+
+    it("should parse Unix root path", function()
+        local components, root = utils.path_components("/")
+        expect(root).to.equal("/")
+        expect(#components).to.equal(0)
+    end)
+
+    it("should parse Unix relative paths", function()
+        local components, root = utils.path_components("relative/path/to/file")
+        expect(root).to_not.exist()
+        expect(#components).to.equal(4)
+        expect(components[1]).to.equal("relative")
+        expect(components[4]).to.equal("file")
+    end)
+
+    it("should parse Windows paths with drive letters", function()
+        local components, root = utils.path_components("C:\\Users\\test\\Documents")
+        expect(root).to.equal("C:")
+        expect(#components).to.equal(3)
+        expect(components[1]).to.equal("Users")
+        expect(components[2]).to.equal("test")
+        expect(components[3]).to.equal("Documents")
+    end)
+
+    it("should parse Windows paths with forward slashes", function()
+        local components, root = utils.path_components("C:/Users/test")
+        expect(root).to.equal("C:")
+        expect(#components).to.equal(2)
+        expect(components[1]).to.equal("Users")
+        expect(components[2]).to.equal("test")
+    end)
+
+    it("should handle Windows drive letter only", function()
+        local components, root = utils.path_components("C:")
+        expect(root).to.equal("C:")
+        expect(#components).to.equal(0)
+    end)
+
+    it("should handle Windows drive letter with trailing slash", function()
+        local components, root = utils.path_components("C:\\")
+        expect(root).to.equal("C:")
+        expect(#components).to.equal(0)
+    end)
+
+    it("should handle lowercase drive letters", function()
+        local components, root = utils.path_components("d:\\data")
+        expect(root).to.equal("d:")
+        expect(#components).to.equal(1)
+        expect(components[1]).to.equal("data")
+    end)
+
+    it("should handle empty and nil inputs", function()
+        local components, root = utils.path_components("")
+        expect(#components).to.equal(0)
+        expect(root).to_not.exist()
+
+        components, root = utils.path_components(nil)
+        expect(#components).to.equal(0)
+        expect(root).to_not.exist()
+    end)
+
+    it("should skip empty components from multiple consecutive separators", function()
+        local components, root = utils.path_components("/home//user///docs")
+        expect(root).to.equal("/")
+        expect(#components).to.equal(3)
+        expect(components[1]).to.equal("home")
+        expect(components[2]).to.equal("user")
+        expect(components[3]).to.equal("docs")
+    end)
+end)
+
+--------------------------------------------------------------------------------
+-- Test: join_path_components
+--------------------------------------------------------------------------------
+
+describe("join_path_components", function()
+    local utils = require("resurrect.utils")
+
+    it("should join Unix path components", function()
+        local path = utils.join_path_components({"home", "user", "docs"}, "/", false)
+        expect(path).to.equal("/home/user/docs")
+    end)
+
+    it("should join Windows path components", function()
+        local path = utils.join_path_components({"Users", "test"}, "C:", true)
+        expect(path).to.equal("C:\\Users\\test")
+    end)
+
+    it("should handle empty components", function()
+        local path = utils.join_path_components({}, "/", false)
+        expect(path).to.equal("/")
+    end)
+
+    it("should handle nil root for relative paths", function()
+        local path = utils.join_path_components({"relative", "path"}, nil, false)
+        expect(path).to.equal("relative/path")
+    end)
+
+    it("should handle root slash on Windows style", function()
+        local path = utils.join_path_components({"home", "user"}, "/", true)
+        expect(path).to.equal("\\home\\user")
+    end)
+end)
+
+--------------------------------------------------------------------------------
+-- Test: build_partial_path
+--------------------------------------------------------------------------------
+
+describe("build_partial_path", function()
+    local utils = require("resurrect.utils")
+
+    it("should build partial Unix paths", function()
+        local components = {"home", "user", "docs", "file"}
+
+        expect(utils.build_partial_path(components, 1, "/", false)).to.equal("/home")
+        expect(utils.build_partial_path(components, 2, "/", false)).to.equal("/home/user")
+        expect(utils.build_partial_path(components, 3, "/", false)).to.equal("/home/user/docs")
+        expect(utils.build_partial_path(components, 4, "/", false)).to.equal("/home/user/docs/file")
+    end)
+
+    it("should build partial Windows paths", function()
+        local components = {"Users", "test", "Documents"}
+
+        expect(utils.build_partial_path(components, 1, "C:", true)).to.equal("C:\\Users")
+        expect(utils.build_partial_path(components, 2, "C:", true)).to.equal("C:\\Users\\test")
+        expect(utils.build_partial_path(components, 3, "C:", true)).to.equal("C:\\Users\\test\\Documents")
+    end)
+
+    it("should handle count greater than components length", function()
+        local components = {"a", "b"}
+        expect(utils.build_partial_path(components, 10, "/", false)).to.equal("/a/b")
+    end)
+
+    it("should handle zero count", function()
+        local components = {"a", "b"}
+        expect(utils.build_partial_path(components, 0, "/", false)).to.equal("/")
+    end)
+
+    it("should handle relative paths", function()
+        local components = {"relative", "path"}
+        expect(utils.build_partial_path(components, 1, nil, false)).to.equal("relative")
+        expect(utils.build_partial_path(components, 2, nil, false)).to.equal("relative/path")
+    end)
+end)
+
+--------------------------------------------------------------------------------
+-- Test: normalize_path with different target_triple values
+--------------------------------------------------------------------------------
+
+describe("normalize_path with different platforms", function()
+    it("should normalize to forward slashes on macOS", function()
+        wezterm._test.set_target_triple("x86_64-apple-darwin")
+        -- Reload utils to pick up new target_triple
+        package.loaded["resurrect.utils"] = nil
+        local utils = require("resurrect.utils")
+
+        expect(utils.normalize_path("/home/user/docs")).to.equal("/home/user/docs")
+        expect(utils.normalize_path("C:\\Users\\test")).to.equal("C:/Users/test")
+    end)
+
+    it("should normalize to forward slashes on Linux", function()
+        wezterm._test.set_target_triple("x86_64-unknown-linux-gnu")
+        package.loaded["resurrect.utils"] = nil
+        local utils = require("resurrect.utils")
+
+        expect(utils.normalize_path("/home/user/docs")).to.equal("/home/user/docs")
+        expect(utils.normalize_path("relative\\path")).to.equal("relative/path")
+    end)
+
+    it("should normalize to backslashes on Windows", function()
+        wezterm._test.set_target_triple("x86_64-pc-windows-msvc")
+        package.loaded["resurrect.utils"] = nil
+        local utils = require("resurrect.utils")
+
+        expect(utils.normalize_path("C:/Users/test")).to.equal("C:\\Users\\test")
+        expect(utils.normalize_path("/home/user")).to.equal("\\home\\user")
+    end)
+
+    it("should handle ARM macOS", function()
+        wezterm._test.set_target_triple("aarch64-apple-darwin")
+        package.loaded["resurrect.utils"] = nil
+        local utils = require("resurrect.utils")
+
+        expect(utils.is_mac).to.equal(true)
+        expect(utils.is_windows).to.equal(false)
+        expect(utils.separator).to.equal("/")
+    end)
+
+    -- Reset to default after platform tests
+    it("cleanup: reset to default platform", function()
+        wezterm._test.set_target_triple("x86_64-apple-darwin")
+        package.loaded["resurrect.utils"] = nil
+    end)
+end)
+
+--------------------------------------------------------------------------------
+-- Test: directory_exists (limited testing without filesystem mocking)
+--------------------------------------------------------------------------------
+
+describe("directory_exists", function()
+    local utils = require("resurrect.utils")
+
+    it("should return true for existing directories", function()
+        -- Test with known existing directories
+        local home = os.getenv("HOME") or "/tmp"
+        expect(utils.directory_exists(home)).to.equal(true)
+    end)
+
+    it("should return false for non-existent directories", function()
+        expect(utils.directory_exists("/nonexistent/path/that/should/not/exist/12345")).to.equal(false)
+    end)
+
+    it("should handle root directory", function()
+        -- Root directory should always exist on Unix systems
+        if not utils.is_windows then
+            expect(utils.directory_exists("/")).to.equal(true)
+        end
+    end)
+end)
+
+--------------------------------------------------------------------------------
+-- Test: ensure_folder_exists (integration test)
+--------------------------------------------------------------------------------
+
+describe("ensure_folder_exists", function()
+    local utils = require("resurrect.utils")
+    local test_base = os.getenv("TMPDIR") or os.getenv("TEMP") or "/tmp"
+
+    it("should return false for empty path", function()
+        local success, err = utils.ensure_folder_exists("")
+        expect(success).to.equal(false)
+        expect(err).to.exist()
+    end)
+
+    it("should return false for nil path", function()
+        local success, err = utils.ensure_folder_exists(nil)
+        expect(success).to.equal(false)
+        expect(err).to.exist()
+    end)
+
+    it("should succeed for existing directory", function()
+        local success, err = utils.ensure_folder_exists(test_base)
+        expect(success).to.equal(true)
+        expect(err).to_not.exist()
+    end)
+
+    it("should create nested directories", function()
+        -- Use a unique test directory to avoid conflicts
+        local unique_id = tostring(os.time()) .. "_" .. tostring(math.random(10000))
+        local test_path = test_base .. "/resurrect_test_" .. unique_id .. "/nested/path"
+
+        local success, err = utils.ensure_folder_exists(test_path)
+        expect(success).to.equal(true)
+
+        -- Verify the directory exists
+        expect(utils.directory_exists(test_path)).to.equal(true)
+
+        -- Cleanup: remove test directories
+        os.execute('rm -rf "' .. test_base .. '/resurrect_test_' .. unique_id .. '" 2>/dev/null')
+    end)
+end)
+
+--------------------------------------------------------------------------------
+-- Test: path_exists
+--------------------------------------------------------------------------------
+
+describe("path_exists", function()
+    local utils = require("resurrect.utils")
+
+    it("should return true for existing files", function()
+        -- Test with a file we know exists (this test file itself)
+        local this_file = debug.getinfo(1, "S").source:match("@?(.*)")
+        if this_file then
+            expect(utils.path_exists(this_file)).to.equal(true)
+        end
+    end)
+
+    it("should return false for non-existent paths", function()
+        expect(utils.path_exists("/nonexistent/file/that/should/not/exist.txt")).to.equal(false)
+    end)
+end)

--- a/plugin/resurrect/types/mux.lua
+++ b/plugin/resurrect/types/mux.lua
@@ -1,0 +1,224 @@
+---@meta
+-- WezTerm Mux object type definitions
+
+---@class MuxDomain
+local MuxDomain = {}
+
+---Check if domain can spawn new panes
+---@return boolean
+function MuxDomain:is_spawnable() end
+
+---Get domain name
+---@return string
+function MuxDomain:name() end
+
+---@class MuxWindow
+local MuxWindow = {}
+
+---Get window title
+---@return string
+function MuxWindow:get_title() end
+
+---Set window title
+---@param title string
+function MuxWindow:set_title(title) end
+
+---Get workspace name
+---@return string
+function MuxWindow:get_workspace() end
+
+---Get all tabs in window
+---@return MuxTab[]
+function MuxWindow:tabs() end
+
+---Get tabs with metadata
+---@return TabInfo[]
+function MuxWindow:tabs_with_info() end
+
+---Spawn new tab
+---@param args? SpawnTabArgs
+---@return MuxTab tab
+---@return Pane pane
+---@return MuxWindow window
+function MuxWindow:spawn_tab(args) end
+
+---Get associated GUI window
+---@return GuiWindow?
+function MuxWindow:gui_window() end
+
+---Get the active tab
+---@return MuxTab
+function MuxWindow:active_tab() end
+
+---Get the active pane
+---@return Pane
+function MuxWindow:active_pane() end
+
+---@class SpawnTabArgs
+---@field cwd? string
+---@field domain? table
+
+---@class TabInfo
+---@field tab MuxTab
+---@field is_active boolean
+
+---@class MuxTab
+local MuxTab = {}
+
+---Get tab title
+---@return string
+function MuxTab:get_title() end
+
+---Set tab title
+---@param title string
+function MuxTab:set_title(title) end
+
+---Get tab ID
+---@return number
+function MuxTab:tab_id() end
+
+---Get all panes with layout info
+---@return PaneInfo[]
+function MuxTab:panes_with_info() end
+
+---Get tab size
+---@return TabSize
+function MuxTab:get_size() end
+
+---Set zoomed pane
+---@param zoomed boolean|Pane
+function MuxTab:set_zoomed(zoomed) end
+
+---Get all panes in this tab
+---@return Pane[]
+function MuxTab:panes() end
+
+---Activate this tab
+function MuxTab:activate() end
+
+---Get the parent window
+---@return MuxWindow
+function MuxTab:window() end
+
+---Get the active pane
+---@return Pane
+function MuxTab:active_pane() end
+
+---@class TabSize
+---@field rows number
+---@field cols number
+---@field pixel_width number
+---@field pixel_height number
+---@field dpi number
+
+---@class PaneInfo
+---@field pane Pane
+---@field is_active boolean
+---@field is_zoomed boolean
+---@field left number
+---@field top number
+---@field width number
+---@field height number
+
+---@class Pane
+local Pane = {}
+
+---Get pane ID
+---@return number
+function Pane:pane_id() end
+
+---Get domain name
+---@return string
+function Pane:get_domain_name() end
+
+---Get current working directory
+---@return PaneUrl?
+function Pane:get_current_working_dir() end
+
+---Check if alt screen is active (e.g., vim, less)
+---@return boolean
+function Pane:is_alt_screen_active() end
+
+---Get foreground process info
+---@return ProcessInfo?
+function Pane:get_foreground_process_info() end
+
+---Get scrollback as escape sequences
+---@param nlines? number Max lines to retrieve
+---@return string
+function Pane:get_lines_as_escapes(nlines) end
+
+---Get pane dimensions
+---@return PaneDimensions
+function Pane:get_dimensions() end
+
+---Split the pane
+---@param args SplitArgs
+---@return Pane
+function Pane:split(args) end
+
+---Activate this pane
+function Pane:activate() end
+
+---Send text to pane
+---@param text string
+function Pane:send_text(text) end
+
+---Inject output into pane (appears in scrollback)
+---@param text string
+function Pane:inject_output(text) end
+
+---Get the parent tab
+---@return MuxTab
+function Pane:tab() end
+
+---@class SplitArgs
+---@field direction? "Right"|"Left"|"Top"|"Bottom"
+---@field size? number Proportion (0-1)
+---@field cwd? string
+---@field domain? table
+---@field top_level? boolean
+
+---@class PaneUrl
+---@field file_path string
+
+---@class ProcessInfo
+---@field name string
+---@field executable string
+---@field argv string[]
+---@field children? ProcessInfo[] Child processes
+---@field pid? number Process ID
+---@field ppid? number Parent process ID
+---@field cwd? string Current working directory
+
+---@class PaneDimensions
+---@field cols number
+---@field rows number
+---@field scrollback_rows number
+---@field pixel_width number
+---@field pixel_height number
+
+---@class GuiWindow
+local GuiWindow = {}
+
+---Set inner window size
+---@param width number
+---@param height number
+function GuiWindow:set_inner_size(width, height) end
+
+---Perform action
+---@param action table
+---@param pane? Pane
+function GuiWindow:perform_action(action, pane) end
+
+---Get the mux window associated with this GUI window
+---@return MuxWindow
+function GuiWindow:mux_window() end
+
+---Check if this window is focused
+---@return boolean
+function GuiWindow:is_focused() end
+
+---Get the active tab
+---@return MuxTab
+function GuiWindow:active_tab() end

--- a/plugin/resurrect/types/resurrect.lua
+++ b/plugin/resurrect/types/resurrect.lua
@@ -1,0 +1,68 @@
+---@meta
+-- Resurrect plugin internal types
+
+---@class WorkspaceState
+---@field workspace string Workspace name
+---@field window_states WindowState[]
+
+---@class WindowState
+---@field title string Window title
+---@field size TabSize
+---@field tabs TabState[]
+
+---@class TabState
+---@field title string Tab title
+---@field is_active boolean
+---@field is_zoomed boolean
+---@field pane_tree PaneTree
+
+---@class PaneTree
+---@field left number X coordinate
+---@field top number Y coordinate
+---@field width number Pane width in cells
+---@field height number Pane height in cells
+---@field cwd string Current working directory
+---@field domain? string Mux domain name
+---@field text? string Scrollback content
+---@field process? ProcessInfo Foreground process
+---@field is_active boolean Is active pane
+---@field is_zoomed boolean Is zoomed
+---@field alt_screen_active boolean Alt screen mode (vim, etc.)
+---@field right? PaneTree Right child (horizontal split)
+---@field bottom? PaneTree Bottom child (vertical split)
+---@field pane? Pane Current pane object (set during restore)
+
+---@class RestoreOptions
+---@field relative? boolean Use relative sizing
+---@field absolute? boolean Use absolute sizing
+---@field window? MuxWindow Target window
+---@field tab? MuxTab Target tab
+---@field pane? Pane Target pane
+---@field on_pane_restore? fun(pane_tree: PaneTree) Custom restore callback
+---@field close_open_panes? boolean Close existing panes
+---@field close_open_tabs? boolean Close existing tabs
+---@field spawn_in_workspace? boolean Spawn in workspace
+---@field resize_window? boolean Resize window to match saved state
+---@field restore_text? boolean Restore scrollback text
+
+---@class SplitCommand
+---@field direction "Right"|"Bottom"
+---@field cwd string
+---@field size? number
+---@field text? string
+---@field domain? string
+
+---@class RawPaneData
+---@field left number
+---@field top number
+---@field width number
+---@field height number
+---@field cwd string
+---@field domain string
+---@field is_spawnable boolean
+---@field text string
+---@field process? ProcessInfo
+---@field is_active boolean
+---@field is_zoomed boolean
+---@field alt_screen_active boolean
+

--- a/plugin/resurrect/types/resurrect.lua
+++ b/plugin/resurrect/types/resurrect.lua
@@ -65,4 +65,3 @@
 ---@field is_active boolean
 ---@field is_zoomed boolean
 ---@field alt_screen_active boolean
-

--- a/plugin/resurrect/types/resurrect.lua
+++ b/plugin/resurrect/types/resurrect.lua
@@ -65,3 +65,21 @@
 ---@field is_active boolean
 ---@field is_zoomed boolean
 ---@field alt_screen_active boolean
+
+---@class RawTabData
+---@field title string
+---@field panes RawPaneData[]
+---@field is_active boolean
+---@field is_zoomed boolean
+
+---@class RawWindowData
+---@field title string
+---@field tabs RawTabData[]
+---@field size TabSize?
+
+---@class ShellApi
+---@field extract_pane fun(pane: Pane, max_lines: number): RawPaneData
+---@field extract_panes fun(pane_infos: PaneInformation[], max_lines: number): RawPaneData[]
+---@field extract_tab fun(mux_tab: MuxTab, max_lines: number): RawTabData
+---@field extract_window fun(mux_win: MuxWindow, max_lines: number): RawWindowData
+---@field warn_not_spawnable fun(domain: string): nil

--- a/plugin/resurrect/types/wezterm.lua
+++ b/plugin/resurrect/types/wezterm.lua
@@ -1,0 +1,138 @@
+---@meta
+-- WezTerm API type definitions for LuaLS
+-- These are stubs for type checking only, not runtime code
+
+---@class WezPlugin
+local WezPlugin = {}
+
+---Require a wezterm plugin
+---@param url string Plugin URL
+---@return table
+function WezPlugin.require(url) end
+
+---@class Wezterm
+---@field mux WezMux
+---@field gui WezGui
+---@field time WezTime
+---@field plugin WezPlugin Plugin loader
+---@field target_triple string Platform identifier (e.g., "x86_64-apple-darwin")
+---@field config_dir string Path to WezTerm config directory
+---@field home_dir string User home directory
+---@field nerdfonts table<string, string> Nerd font icon mappings
+local Wezterm = {}
+
+---Log info message
+---@param msg string
+function Wezterm.log_info(msg) end
+
+---Log warning message
+---@param msg string
+function Wezterm.log_warn(msg) end
+
+---Log error message
+---@param msg string
+function Wezterm.log_error(msg) end
+
+---Encode value to JSON string
+---@param val any
+---@return string
+function Wezterm.json_encode(val) end
+
+---Parse JSON string to value
+---@param str string
+---@return any
+function Wezterm.json_parse(str) end
+
+---Emit an event
+---@param event string Event name
+---@param ... any Event arguments
+function Wezterm.emit(event, ...) end
+
+---Register event handler
+---@param event string Event name
+---@param callback function Handler function
+function Wezterm.on(event, callback) end
+
+---Join arguments for shell command
+---@param args string[]
+---@return string
+function Wezterm.shell_join_args(args) end
+
+---Run child process synchronously
+---@param args string[] Command and arguments
+---@return boolean success
+---@return string stdout
+---@return string stderr
+function Wezterm.run_child_process(args) end
+
+---Read directory contents
+---@param path string
+---@return string[] files
+function Wezterm.read_dir(path) end
+
+---Format styled text
+---@param segments table[]
+---@return string
+function Wezterm.format(segments) end
+
+---Create action callback
+---@param callback fun(window: GuiWindow, pane: Pane, id?: string, label?: string)
+---@return table action
+function Wezterm.action_callback(callback) end
+
+---@class WezAction
+---@field CloseCurrentPane fun(opts: table): table
+---@field CloseCurrentTab fun(opts: table): table
+---@field InputSelector fun(opts: table): table
+---@field PromptInputLine fun(opts: table): table
+local WezAction = {}
+
+---@type WezAction
+Wezterm.action = WezAction
+
+---@class WezMux
+local WezMux = {}
+
+---Get active workspace name
+---@return string
+function WezMux.get_active_workspace() end
+
+---Get all mux windows
+---@return MuxWindow[]
+function WezMux.all_windows() end
+
+---Spawn a new window
+---@param args? SpawnWindowArgs
+---@return MuxTab tab
+---@return Pane pane
+---@return MuxWindow window
+function WezMux.spawn_window(args) end
+
+---Get domain by name
+---@param name string
+---@return MuxDomain
+function WezMux.get_domain(name) end
+
+---Set active workspace
+---@param name string
+function WezMux.set_active_workspace(name) end
+
+---@class SpawnWindowArgs
+---@field workspace? string
+---@field cwd? string
+---@field domain? table
+
+---@class WezGui
+local WezGui = {}
+
+---Get all GUI windows
+---@return GuiWindow[]
+function WezGui.gui_windows() end
+
+---@class WezTime
+local WezTime = {}
+
+---Schedule callback after delay
+---@param seconds number
+---@param callback function
+function WezTime.call_after(seconds, callback) end

--- a/plugin/resurrect/utils.lua
+++ b/plugin/resurrect/utils.lua
@@ -6,6 +6,89 @@ utils.is_windows = wezterm.target_triple == "x86_64-pc-windows-msvc"
 utils.is_mac = (wezterm.target_triple == "x86_64-apple-darwin" or wezterm.target_triple == "aarch64-apple-darwin")
 utils.separator = utils.is_windows and "\\" or "/"
 
+--------------------------------------------------------------------------------
+-- Path Normalization (Pure Functions)
+--------------------------------------------------------------------------------
+
+--- Check if a path looks like a Windows path (has drive letter or backslashes)
+---@param path string
+---@return boolean
+function utils.is_windows_path(path)
+	-- Guard: empty or nil path is not a Windows path
+	if not path or path == "" then return false end
+	-- Drive letter (e.g., "C:") or backslash separator indicates Windows
+	return path:match("^%a:") ~= nil or path:find("\\", 1, true) ~= nil
+end
+
+--- Normalize path separators to the target platform's separator
+--- Pure function: takes explicit is_windows parameter
+---@param path string The path to normalize
+---@param to_windows boolean If true, convert to backslashes; if false, convert to forward slashes
+---@return string The normalized path
+function utils.normalize_path_separators(path, to_windows)
+	if not path or path == "" then return path end
+	-- Ternary: convert to backslash for Windows, forward slash for Unix
+	return to_windows and path:gsub("/", "\\") or path:gsub("\\", "/")
+end
+
+--- Normalize a path to the current platform's conventions
+---@param path string The path to normalize
+---@return string The normalized path
+function utils.normalize_path(path)
+	return utils.normalize_path_separators(path, utils.is_windows)
+end
+
+--- Split a path into its component parts
+--- Handles both Windows and Unix paths
+---@param path string The path to split
+---@return string[] components Array of path components
+---@return string|nil drive_or_root Drive letter (e.g., "C:") for Windows, "/" for Unix absolute paths, or nil for relative paths
+function utils.path_components(path)
+	if not path or path == "" then return {}, nil end
+
+	-- Normalize to forward slashes for consistent parsing
+	local normalized = path:gsub("\\", "/")
+
+	-- Extract drive/root prefix: Windows drive letter or Unix root
+	local drive, rest = normalized:match("^(%a:)(.*)$")
+	local drive_or_root = drive or (normalized:sub(1, 1) == "/" and "/" or nil)
+	normalized = drive and rest or (drive_or_root == "/" and normalized:sub(2) or normalized)
+
+	-- Collect non-empty path components
+	local components = {}
+	for component in normalized:gmatch("[^/]+") do
+		if component ~= "" then components[#components + 1] = component end
+	end
+
+	return components, drive_or_root
+end
+
+--- Join path components back into a path string
+---@param components string[] Array of path components
+---@param drive_or_root string|nil Drive letter or root indicator
+---@param use_backslash boolean Whether to use backslashes (Windows style)
+---@return string The joined path
+function utils.join_path_components(components, drive_or_root, use_backslash)
+	local sep = use_backslash and "\\" or "/"
+	-- Build prefix: "/" becomes sep, drive letter gets sep appended, nil becomes empty
+	local prefix = drive_or_root and (drive_or_root == "/" and sep or drive_or_root .. sep) or ""
+	return prefix .. table.concat(components, sep)
+end
+
+--- Build a path from root and a sequence of components
+--- Used for iteratively creating parent directories
+---@param components string[] Array of path components
+---@param count number Number of components to include (from the start)
+---@param drive_or_root string|nil Drive letter or root indicator
+---@param use_backslash boolean Whether to use backslashes (Windows style)
+---@return string The partial path
+function utils.build_partial_path(components, count, drive_or_root, use_backslash)
+	-- Take first N components and join them
+	local partial = {}
+	for i = 1, math.min(count, #components) do partial[#partial + 1] = components[i] end
+	return utils.join_path_components(partial, drive_or_root, use_backslash)
+end
+
 -- Helper function to remove formatting esc sequences in the string
 ---@param str string
 ---@return string
@@ -17,11 +100,9 @@ end
 -- getting screen dimensions
 ---@return number
 function utils.get_current_window_width()
-	local windows = wezterm.gui.gui_windows()
-	for _, window in ipairs(windows) do
-		if window:is_focused() then
-			return window:active_tab():get_size().cols
-		end
+	-- Find focused window and return its column width, default to 80
+	for _, window in ipairs(wezterm.gui.gui_windows()) do
+		if window:is_focused() then return window:active_tab():get_size().cols end
 	end
 	return 80
 end
@@ -52,51 +133,104 @@ function utils.execute(cmd)
 	local stdout
 	local suc, err = pcall(function()
 		local handle = io.popen(cmd)
-		if not handle then
-			error("Could not open process: " .. cmd)
-		end
+		if not handle then error("Could not open process: " .. cmd) end
 		stdout = handle:read("*a")
-		if stdout == nil then
-			error("Error running process: " .. cmd)
-		end
+		if stdout == nil then error("Error running process: " .. cmd) end
 		handle:close()
 	end)
-	if suc then
-		return suc, stdout
+	-- Return (success, stdout) on success, (false, error) on failure
+	return suc, suc and stdout or err
+end
+
+--------------------------------------------------------------------------------
+-- Directory Creation (Imperative I/O)
+--------------------------------------------------------------------------------
+
+--- Check if a path exists (file or directory)
+--- Uses os.rename as primary check, with wezterm.run_child_process fallback for special dirs (e.g., root)
+---@param path string The path to check
+---@return boolean exists True if the path exists
+function utils.path_exists(path)
+	if not path or path == "" then return false end
+
+	-- Primary: os.rename to self (fast, no process spawn)
+	local ok, err = os.rename(path, path)
+	if ok then return true end
+	if err and err:find("[Pp]ermission denied") then return true end
+
+	-- Fallback using wezterm.run_child_process instead of io.popen
+	local args = utils.is_windows
+		and { "cmd.exe", "/c", "if", "exist", path:gsub("/", "\\"), "(echo Y)" }
+		or { "test", "-e", path }
+	local success, stdout, stderr = wezterm.run_child_process(args)
+	-- For Unix: success itself indicates existence
+	-- For Windows: check stdout for "Y"
+	if utils.is_windows then
+		return stdout and stdout:match("Y") ~= nil
 	else
-		return suc, err
+		return success
 	end
 end
 
--- Create the folder if it does not exist
----@param path string
+--- Alias for path_exists (directories and files use same check)
+utils.directory_exists = utils.path_exists
+
+--- Create a single directory (not recursive)
+---@param path string The directory path to create
+---@return boolean success True if created or already exists
+---@return string|nil error Error message if creation failed
+function utils.create_single_directory(path)
+	if not path or path == "" then return false, "Path is empty" end
+	if utils.path_exists(path) then return true, nil end
+
+	local args = utils.is_windows
+		and { "cmd.exe", "/c", "mkdir", path:gsub("/", "\\") }
+		or { "mkdir", path }
+
+	local success, stdout, stderr = wezterm.run_child_process(args)
+	if success or utils.path_exists(path) then return true, nil end
+
+	return false, "Failed to create: " .. path .. (stderr and (" - " .. stderr) or "")
+end
+
+--- Create a directory and all parent directories as needed
+--- Handles Windows drive letters (e.g., C:) and both / and \ separators
+---@param path string The full directory path to create
+---@return boolean success True if all directories were created or already exist
+---@return string|nil error Error message if creation failed
 function utils.ensure_folder_exists(path)
-	if utils.is_windows then
-		os.execute('mkdir /p "' .. path:gsub("/", "\\" .. '"'))
-	else
-		os.execute('mkdir -p "' .. path .. '"')
+	if not path or path == "" then return false, "Path is empty or nil" end
+	if utils.path_exists(path) then return true, nil end
+
+	local components, drive_or_root = utils.path_components(path)
+	if #components == 0 then
+		return drive_or_root and utils.path_exists(drive_or_root) or false, "Invalid path"
 	end
+
+	-- Create directories iteratively from root
+	for i = 1, #components do
+		local partial = utils.build_partial_path(components, i, drive_or_root, utils.is_windows)
+		local success, err = utils.create_single_directory(partial)
+		if not success then return false, err end
+	end
+
+	return true, nil
 end
 
 -- deep copy
 ---@param original table
 ---@return any copy
 function utils.deepcopy(original)
-	local copy
-	if type(original) == "table" then
-		copy = {}
-		for k, v in pairs(original) do
-			copy[k] = utils.deepcopy(v)
-		end
-	else
-		copy = original
-	end
+	-- Non-tables return as-is; tables are recursively copied
+	if type(original) ~= "table" then return original end
+	local copy = {}
+	for k, v in pairs(original) do copy[k] = utils.deepcopy(v) end
 	return copy
 end
 
 -- extend table
 ---@alias behavior
----| 'error' # Raises an error if a kye exists in multiple tables
+---| 'error' # Raises an error if a key exists in multiple tables
 ---| 'keep'  # Uses the value from the leftmost table (first occurrence)
 ---| 'force' # Uses the value from the rightmost table (last occurrence)
 ---
@@ -105,44 +239,38 @@ end
 ---@return table|nil
 function utils.tbl_deep_extend(behavior, ...)
 	local tables = { ... }
-	if #tables == 0 then
-		return {}
+	if #tables == 0 then return {} end
+
+	-- Helper: copy value (deep copy tables, pass-through primitives)
+	local function copy_val(v)
+		return type(v) == "table" and utils.deepcopy(v) or v
 	end
 
+	-- Initialize result with first table
 	local result = {}
-	for k, v in pairs(tables[1]) do
-		if type(v) == "table" then
-			result[k] = utils.deepcopy(v)
-		else
-			result[k] = v
-		end
-	end
+	for k, v in pairs(tables[1]) do result[k] = copy_val(v) end
 
+	-- Behavior dispatch table for handling key conflicts
+	local conflict_handlers = {
+		error = function(k) error("Key '" .. tostring(k) .. "' exists in multiple tables") end,
+		force = function(_, v) return copy_val(v) end,
+		keep = function(_, _, existing) return existing end,  -- Keep existing value
+	}
+
+	-- Merge remaining tables
 	for i = 2, #tables do
 		for k, v in pairs(tables[i]) do
 			if type(result[k]) == "table" and type(v) == "table" then
-				-- For nested tables, we recurse with the same behavior
+				-- Recursively merge nested tables
 				result[k] = utils.tbl_deep_extend(behavior, result[k], v)
 			elseif result[k] ~= nil then
-				-- Key exists in the result already
-				if behavior == "error" then
-					error("Key '" .. tostring(k) .. "' exists in multiple tables")
-				elseif behavior == "force" then
-					-- "force" uses value from rightmost table
-					if type(v) == "table" then
-						result[k] = utils.deepcopy(v)
-					else
-						result[k] = v
-					end
-				end
-			-- "keep" keeps the leftmost value, which is already in result
+				-- Key conflict: dispatch based on behavior
+				local handler = conflict_handlers[behavior]
+				local new_val = handler(k, v, result[k])
+				if new_val ~= nil then result[k] = new_val end
 			else
-				-- Key doesn't exist in result yet, add it
-				if type(v) == "table" then
-					result[k] = utils.deepcopy(v)
-				else
-					result[k] = v
-				end
+				-- New key: just add it
+				result[k] = copy_val(v)
 			end
 		end
 	end

--- a/plugin/resurrect/utils.lua
+++ b/plugin/resurrect/utils.lua
@@ -1,4 +1,5 @@
-local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
+---@type Wezterm
+local wezterm = require("wezterm")
 
 local utils = {}
 

--- a/plugin/resurrect/window_state.lua
+++ b/plugin/resurrect/window_state.lua
@@ -1,4 +1,5 @@
-local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
+---@type Wezterm
+local wezterm = require("wezterm")
 local tab_state_mod = require("resurrect.tab_state")
 local pub = {}
 
@@ -54,6 +55,7 @@ function pub.restore_window(window, window_state, opts)
 
 	local active_tab
 	for i, tab_state in ipairs(window_state.tabs) do
+		---@type MuxTab
 		local tab
 		if i == 1 and opts.tab then
 			tab = opts.tab
@@ -66,10 +68,10 @@ function pub.restore_window(window, window_state, opts)
 		end
 
 		if i == 1 and opts.close_open_tabs then
-			close_all_other_tabs(window, tab)
+			close_all_other_tabs(window, tab --[[@as MuxTab]])
 		end
 
-		tab_state_mod.restore_tab(tab, tab_state, opts)
+		tab_state_mod.restore_tab(tab --[[@as MuxTab]], tab_state, opts)
 		if tab_state.is_active then
 			active_tab = tab
 		end

--- a/plugin/resurrect/window_state.lua
+++ b/plugin/resurrect/window_state.lua
@@ -64,7 +64,7 @@ function pub.restore_window(window, window_state, opts)
 			if tab_state.pane_tree.domain then
 				spawn_tab_args.domain = { DomainName = tab_state.pane_tree.domain }
 			end
-			tab, opts.pane, _ = window:spawn_tab(spawn_tab_args)
+			tab, opts.pane = window:spawn_tab(spawn_tab_args)
 		end
 
 		if i == 1 and opts.close_open_tabs then

--- a/plugin/resurrect/workspace_state.lua
+++ b/plugin/resurrect/workspace_state.lua
@@ -1,4 +1,5 @@
-local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
+---@type Wezterm
+local wezterm = require("wezterm")
 local window_state_mod = require("resurrect.window_state")
 
 local pub = {}

--- a/plugin/resurrect/workspace_state.lua
+++ b/plugin/resurrect/workspace_state.lua
@@ -7,7 +7,9 @@ local pub = {}
 ---@param workspace_state workspace_state
 ---@param opts? restore_opts
 function pub.restore_workspace(workspace_state, opts)
-	if workspace_state == nil then
+	-- Guard: nil state or empty window list
+	if not workspace_state or not workspace_state.window_states or #workspace_state.window_states == 0 then
+		wezterm.emit("resurrect.error", "Cannot restore empty or invalid workspace state")
 		return
 	end
 

--- a/plugin/types.lua
+++ b/plugin/types.lua
@@ -2,7 +2,5 @@
 ---@alias workspace_state {workspace: string, window_states: window_state[]}
 ---@alias window_state {title: string, tabs: tab_state[], workspace: string, size: tab_size}
 ---@alias tab_state {title: string, pane_tree: pane_tree, is_active: boolean, is_zoomed: boolean}
----@alias MuxTab any
----@alias MuxWindow any
 
 ---@alias restore_opts {spawn_in_workspace: boolean?, relative: boolean?, absolute: boolean?, close_open_tabs: boolean?, close_open_panes: boolean?, pane: Pane?, tab: MuxTab?, window: MuxWindow, resize_window: boolean?, on_pane_restore: fun(pane_tree: pane_tree)}


### PR DESCRIPTION
## Summary

- Add `shell/api.lua` module to centralize all WezTerm API calls for data extraction
- Extract pane data (cwd, domain, scrollback, process info) with Windows path fix and domain spawnability checks
- Add `extract_panes`, `extract_tab`, `extract_window` for higher-level extraction
- Add 22 tests covering all extraction functions and edge cases
- Add `RawTabData`, `RawWindowData`, `ShellApi` types to `types/resurrect.lua`

This is Phase 1 of the refactoring plan to separate the functional core from the imperative shell.

## Test plan

- [x] All 173 tests pass (including 22 new tests for shell API)
- [x] Lint passes with no warnings
- [x] Type check passes with no errors
- [x] Format check passes

```bash
make all  # Runs: fix -> lint -> check -> test
```