### PR TITLE
Fix Windows path handling + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,35 @@ to see where they are stored. You can then update them individually using git pu
 
 Add `wezterm.plugin.update_all()` to your Wezterm config.
 
+## Testing
+
+Tests are run with Busted via LuaRocks.
+
+All OSes:
+
+```sh
+luarocks install busted
+```
+
+Run tests:
+
+```sh
+eval "$(luarocks path)"
+busted
+```
+
+Windows notes:
+
+- PowerShell is the most reliable shell for running LuaRocks and Busted (Git Bash/MSYS can mangle arguments and paths).
+- If `luarocks install busted` fails while building native dependencies (for example `luasystem`), install a GCC toolchain (MinGW-w64 or MSYS2 MinGW64) and make sure its `bin` directory is on `PATH` for the PowerShell session.
+
+PowerShell usage:
+
+```powershell
+Invoke-Expression (luarocks path)
+busted
+```
+
 ## Contributions
 
 Suggestions, Issues and PRs are welcome!

--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -87,7 +87,13 @@ local function insert_panes(root, panes)
 		else
 			root.cwd = root.pane:get_current_working_dir().file_path
 			if utils.is_windows then
+				-- WezTerm returns file_path as /C:/... on Windows; strip the leading slash.
 				root.cwd = root.cwd:gsub("^/([a-zA-Z]):", "%1:")
+				-- WSL mounts Windows drives at /mnt/c/...; convert to C:\... so that
+				-- WezTerm's mux can validate the path in Windows context before spawning.
+				root.cwd = root.cwd:gsub("^/mnt/([a-zA-Z])(.*)", function(drive, rest)
+					return drive:upper() .. ":" .. rest:gsub("/", "\\")
+				end)
 			end
 		end
 

--- a/plugin/resurrect/spec/ensure_folder_exists_spec.lua
+++ b/plugin/resurrect/spec/ensure_folder_exists_spec.lua
@@ -1,0 +1,157 @@
+local function is_windows()
+  return package.config:sub(1, 1) == "\\"
+end
+
+-- Minimal wezterm stub for utils.lua.
+local wezterm_stub = {
+  target_triple = is_windows() and "x86_64-pc-windows-msvc" or "x86_64-unknown-linux-gnu",
+}
+_G.wezterm = wezterm_stub
+package.preload["wezterm"] = function()
+  return wezterm_stub
+end
+
+local search_paths = {
+  -- repo root
+  "./plugin/?.lua",
+  "./plugin/?/init.lua",
+  "./plugin/?/?.lua",
+  -- when cwd is plugin/resurrect
+  "../../plugin/?.lua",
+  "../../plugin/?/init.lua",
+  "../../plugin/?/?.lua",
+}
+
+package.path = table.concat(search_paths, ";") .. ";" .. package.path
+
+local utils = require("resurrect.utils")
+
+local sep = utils.is_windows and "\\" or "/"
+
+-- Probe by writing a temp file inside the directory.
+-- os.rename(dir, dir) can return nil on Windows for permission/lock reasons
+-- even when the directory exists, giving a misleading false negative.
+local function dir_exists(path)
+  local probe = path .. sep .. ".probe"
+  local f = io.open(probe, "w")
+  if f then
+    f:close()
+    os.remove(probe)
+    return true
+  end
+  return false
+end
+
+local function rmdir_recursive(path)
+  if utils.is_windows then
+    if not path:find('"') then
+      os.execute('rmdir /s /q "' .. path .. '" >nul 2>&1')
+    end
+  else
+    local quoted = "'" .. path:gsub("'", "'\\''") .. "'"
+    os.execute("rm -rf " .. quoted)
+  end
+end
+
+-- Returns a unique absolute temp path without creating it.
+-- tostring({}) yields a unique table address within this process; combined with
+-- os.time() it is extremely unlikely to collide across concurrent processes.
+local function unique_tmp_base()
+  local id = tostring(os.time()) .. "_" .. tostring({}):gsub("[^%w]", "")
+  if utils.is_windows then
+    local tmp_dir = os.getenv("TEMP") or os.getenv("TMP") or "C:\\Temp"
+    return tmp_dir .. "\\_resurrect_test_" .. id
+  else
+    return "/tmp/_resurrect_test_" .. id
+  end
+end
+
+describe("utils.ensure_folder_exists", function()
+  local test_base
+  local cleanup_extras  -- additional paths cleaned up by after_each
+
+  before_each(function()
+    test_base = unique_tmp_base()
+    cleanup_extras = {}
+  end)
+
+  after_each(function()
+    rmdir_recursive(test_base)
+    for _, path in ipairs(cleanup_extras) do
+      rmdir_recursive(path)
+    end
+  end)
+
+  it("creates a nested directory structure", function()
+    local nested = test_base .. sep .. "a" .. sep .. "b"
+    assert.is_true(utils.ensure_folder_exists(nested))
+    assert.is_true(dir_exists(test_base))
+    assert.is_true(dir_exists(nested))
+  end)
+
+  -- The open-handle false-negative scenario (Windows only, triggered when
+  -- WezTerm holds a handle to the directory) cannot be tested portably without
+  -- monkey-patching io.open. The idempotency test below exercises the
+  -- happy-path re-entry but not the open-handle scenario.
+  it("is idempotent on an existing path", function()
+    local nested = test_base .. sep .. "a" .. sep .. "b"
+    assert.is_true(utils.ensure_folder_exists(nested))
+    assert.is_true(utils.ensure_folder_exists(nested))
+  end)
+
+  it("handles directory names containing spaces", function()
+    local spaced = test_base .. sep .. "dir with spaces" .. sep .. "nested dir"
+    assert.is_true(utils.ensure_folder_exists(spaced))
+    assert.is_true(dir_exists(spaced))
+  end)
+
+  it("returns false when a path component is a file, not a directory", function()
+    assert.is_true(utils.ensure_folder_exists(test_base))
+    local obstacle = test_base .. sep .. "obstacle.txt"
+    local f = assert(io.open(obstacle, "w"))
+    f:write("x")
+    f:close()
+    assert.is_false(utils.ensure_folder_exists(obstacle .. sep .. "child"))
+  end)
+
+  it("handles relative paths", function()
+    local id = tostring({}):gsub("[^%w]", "")
+    local rel_base = "_resurrect_rel_" .. id
+    -- Register before asserting so after_each cleans up even on failure.
+    -- This path lands in CWD rather than the temp root, so it cannot be
+    -- covered by the test_base cleanup.
+    table.insert(cleanup_extras, rel_base)
+    local rel_nested = rel_base .. sep .. "a" .. sep .. "b"
+    assert.is_true(utils.ensure_folder_exists(rel_nested))
+    assert.is_true(dir_exists(rel_nested))
+  end)
+
+  -- Windows-only path form tests.
+  -- UNC paths (\\server\share\...) are not tested: the server and share
+  -- components cannot be created via mkdir, so a meaningful test would require
+  -- a live network share or privileged loopback (\\localhost\c$\...) that is
+  -- not suitable for a local or CI environment.
+  if utils.is_windows then
+    it("handles absolute paths with a drive letter", function()
+      local drive = (os.getenv("TEMP") or "C:\\"):match("^(%a:)") or "C:"
+      local abs_base = drive .. "\\_resurrect_abs_" .. tostring({}):gsub("[^%w]", "")
+      table.insert(cleanup_extras, abs_base)
+      local abs_nested = abs_base .. "\\x\\y"
+      assert.is_true(utils.ensure_folder_exists(abs_nested))
+      assert.is_true(dir_exists(abs_nested))
+    end)
+
+    it("normalises drive-relative paths (C:foo) to absolute from drive root", function()
+      local drive = (os.getenv("TEMP") or "C:\\"):match("^(%a:)") or "C:"
+      local id = tostring({}):gsub("[^%w]", "")
+      local abs_base = drive .. "\\_resurrect_driverel_" .. id
+      table.insert(cleanup_extras, abs_base)
+      -- Pass the path without a separator after the drive letter.
+      local driverel = drive .. "_resurrect_driverel_" .. id .. "\\sub"
+      -- The function should normalise this to drive:\... and create it there.
+      local expected = abs_base .. "\\sub"
+      assert.is_true(utils.ensure_folder_exists(driverel))
+      assert.is_true(dir_exists(expected))
+    end)
+  end
+end)

--- a/plugin/resurrect/spec/state_manager_spec.lua
+++ b/plugin/resurrect/spec/state_manager_spec.lua
@@ -1,0 +1,75 @@
+local function is_windows()
+  return package.config:sub(1, 1) == "\\"
+end
+
+-- Minimal wezterm stub.
+local wezterm_stub = {
+  target_triple = is_windows() and "x86_64-pc-windows-msvc" or "x86_64-unknown-linux-gnu",
+  emit = function() end,
+}
+_G.wezterm = wezterm_stub
+package.preload["wezterm"] = function()
+  return wezterm_stub
+end
+
+-- Stub file_io and capture the path passed to load_json so we can assert
+-- on what get_file_path (a local function) actually produced.
+local last_load_path
+package.preload["resurrect.file_io"] = function()
+  return {
+    load_json = function(path)
+      last_load_path = path
+      return {}
+    end,
+    write_state = function() end,
+    write_file = function() end,
+  }
+end
+
+local search_paths = {
+  -- repo root
+  "./plugin/?.lua",
+  "./plugin/?/init.lua",
+  "./plugin/?/?.lua",
+  -- when cwd is plugin/resurrect
+  "../../plugin/?.lua",
+  "../../plugin/?/init.lua",
+  "../../plugin/?/?.lua",
+}
+
+package.path = table.concat(search_paths, ";") .. ";" .. package.path
+
+local state_manager = require("resurrect.state_manager")
+
+local sep = is_windows() and "\\" or "/"
+local base = is_windows()
+  and ((os.getenv("TEMP") or os.getenv("TMP") or "C:\\Temp") .. "\\resurrect_sm_test")
+  or "/tmp/resurrect_sm_test"
+
+-- get_file_path is a local function and cannot be called directly.
+-- These tests exercise it via load_state(), which passes its return value
+-- straight to file_io.load_json() with no intervening transformation.
+describe("state_manager path construction (via load_state)", function()
+  before_each(function()
+    last_load_path = nil
+    state_manager.save_state_dir = base
+  end)
+
+  it("separates save_state_dir and type with a path separator", function()
+    state_manager.load_state("myworkspace", "workspace")
+    assert.equals(base .. sep .. "workspace" .. sep .. "myworkspace.json", last_load_path)
+  end)
+
+  it("replaces path separator characters in file names with +", function()
+    state_manager.load_state("foo" .. sep .. "bar", "workspace")
+    assert.equals(base .. sep .. "workspace" .. sep .. "foo+bar.json", last_load_path)
+  end)
+
+  it("replaces reserved characters : [ ] ? / in file names with +", function()
+    state_manager.load_state("name:with[reserved]chars?and/slashes", "window")
+    assert.equals(
+      base .. sep .. "window" .. sep .. "name+with+reserved+chars+and+slashes.json",
+      last_load_path
+    )
+  end)
+end)

--- a/plugin/resurrect/state_manager.lua
+++ b/plugin/resurrect/state_manager.lua
@@ -13,10 +13,10 @@ local function get_file_path(file_name, type, opt_name)
 		file_name = opt_name
 	end
 	return string.format(
-		"%s%s" .. utils.separator .. "%s.json",
+		"%s" .. utils.separator .. "%s" .. utils.separator .. "%s.json",
 		pub.save_state_dir,
 		type,
-		file_name:gsub(utils.separator, "+")
+		file_name:gsub("[" .. utils.separator .. ":%[%]?/]", "+")
 	)
 end
 

--- a/plugin/resurrect/utils.lua
+++ b/plugin/resurrect/utils.lua
@@ -68,14 +68,128 @@ function utils.execute(cmd)
 	end
 end
 
--- Create the folder if it does not exist
----@param path string
-function utils.ensure_folder_exists(path)
+-- Shell-safe wrapper around mkdir for a single already-assembled path segment.
+-- On Unix, single-quote wrapping is used so that spaces and most metacharacters
+-- are inert; embedded single quotes are escaped with the '\'' idiom.
+-- On Windows, " is not a valid NTFS filename character so we validate and reject
+-- rather than attempt to escape it; remaining quoting via double-quotes is safe.
+local function shell_mkdir(path)
 	if utils.is_windows then
-		os.execute('mkdir /p "' .. path:gsub("/", "\\" .. '"'))
+		if path:find('"') then
+			return false
+		end
+		return os.execute('mkdir "' .. path .. '"')
 	else
-		os.execute('mkdir -p "' .. path .. '"')
+		local quoted = "'" .. path:gsub("'", "'\\''") .. "'"
+		return os.execute("mkdir " .. quoted)
 	end
+end
+
+-- Normalise separators and strip the root prefix from path.
+-- Returns the platform separator, the root component (e.g. "C:\", "/", "\\"),
+-- and the remaining path with the root removed.
+-- On Windows forward slashes are converted to backslashes before parsing.
+---@param path string
+---@return string sep, string root, string stripped
+local function parse_root(path)
+	local sep
+	if utils.is_windows then
+		sep = "\\"
+		path = path:gsub("/", sep)
+	else
+		sep = "/"
+	end
+
+	local root = ""
+	if utils.is_windows then
+		local drive = path:match("^(%a:)[/\\]")
+		if drive then
+			-- Absolute path (e.g. C:\foo): capture "C:", append sep to form "C:\",
+			-- then strip the 3-char prefix so the remainder is "foo\...".
+			root = drive .. sep
+			path = path:sub(4)
+		elseif path:match("^%a:[^/\\]") then
+			-- Drive-relative path (e.g. C:foo); normalise to absolute from drive root.
+			-- Strip the 2-char "C:" prefix; root gets the explicit separator added.
+			root = path:sub(1, 2) .. sep
+			path = path:sub(3)
+		elseif path:sub(1, 2) == "\\\\" then
+			-- UNC path (e.g. \\server\share\...): strip the 2-char "\\" prefix.
+			-- The server and share components cannot be created via mkdir;
+			-- this only works when the share already exists.
+			root = "\\\\"
+			path = path:sub(3)
+		end
+	else
+		if path:sub(1, 1) == "/" then
+			-- Absolute Unix path: strip the leading separator; root is "/".
+			root = "/"
+			path = path:sub(2)
+		end
+	end
+
+	return sep, root, path
+end
+
+-- Probe-write check: attempts to create and immediately remove a temp file
+-- inside path. More reliable than os.rename on Windows, where open handles
+-- held by WezTerm itself cause os.rename(dir, dir) to return nil even when
+-- the directory exists and is fully usable.
+-- A unique suffix from tostring({}) (table address) avoids collisions across
+-- concurrent processes or calls.
+local function dir_is_accessible(path)
+	local probe = path .. utils.separator .. ".resurrect_probe_" .. tostring({}):gsub("[^%w]", "")
+	local f = io.open(probe, "w")
+	if f then
+		f:close()
+		os.remove(probe)
+		return true
+	end
+	return false
+end
+
+-- Ensure a single already-assembled path exists, creating it if necessary.
+-- Returns false if the directory could not be created or verified.
+---@param path string
+---@return boolean
+local function mkdir_if_missing(path)
+	-- Probe-write is the primary existence check. os.rename is skipped because
+	-- it gives false negatives on Windows when WezTerm holds open handles,
+	-- which would cause shell_mkdir to be called on every startup for
+	-- directories that already exist, producing visible cmd.exe window flashes.
+	if dir_is_accessible(path) then
+		return true
+	end
+	if shell_mkdir(path) then
+		-- Post-verify: confirm the directory is actually usable after creation.
+		return dir_is_accessible(path)
+	end
+	return false
+end
+
+-- Create the folder if it does not exist.
+-- Drive-relative paths on Windows (e.g. C:foo\bar) are normalised to absolute
+-- from the drive root (C:\foo\bar). UNC paths (\\server\share\...) are
+-- supported only when the server and share components already exist.
+-- Path components are not sanitized; . and .. segments produce undefined behavior.
+---@param path string
+---@return boolean success
+function utils.ensure_folder_exists(path)
+	local sep, root, stripped = parse_root(path)
+	local current = root
+	for part in string.gmatch(stripped, "[^" .. sep .. "]+") do
+		if current == "" then
+			current = part
+		elseif current:sub(-1) == sep then
+			current = current .. part
+		else
+			current = current .. sep .. part
+		end
+		if not mkdir_if_missing(current) then
+			return false
+		end
+	end
+	return true
 end
 
 -- deep copy


### PR DESCRIPTION
This PR fixes various windows path handling bugs. Building on https://github.com/MLFlexer/resurrect.wezterm/pull/134 it
- Removes the `/p` flag which breaks mkdir on Windows.
- Handles sanitizing reserved characters in path names on windows (`: [ ] ? /`).
- Fixes some path construction bugs that meant `get_file_path` wasn't using `type` so `state_dir/workspace/name.json` would be incorrectly rendered as `state_dir/name.json`.

It also
- Adds tests.
- Adds handling to different windows path forms (e.g., relative paths like `C:foo`).
- Adds more robust quoting of paths.
- Handles restoring paths from inside WSL for `/mnt/<drive letter>` paths.

Individual commits are self-describing — see the commit log for details.