### PR TITLE
fix: Windows compatibility for paths and file names

### DIFF
--- a/plugin/resurrect/state_manager.lua
+++ b/plugin/resurrect/state_manager.lua
@@ -13,10 +13,10 @@ local function get_file_path(file_name, type, opt_name)
 		file_name = opt_name
 	end
 	return string.format(
-		"%s%s" .. utils.separator .. "%s.json",
+		"%s" .. utils.separator .. "%s" .. utils.separator .. "%s.json",
 		pub.save_state_dir,
 		type,
-		file_name:gsub(utils.separator, "+")
+		file_name:gsub("[" .. utils.separator .. ":%[%]?/]", "+")
 	)
 end
 

--- a/plugin/resurrect/utils.lua
+++ b/plugin/resurrect/utils.lua
@@ -72,7 +72,7 @@ end
 ---@param path string
 function utils.ensure_folder_exists(path)
 	if utils.is_windows then
-		os.execute('mkdir /p "' .. path:gsub("/", "\\" .. '"'))
+		os.execute('mkdir "' .. path:gsub("/", "\\") .. '"')
 	else
 		os.execute('mkdir -p "' .. path .. '"')
 	end


### PR DESCRIPTION
 - Fixes path construction to handle Windows backslashes
 - Add other Windows reserved path characters from the resulting file name
 - Fix mkdir call on Windows (does not have `/p` flag, and that behaviour is the default)