### PR TITLE
feat(state_manager): add event_driven_save for immediate saves on structural changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,48 @@ You can add the `opts` table to change the behaviour. It exposes the following o
 `save_windows` will save windows if true otherwise not.
 `save_tabs` will save tabs if true otherwise not.
 
+### Event-driven saving of state
+
+`resurrect.state_manager.event_driven_save(opts?)` saves state immediately whenever
+the pane or tab structure changes (new split, new tab, closed pane), rather than
+waiting for a periodic timer. This is the recommended approach when you want
+state to always be current.
+
+```lua
+resurrect.state_manager.event_driven_save({
+  save_workspaces = true,  -- default: true
+  save_windows    = false, -- default: false
+  save_tabs       = false, -- default: false
+  user_var        = nil,   -- optional: name of a user variable to also trigger saves
+})
+```
+
+`save_workspaces`, `save_windows`, and `save_tabs` mirror the same options in `periodic_save`.
+
+`user_var` enables an additional save trigger via shell integration. When set, a save
+fires whenever the shell sends an OSC 1337 `SetUserVar` sequence with that variable name.
+This is useful for saving on directory change. Example shell integration (zsh/bash):
+
+```sh
+# In your .zshrc / .bashrc — fires only when $PWD changes
+_wezterm_precmd() {
+  if [[ "$PWD" != "$_WEZTERM_LAST_PWD" ]]; then
+    _WEZTERM_LAST_PWD="$PWD"
+    printf "\033]1337;SetUserVar=WEZTERM_SAVE=%s\007" "$(printf 1 | base64)"
+  fi
+}
+precmd_functions+=(_wezterm_precmd)
+```
+
+Then pass the matching variable name to `event_driven_save`:
+
+```lua
+resurrect.state_manager.event_driven_save({ user_var = "WEZTERM_SAVE" })
+```
+
+`event_driven_save` also keeps `current_state` up to date on every save, which is
+required for `resurrect_on_gui_startup` to restore the correct workspace.
+
 ### Resurrecting on startup
 
 You can resume from where you left off by resurrecting on startup with
@@ -344,6 +386,8 @@ This plugin emits the following events that you can use for your own callback fu
 - `resurrect.state_manager.delete_state.start(file_path)`
 - `resurrect.state_manager.load_state.finished(name, type)`
 - `resurrect.state_manager.load_state.start(name, type)`
+- `resurrect.state_manager.event_driven_save.start(opts)`
+- `resurrect.state_manager.event_driven_save.finished(opts)`
 - `resurrect.state_manager.periodic_save.start(opts)`
 - `resurrect.state_manager.periodic_save.finished(opts)`
 - `resurrect.file_io.write_state.finished(file_path, event_type)`

--- a/plugin/resurrect/state_manager.lua
+++ b/plugin/resurrect/state_manager.lua
@@ -90,6 +90,80 @@ function pub.periodic_save(opts)
 	end)
 end
 
+---Saves the state whenever the pane or tab structure changes.
+---More responsive than periodic_save: fires immediately on splits, new tabs,
+---and closed panes rather than waiting for a timer.
+---Also supports an optional user variable trigger for shell-reported events
+---such as directory changes (requires shell integration to send the OSC 1337
+---SetUserVar sequence; see the README for details).
+---@param opts? { save_workspaces: boolean?, save_windows: boolean?, save_tabs: boolean?, user_var: string? }
+function pub.event_driven_save(opts)
+	opts = opts or {}
+	if opts.save_workspaces == nil then
+		opts.save_workspaces = true
+	end
+
+	local last_structure = {}
+
+	local function do_save(window)
+		wezterm.emit("resurrect.state_manager.event_driven_save.start", opts)
+
+		if opts.save_workspaces then
+			local workspace_state = require("resurrect.workspace_state").get_workspace_state()
+			pub.save_state(workspace_state)
+			pub.write_current_state(workspace_state.workspace, "workspace")
+		end
+
+		if opts.save_windows then
+			local mux_win = window:mux_window()
+			local title = mux_win:get_title()
+			if title ~= "" and title ~= nil then
+				pub.save_state(require("resurrect.window_state").get_window_state(mux_win))
+			end
+		end
+
+		if opts.save_tabs then
+			local mux_win = window:mux_window()
+			for _, mux_tab in ipairs(mux_win:tabs()) do
+				local title = mux_tab:get_title()
+				if title ~= "" and title ~= nil then
+					pub.save_state(require("resurrect.tab_state").get_tab_state(mux_tab))
+				end
+			end
+		end
+
+		wezterm.emit("resurrect.state_manager.event_driven_save.finished", opts)
+	end
+
+	-- Save when the pane/tab structure changes (new split, new tab, closed pane).
+	-- pane-focus-changed fires on every focus move, so we compare tab+pane counts
+	-- and only save when the structure actually changes.
+	wezterm.on("pane-focus-changed", function(window, pane)
+		local win_id = tostring(window:window_id())
+		local tabs = window:mux_window():tabs()
+		local pane_count = 0
+		for _, tab in ipairs(tabs) do
+			pane_count = pane_count + #tab:panes()
+		end
+		local sig = #tabs .. ":" .. pane_count
+		if last_structure[win_id] ~= sig then
+			last_structure[win_id] = sig
+			do_save(window)
+		end
+	end)
+
+	-- Optional: also save when the shell reports a user-defined variable change.
+	-- Useful for saving on directory change. Example shell integration (zsh/bash):
+	--   precmd() { printf "\033]1337;SetUserVar=WEZTERM_SAVE=%s\007" "$(printf 1 | base64)"; }
+	if opts.user_var then
+		wezterm.on("user-var-changed", function(window, pane, name, value)
+			if name == opts.user_var then
+				do_save(window)
+			end
+		end)
+	end
+end
+
 ---Writes the current state name and type
 ---@param name string
 ---@param type string


### PR DESCRIPTION
## Summary

feat(state_manager): add event_driven_save for immediate saves on structural changes

Adds `resurrect.state_manager.event_driven_save(opts)` as a complement to
`periodic_save`. Instead of a timer, it saves whenever pane/tab structure
changes (detected via `pane-focus-changed`) and optionally on shell-reported
events via `user-var-changed` (e.g. directory changes using OSC 1337 shell
integration).

Also keeps `current_state` up to date on every save so that
`resurrect_on_gui_startup` always has a fresh workspace to restore.

Documents the new function, its opts, the shell integration pattern, and
the two new events in the README.