### PR TITLE
fix: cd to original CWD before restoring Claude Code sessions

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,42 @@
+-- luacheck configuration for wezterm-resurrect
+-- WezTerm plugin using Lua 5.4
+
+-- Target Lua version (WezTerm embeds Lua 5.4)
+std = "lua54"
+
+-- Maximum line length (relaxed for annotation comments)
+max_line_length = 150
+max_code_line_length = 120
+max_comment_line_length = false
+
+-- Global variables injected by WezTerm runtime
+globals = {
+    "wezterm",
+}
+
+-- Read-only globals available in the WezTerm environment
+read_globals = {
+    "wezterm",
+}
+
+-- Warnings to ignore project-wide
+ignore = {
+    "212",      -- unused argument (common in WezTerm callbacks: function(window, pane))
+    "213",      -- unused loop variable (common: for _, item in ipairs(...))
+    "631",      -- max_line_length (handled separately above)
+}
+
+-- Per-path overrides
+files["plugin/resurrect/spec/**"] = {
+    -- Test files use busted globals (describe, it, assert, etc.)
+    std = "+busted",
+    -- Allow test-specific globals
+    globals = {
+        "_G",
+    },
+}
+
+files["plugin/resurrect/test/**"] = {
+    -- Test helper files
+    std = "+busted",
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# wezterm-resurrect
+
+Fork of MLFlexer/resurrect.wezterm with Windows fixes, security hardening, and Claude Code session restoration.
+
+## Branching & Worktrees
+
+- Never commit directly to main branch
+- All feature/fix work happens on branches in worktrees
+- Worktrees live at `Documents/Code/wezterm-resurrect Worktrees/<branch-name>`
+- Before creating a new worktree, update local main with latest from remote main
+- PRs merge to main with squash via `gh pr merge --squash`
+- Main repo at `Documents/Code/wezterm-resurrect` stays on `main` as the clean reference
+
+## Plugin Architecture
+
+- Entry point: `plugin/init.lua`
+- Modules: `plugin/resurrect/` (state_manager, instance_manager, pane_tree, tab_state, window_state, workspace_state, process_handlers, file_io, encryption, fuzzy_loader, utils)
+- Plugin cache on Windows: `%APPDATA%/wezterm/plugins/httpssCssZssZsgithubsDscomsZsYedPoolsZsresurrectsDswezterm/`
+- After pushing changes, also copy modified files to the plugin cache for immediate testing
+
+## WezTerm Lua Constraints
+
+- `wezterm.run_child_process` yields (async) -- cannot be called during plugin init or config loading. Use `os.execute` for synchronous operations needed at init time.
+- `package.config:sub(1,1)` returns `/` in WezTerm Lua on Windows -- use `utils.is_windows` and `utils.separator` instead
+- `os.rename` fails on Windows when target file exists -- use direct `io.open("w")` writes instead of atomic rename for small metadata files
+- Plugin code is loaded into memory on WezTerm startup -- cache updates require a WezTerm restart to take effect
+
+## Testing
+
+- Run `bash test_debug/verify.sh` for luacheck + busted tests
+- Always verify cached plugin matches source repo before testing
+- No Lua runtime installed on system -- tests use bundled tools in `test_debug/tools/`
+
+## Multi-Instance State Management
+
+- Each WezTerm process gets a unique instance ID (`os.time() .. "_" .. math.random()`)
+- Instance state saved to `state/instances/<instance_id>.json` + `.meta`
+- On startup, instance selector auto-shows if saved instances exist (`auto_restore_prompt` option)
+- Alt+R shows instance selector with restore/delete/rename modes; [Browse named saves] falls through to fuzzy_loader
+- Alt+S triggers a full manual save (workspace + instance + status bar update)
+- Old instances auto-cleaned after `retention_days` (default 7)
+
+## Claude Code Integration
+
+- SessionStart hook writes session data to `~/.claude/pane-sessions/<WEZTERM_PANE>.json`
+- `setup_claude_session_hooks()` auto-configures both `~/.claude/settings.json` and `~/.claude-alt/settings.json` (for claude2 multi-account setups)
+- Process detection uses pane-session files as primary signal (foreground process is unreliable when Claude runs child processes)
+- claude vs claude2 distinguished via `transcript_path` in pane-session data (`.claude-alt` = claude2)
+- Supports `claude`, `claude2`, and other variants via pattern matching

--- a/README.md
+++ b/README.md
@@ -212,6 +212,48 @@ You can add the `opts` table to change the behaviour. It exposes the following o
 `save_windows` will save windows if true otherwise not.
 `save_tabs` will save tabs if true otherwise not.
 
+### Event-driven saving of state
+
+`resurrect.state_manager.event_driven_save(opts?)` saves state immediately whenever
+the pane or tab structure changes (new split, new tab, closed pane), rather than
+waiting for a periodic timer. This is the recommended approach when you want
+state to always be current.
+
+```lua
+resurrect.state_manager.event_driven_save({
+  save_workspaces = true,  -- default: true
+  save_windows    = false, -- default: false
+  save_tabs       = false, -- default: false
+  user_var        = nil,   -- optional: name of a user variable to also trigger saves
+})
+```
+
+`save_workspaces`, `save_windows`, and `save_tabs` mirror the same options in `periodic_save`.
+
+`user_var` enables an additional save trigger via shell integration. When set, a save
+fires whenever the shell sends an OSC 1337 `SetUserVar` sequence with that variable name.
+This is useful for saving on directory change. Example shell integration (zsh/bash):
+
+```sh
+# In your .zshrc / .bashrc — fires only when $PWD changes
+_wezterm_precmd() {
+  if [[ "$PWD" != "$_WEZTERM_LAST_PWD" ]]; then
+    _WEZTERM_LAST_PWD="$PWD"
+    printf "\033]1337;SetUserVar=WEZTERM_SAVE=%s\007" "$(printf 1 | base64)"
+  fi
+}
+precmd_functions+=(_wezterm_precmd)
+```
+
+Then pass the matching variable name to `event_driven_save`:
+
+```lua
+resurrect.state_manager.event_driven_save({ user_var = "WEZTERM_SAVE" })
+```
+
+`event_driven_save` also keeps `current_state` up to date on every save, which is
+required for `resurrect_on_gui_startup` to restore the correct workspace.
+
 ### Resurrecting on startup
 
 You can resume from where you left off by resurrecting on startup with
@@ -344,6 +386,8 @@ This plugin emits the following events that you can use for your own callback fu
 - `resurrect.state_manager.delete_state.start(file_path)`
 - `resurrect.state_manager.load_state.finished(name, type)`
 - `resurrect.state_manager.load_state.start(name, type)`
+- `resurrect.state_manager.event_driven_save.start(opts)`
+- `resurrect.state_manager.event_driven_save.finished(opts)`
 - `resurrect.state_manager.periodic_save.start(opts)`
 - `resurrect.state_manager.periodic_save.finished(opts)`
 - `resurrect.file_io.write_state.finished(file_path, event_type)`
@@ -504,6 +548,35 @@ to see where they are stored. You can then update them individually using git pu
 #### Automatically
 
 Add `wezterm.plugin.update_all()` to your Wezterm config.
+
+## Testing
+
+Tests are run with Busted via LuaRocks.
+
+All OSes:
+
+```sh
+luarocks install busted
+```
+
+Run tests:
+
+```sh
+eval "$(luarocks path)"
+busted
+```
+
+Windows notes:
+
+- PowerShell is the most reliable shell for running LuaRocks and Busted (Git Bash/MSYS can mangle arguments and paths).
+- If `luarocks install busted` fails while building native dependencies (for example `luasystem`), install a GCC toolchain (MinGW-w64 or MSYS2 MinGW64) and make sure its `bin` directory is on `PATH` for the PowerShell session.
+
+PowerShell usage:
+
+```powershell
+Invoke-Expression (luarocks path)
+busted
+```
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -95,12 +95,13 @@ return config
 **3. Restart WezTerm.** The plugin downloads automatically on first launch.
 
 `setup(config)` automatically configures:
+- **Per-instance state saving** -- each WezTerm window saves independently (no more clobbering between windows)
 - **Event-driven + periodic (5 min) state saving** of workspaces, windows, and tabs
-- **Workspace restoration on startup** -- reopen all your tabs, panes, and working directories
+- **Instance selector on startup** -- if saved instances exist, shows a selector to restore/delete/rename them
 - **Claude Code session restoration** -- detects Claude Code processes and resumes them via `--resume <session-id>`
-- **Claude Code SessionStart hook** in `~/.claude/settings.json` for session ID tracking
+- **Claude Code SessionStart hook** in `~/.claude/settings.json` (and `~/.claude-alt/settings.json` for multi-account `claude2` setups)
 - **Status bar** showing last save time and tab titles
-- **Keybindings**: Alt+W (save workspace), Alt+R (fuzzy restore), Alt+Shift+W (save window), Alt+Shift+T (save tab)
+- **Keybindings**: Alt+S (full save), Alt+R (instance selector / restore), Alt+W (save workspace), Alt+Shift+W (save window), Alt+Shift+T (save tab)
 
 No manual plugin installation needed -- `wezterm.plugin.require()` auto-fetches from GitHub on first launch.
 
@@ -110,14 +111,16 @@ All options are optional. Defaults are shown below:
 
 ```lua
 resurrect.setup(config, {
-  periodic_interval  = 300,   -- seconds between periodic saves (default: 5 min)
-  restore_delay      = 3,     -- seconds to wait before sending restore commands
-  save_workspaces    = true,  -- save workspace state
-  save_windows       = true,  -- save window state
-  save_tabs          = true,  -- save tab state
-  keybindings        = true,  -- add Alt+W/R/Shift+W/Shift+T bindings
-  status_bar         = true,  -- show save time + tab titles in right status
-  claude_hooks       = true,  -- auto-configure Claude Code SessionStart hook
+  periodic_interval    = 300,   -- seconds between periodic saves (default: 5 min)
+  restore_delay        = 3,     -- seconds to wait before sending restore commands
+  save_workspaces      = true,  -- save workspace state
+  save_windows         = true,  -- save window state
+  save_tabs            = true,  -- save tab state
+  keybindings          = true,  -- add Alt+S/R/W/Shift+W/Shift+T bindings
+  status_bar           = true,  -- show save time + tab titles in right status
+  claude_hooks         = true,  -- auto-configure Claude Code SessionStart hook
+  auto_restore_prompt  = true,  -- show instance selector on startup if saved instances exist
+  retention_days       = 7,     -- auto-delete instance states older than this many days
 })
 ```
 
@@ -375,8 +378,14 @@ required for `resurrect_on_gui_startup` to restore the correct workspace.
 
 ### Resurrecting on startup
 
-You can resume from where you left off by resurrecting on startup with
-the following addition to your config:
+If you use `setup()`, startup restoration is automatic. On startup:
+1. Old instances (older than `retention_days`) are cleaned up
+2. If saved instances exist and `auto_restore_prompt` is true, an instance selector appears
+3. If no instances exist, it falls back to the legacy `current_state` mechanism
+
+You can dismiss the selector (Esc) to start fresh.
+
+For manual configuration without `setup()`, you can still use the legacy approach:
 
 ```lua
 wezterm.on("gui-startup", resurrect.state_manager.resurrect_on_gui_startup)
@@ -511,6 +520,8 @@ This plugin emits the following events that you can use for your own callback fu
 - `resurrect.state_manager.periodic_save.finished(opts)`
 - `resurrect.file_io.write_state.finished(file_path, event_type)`
 - `resurrect.file_io.write_state.start(file_path, event_type)`
+- `resurrect.instance_manager.save_instance.finished(instance_id)`
+- `resurrect.instance_manager.delete_instance.finished(instance_id)`
 - `resurrect.tab_state.restore_tab.finished`
 - `resurrect.tab_state.restore_tab.start`
 - `resurrect.window_state.restore_window.finished`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,126 @@ Resurrect your terminal environment!⚰️ A plugin to save the state of your wi
 - Re-attach to remote domains (e.g. SSH, SSHMUX, WSL, Docker, ect.).
 - Optionally enable encryption and decryption of the saved state.
 
-## Setup example
+## Quick Start
+
+### One-Line Install
+
+Paste into your terminal. This creates a new config or patches your existing one (with backup):
+
+**PowerShell (Windows):**
+
+```powershell
+$f="$HOME\.wezterm.lua"; if (!(Test-Path $f)) { @"
+local wezterm = require("wezterm")
+local config = wezterm.config_builder()
+local resurrect = wezterm.plugin.require("https://github.com/YedPool/resurrect.wezterm")
+
+resurrect.setup(config)
+
+return config
+"@ | Set-Content $f -Encoding UTF8; Write-Host "Created $f with resurrect enabled" } elseif (Select-String -Path $f -Pattern "resurrect" -Quiet) { Write-Host "resurrect is already in your config" } else { Copy-Item $f "$f.bak"; $c = Get-Content $f -Raw; $req = 'local resurrect = wezterm.plugin.require("https://github.com/YedPool/resurrect.wezterm")'; $c = $c -replace '(local\s+config\s*=\s*wezterm\.config_builder\(\))', "`$1`n$req"; $c = $c -replace '(return\s+config)', "resurrect.setup(config)`n`$1"; Set-Content $f $c -Encoding UTF8; Write-Host "Updated $f (backup saved to $f.bak)" }
+```
+
+**Bash (macOS / Linux):**
+
+```bash
+f="$HOME/.wezterm.lua"; if [ ! -f "$f" ]; then cat > "$f" << 'EOF'
+local wezterm = require("wezterm")
+local config = wezterm.config_builder()
+local resurrect = wezterm.plugin.require("https://github.com/YedPool/resurrect.wezterm")
+
+resurrect.setup(config)
+
+return config
+EOF
+echo "Created $f with resurrect enabled"; elif grep -q "resurrect" "$f"; then echo "resurrect is already in your config"; else cp "$f" "$f.bak"; sed -i.tmp '/config_builder()/a local resurrect = wezterm.plugin.require("https://github.com/YedPool/resurrect.wezterm")' "$f"; sed -i.tmp 's/return config/resurrect.setup(config)\nreturn config/' "$f"; rm -f "$f.tmp"; echo "Updated $f (backup saved to $f.bak)"; fi
+```
+
+Then restart WezTerm. On first launch it automatically downloads the plugin from GitHub.
+
+### Manual Install
+
+If you prefer to set things up by hand, or the one-liner didn't work with your config:
+
+**1. Locate your config file:**
+
+| OS | Path |
+|----|------|
+| **Windows** | `C:\Users\<username>\.wezterm.lua` |
+| **macOS** | `~/.wezterm.lua` |
+| **Linux** | `~/.wezterm.lua` or `$XDG_CONFIG_HOME/wezterm/wezterm.lua` |
+
+If you don't have one yet, create it. See the [WezTerm config docs](https://wezfurlong.org/wezterm/config/files.html) for details.
+
+**2. Add these two lines to your config:**
+
+Add the `require` line near the top (after `local config = wezterm.config_builder()`):
+
+```lua
+local resurrect = wezterm.plugin.require("https://github.com/YedPool/resurrect.wezterm")
+```
+
+Add the `setup` call before `return config`:
+
+```lua
+resurrect.setup(config)
+```
+
+A complete minimal config looks like this:
+
+```lua
+local wezterm = require("wezterm")
+local config = wezterm.config_builder()
+local resurrect = wezterm.plugin.require("https://github.com/YedPool/resurrect.wezterm")
+
+-- your existing config here (colors, fonts, shell, etc.)
+
+resurrect.setup(config)
+
+return config
+```
+
+**3. Restart WezTerm.** The plugin downloads automatically on first launch.
+
+`setup(config)` automatically configures:
+- **Event-driven + periodic (5 min) state saving** of workspaces, windows, and tabs
+- **Workspace restoration on startup** -- reopen all your tabs, panes, and working directories
+- **Claude Code session restoration** -- detects Claude Code processes and resumes them via `--resume <session-id>`
+- **Claude Code SessionStart hook** in `~/.claude/settings.json` for session ID tracking
+- **Status bar** showing last save time and tab titles
+- **Keybindings**: Alt+W (save workspace), Alt+R (fuzzy restore), Alt+Shift+W (save window), Alt+Shift+T (save tab)
+
+No manual plugin installation needed -- `wezterm.plugin.require()` auto-fetches from GitHub on first launch.
+
+### Setup Options
+
+All options are optional. Defaults are shown below:
+
+```lua
+resurrect.setup(config, {
+  periodic_interval  = 300,   -- seconds between periodic saves (default: 5 min)
+  restore_delay      = 3,     -- seconds to wait before sending restore commands
+  save_workspaces    = true,  -- save workspace state
+  save_windows       = true,  -- save window state
+  save_tabs          = true,  -- save tab state
+  keybindings        = true,  -- add Alt+W/R/Shift+W/Shift+T bindings
+  status_bar         = true,  -- show save time + tab titles in right status
+  claude_hooks       = true,  -- auto-configure Claude Code SessionStart hook
+})
+```
+
+Set any option to `false` to disable that feature. For example, to skip keybindings and add your own:
+
+```lua
+resurrect.setup(config, { keybindings = false })
+
+-- Add your own custom bindings here
+config.keys = { ... }
+```
+
+## Advanced Setup (Manual Configuration)
+
+If you need fine-grained control over each component, you can configure them individually instead of using `setup()`.
 
 1. Require the plugin:
 

--- a/planning/deep-review-full-repo.md
+++ b/planning/deep-review-full-repo.md
@@ -1,0 +1,199 @@
+# Deep Review: wezterm-resurrect Full Repo
+**Date:** 2026-03-13
+**Branch:** main
+**Files Reviewed:** 15 Lua files + README.md
+
+---
+
+## Executive Summary
+
+The plugin is architecturally sound with clean call chains (0 broken cross-layer calls out of 73 verified). However, the security audit revealed 3 critical command injection vectors stemming from a single root cause: **state files are trusted implicitly, and their contents are sent as keystrokes to terminal panes**. Anyone who can write to the state directory can achieve arbitrary code execution. The optimization review found dead code, a 200-line function needing decomposition, and duplicated save logic. Overall this is solid work that needs input validation hardening before public release.
+
+---
+
+## Security Findings
+
+### Critical
+
+**S1. Command injection via crafted state files -- process restore commands**
+- File: `tab_state.lua:197-206`, `process_handlers.lua:189`
+- The `get_restore_cmd` function builds a command from JSON state data (`process_info.name`, `session_id`) and sends it to the terminal via `send_text()`. A tampered state file can inject arbitrary shell commands. While `wezterm.shell_join_args()` provides quoting, the binary name on line 189 is used without validation.
+- Fix: Validate binary name matches `^claude[%d%-]*$` and session_id matches `^[%x%-]+$`.
+
+**S2. Command injection via `cd` in tab restoration**
+- File: `tab_state.lua:104`
+- CWD from state file is sent as `cd <cwd>\r\n` to a shell pane. A crafted CWD with shell metacharacters could escape quoting.
+- Fix: Reject CWDs containing `[;&|` + backtick + `$(){}]` characters.
+
+**S3. Command injection in `setup_claude_session_hooks` via `os.execute`**
+- File: `process_handlers.lua:290-293`
+- `pane_sessions_dir` (derived from `HOME`/`USERPROFILE`) is interpolated into an `os.execute` shell string without sanitization. Does NOT use `utils.shell_mkdir` which has a `"` check.
+- Fix: Use `utils.shell_mkdir()` or validate the path contains no shell metacharacters.
+
+### High
+
+**S4. Path traversal in `delete_state` -- incomplete protection**
+- File: `state_manager.lua:251-266`
+- Only checks for `..` but allows absolute paths, symlinks. `os.remove` called on user-influenced path.
+- Fix: Also reject paths starting with `/`, `\`, or drive letters (`%a:`), and restrict to `.json` extension.
+
+**S5. Secrets exposure -- terminal scrollback saved as plaintext JSON**
+- File: `pane_tree.lua:239`
+- Up to 3500 lines of scrollback (which may contain API keys, passwords, tokens) saved as plaintext JSON with default umask permissions.
+- Fix: Set restrictive file permissions (0600/0700), consider secret-scrubbing regex, push encryption recommendation more prominently.
+
+**S6. Arbitrary file overwrite via `WEZTERM_PANE` injection**
+- File: `process_handlers.lua:343`
+- The SessionStart hook command: `cat > "$HOME/.claude/pane-sessions/${WEZTERM_PANE:-unknown}.json"`. A crafted `WEZTERM_PANE` value like `../../.bashrc` would overwrite arbitrary files.
+- Fix: Validate `WEZTERM_PANE` matches `^[0-9]+$` in the hook command.
+
+**S7. Claude Code `settings.json` manipulation -- non-atomic write + TOCTOU**
+- File: `process_handlers.lua:276-369`
+- Reads, modifies, writes `settings.json` directly. Crash mid-write corrupts file. TOCTOU race with concurrent Claude Code writes.
+- Fix: Write to temp file first, then rename. Add file locking or version marker.
+
+### Medium
+
+**S8. Shell injection in fuzzy_loader `find` command**
+- File: `fuzzy_loader.lua:63-89`
+- `base_path` embedded in shell string with only `"` escaping. `$()` or backticks not handled.
+- Fix: Use `wezterm.run_child_process` with argument arrays.
+
+**S9. Dead code with injection vulnerability (`execute_cmd_with_stdin`)**
+- File: `encryption.lua:19-65`
+- Unused function uses `io.popen(cmd)` with unescaped string. Risk if someone calls it later.
+- Fix: Delete the function entirely.
+
+**S10. Unvalidated `session_id` from pane session files**
+- File: `process_handlers.lua:238-240`
+- Session ID from JSON file used in commands without format validation.
+- Fix: Validate matches `^[%x%-]+$`.
+
+**S11. `read_pane_session` path injection via `pane_id`**
+- File: `process_handlers.lua:128-152`
+- `pane_id` used directly in file path. If ever a string with `..`, allows reading arbitrary JSON files.
+- Fix: Validate `tostring(pane_id)` matches `^%d+$`.
+
+**S12. Non-atomic file operations**
+- Files: `state_manager.lua:209`, `process_handlers.lua:358`, `file_io.lua:25-27`
+- Windows fallback in `write_file` has a window where file is deleted but not yet renamed (data loss on crash).
+
+### Low
+
+**S13.** `get_file_path` sanitization misses `%`, `#`, newlines, high-Unicode (`state_manager.lua:19`)
+**S14.** Unbounded recursion in pane tree traversal (`pane_tree.lua:74-271`)
+**S15.** `os.tmpname()` uses predictable paths on some systems (`encryption.lua:72`)
+**S16.** No file permission control on state files (`file_io.lua`)
+**S17.** `--dangerously-skip-permissions` flag persisted across restore cycles (`process_handlers.lua:205-207`)
+
+---
+
+## Optimization Findings
+
+### Dead Code
+
+**O1.** `execute_cmd_with_stdin` -- 47 lines, never called (`encryption.lua:19-65`) -- MEDIUM
+**O2.** `utils.exec()` and `utils.execute()` -- never called by any module (`utils.lua:52-72`) -- LOW
+**O3.** `pane_tree.map()` -- defined/exported but never called (`pane_tree.lua:286-300`) -- LOW
+**O4.** `utils.deepcopy()` -- only called internally by `tbl_deep_extend`, could be local (`utils.lua:202-213`) -- LOW
+
+### Duplication
+
+**O5.** `periodic_save` and `event_driven_save` have near-identical save logic (`state_manager.lua:68-104` vs `129-157`) -- MEDIUM. Extract shared `save_all(opts, window_override)`.
+**O6.** Inline `require()` calls repeated in save callbacks instead of top-level locals (`state_manager.lua:71,135,79,139,89,148`) -- LOW
+**O7.** `is_windows` and `separator` computed in both `init.lua:7-8` and `utils.lua:5-7` -- LOW
+**O8.** `save_tab_action()` and `save_window_action()` follow identical prompt-then-save pattern (`tab_state.lua:128-149`, `window_state.lua:90-112`) -- MEDIUM
+
+### Code Quality
+
+**O9.** `insert_panes` is 200 lines with 7+ responsibilities: domain detection, CWD normalization, alt-screen detection, process handler lookup, NixOS sanitization, scrollback capture, tree recursion (`pane_tree.lua:74-271`) -- **HIGH**
+**O10.** Deep nesting (5+ levels) in process capture path (`pane_tree.lua:108-241`) -- MEDIUM
+**O11.** `insert_choices` is 150 lines combining file parsing, width computation, and label assembly (`fuzzy_loader.lua:103-254`) -- LOW
+**O12.** Filename sanitization regex is a magic character set with no documentation (`state_manager.lua:19`) -- LOW
+**O13.** `acc.active_pane` nil dereference if no pane has `is_active = true` (`tab_state.lua:123`) -- MEDIUM
+
+### Performance
+
+**O14.** `periodic_save` reschedules itself recursively, creating new closures each time (`state_manager.lua:65-104`) -- MEDIUM
+**O15.** `sanitize_json` runs gsub on entire JSON string every save; may be unnecessary if `json_encode` already escapes (`file_io.lua:74-81`) -- LOW
+**O16.** `pane-focus-changed` handler computes structure signature on every focus change without debounce (`state_manager.lua:164-186`) -- LOW
+
+### Architecture
+
+**O17.** `pane_tree.lua` tightly coupled to `process_handlers` -- data structure module does process detection/session lookup (`pane_tree.lua`) -- **HIGH**
+**O18.** `setup_claude_session_hooks` modifies external app config on every startup (`process_handlers.lua:276-369`) -- MEDIUM
+**O19.** `save_state()` uses duck-typing to determine state type instead of explicit type field (`state_manager.lua:26-39`) -- MEDIUM
+**O20.** Encryption state scattered across `file_io.lua` defaults + `encryption.lua` implementation + `state_manager.lua` delegation (`file_io.lua:3-5`) -- LOW
+
+---
+
+## Traceability Findings
+
+### Call Chain: Save Flow (Trigger -> State Capture -> Process Handlers -> File I/O)
+
+73 cross-layer calls verified across both save and restore flows.
+
+| Category | Count |
+|----------|-------|
+| OK | 69 |
+| WARNING | 4 |
+| BROKEN | 0 |
+
+**Warnings:**
+
+| Caller | Callee | Issue |
+|--------|--------|-------|
+| `state_manager.lua:129-157` | `event_driven_save do_save()` | Not wrapped in `pcall` unlike `periodic_save`. Unhandled error could break WezTerm event handler chain. |
+| `tab_state.lua:124` | `acc.active_pane:activate()` | `active_pane` may be nil if no pane has `is_active = true` (corrupted state). |
+| `state_manager.lua:206` | `pub.save_state_dir` | No nil-guard. If `init()` fails, all subsequent calls produce confusing nil concatenation errors. |
+| `pane_tree.lua:114` | `get_foreground_process_info()` | Could return nil if process exits between domain check and call. Guarded by `domain == "local"` but not nil-checked. |
+
+### Call Chain: Restore Flow (Trigger -> File I/O -> State Restore -> Process Handlers)
+
+| Category | Count |
+|----------|-------|
+| OK | 31 |
+| WARNING | 2 |
+| BROKEN | 0 |
+
+**Warnings:**
+
+| Caller | Callee | Issue |
+|--------|--------|-------|
+| `tab_state.lua:124` | `acc.active_pane:activate()` | Same nil dereference issue as save flow. |
+| `init.lua:170` vs `fuzzy_loader.lua:283` | Callback arity | Fuzzy loader passes 3 args, callback declares 2. Harmless in Lua but unused `save_state_dir` arg. |
+
+---
+
+## Action Items
+
+### 1. Must Fix (Critical/High security)
+
+- [ ] **[CRITICAL]** Validate binary name in Claude Code restore command (`process_handlers.lua:189`) -- reject names not matching `^claude[%d%-]*$`
+- [ ] **[CRITICAL]** Validate session_id format as UUID-like `^[%x%-]+$` (`process_handlers.lua:244`, `232-233`)
+- [ ] **[CRITICAL]** Validate CWD in tab restore -- reject shell metacharacters (`tab_state.lua:104`)
+- [ ] **[CRITICAL]** Fix `os.execute` injection in `setup_claude_session_hooks` -- use `utils.shell_mkdir` (`process_handlers.lua:290-293`)
+- [ ] **[HIGH]** Harden `delete_state` path traversal protection -- reject absolute paths and non-.json files (`state_manager.lua:251-266`)
+- [ ] **[HIGH]** Validate `WEZTERM_PANE` in hook command -- require numeric only (`process_handlers.lua:343`)
+- [ ] **[HIGH]** Add nil guard for `acc.active_pane:activate()` (`tab_state.lua:124`)
+
+### 2. Should Fix
+
+- [ ] **[MEDIUM]** Delete dead `execute_cmd_with_stdin` function (`encryption.lua:19-65`)
+- [ ] **[MEDIUM]** Validate `pane_id` is numeric in `read_pane_session` (`process_handlers.lua:128`)
+- [ ] **[MEDIUM]** Wrap `event_driven_save do_save()` in `pcall` (`state_manager.lua:129-157`)
+- [ ] **[MEDIUM]** Add nil-guard for `save_state_dir` (`state_manager.lua:206`)
+- [ ] **[MEDIUM]** Use argument arrays in fuzzy_loader instead of shell strings (`fuzzy_loader.lua:63-89`)
+- [ ] **[MEDIUM]** Extract duplicated save logic into shared function (`state_manager.lua:68-104` vs `129-157`)
+- [ ] **[MEDIUM]** Decompose `insert_panes` 200-line function (`pane_tree.lua:74-271`)
+
+### 3. Can Fix Later
+
+- [ ] **[LOW]** Remove unused `utils.exec()`/`utils.execute()` (`utils.lua:52-72`)
+- [ ] **[LOW]** Remove unused `pane_tree.map()` or document as public API (`pane_tree.lua:286-300`)
+- [ ] **[LOW]** Decouple `pane_tree.lua` from `process_handlers` (`pane_tree.lua`)
+- [ ] **[LOW]** Add explicit `type` field to state objects instead of duck-typing (`state_manager.lua:26-39`)
+- [ ] **[LOW]** Debounce `pane-focus-changed` handler (`state_manager.lua:164-186`)
+- [ ] **[LOW]** Use named local function for `periodic_save` rescheduling (`state_manager.lua:65-104`)
+- [ ] **[LOW]** Set restrictive file permissions on state files (`file_io.lua`)
+- [ ] **[LOW]** Consider not persisting `--dangerously-skip-permissions` flag (`process_handlers.lua:205-207`)

--- a/planning/deep-review-integrate-community-fixes.md
+++ b/planning/deep-review-integrate-community-fixes.md
@@ -1,0 +1,185 @@
+# Deep Review: integrate-community-fixes
+
+**Date:** 2026-03-13
+**Branch:** integrate-community-fixes
+**Files Reviewed:** 12 (all plugin source + spec files)
+
+---
+
+## Executive Summary
+
+The core architecture (pane tree, hierarchical state, save/restore flow) is sound. However, the codebase has **significant security vulnerabilities** around shell command execution and file path handling that must be addressed before this fork is production-ready. The cherry-picked PRs fix real bugs but the underlying code has systemic issues with inconsistent process execution patterns (`os.execute` vs `io.popen` vs `wezterm.run_child_process`) and insufficient input sanitization. The optimization review found dead code, duplicated save logic, and a crash-causing nil guard.
+
+**Verdict:** Merge the integration PR (the cherry-picks improve things), but Phase 2 MUST address the security and quality findings before release.
+
+---
+
+## Security Findings
+
+### Critical
+
+**S1. Command injection via os.execute in fuzzy_loader.lua (line 123)**
+- `os.execute("wscript.exe //nologo " .. launcher_vbs)` with unquoted path concatenation
+- Directly contradicts the #125 fix that replaced os.execute in utils.lua
+- Fix: Replace with `wezterm.run_child_process({"wscript.exe", "//nologo", launcher_vbs})`
+
+### High
+
+**S2. io.popen shell injection in utils.execute() (lines 51-69)**
+- Called from fuzzy_loader.lua with string-interpolated find commands containing `base_path`
+- Double quotes don't prevent all shell injection on Unix ($(), backticks)
+- Fix: Replace with array-based `wezterm.run_child_process`
+
+**S3. VBScript injection in fuzzy_loader.lua (lines 66-97)**
+- `base_path` interpolated into VBS code; only backslash is escaped, not double quotes
+- Crafted save_state_dir with `"` breaks out of VBS string literal
+- Fix: Escape `"` as `""` in VBS strings, or replace entire VBS approach
+
+**S4. Path traversal in delete_state (state_manager.lua lines 205-214)**
+- `pub.save_state_dir .. file_path` with no confinement check
+- `../../../important_file` traverses outside state directory
+- Fix: Validate resolved path starts with save_state_dir prefix; reject `..` segments
+
+**S7. Shell injection in encrypt() (encryption.lua line 70)**
+- `file_path` only has spaces escaped, not other shell metacharacters
+- Passed to shell via string.format through `sh -c` or `pwsh.exe -Command`
+- Fix: Use array-based `wezterm.run_child_process` like decrypt() already does
+
+**S11. Command execution from untrusted state files (tab_state.lua line 154)**
+- `pane:send_text(wezterm.shell_join_args(pane_tree.process.argv) .. "\r\n")`
+- Deserialized JSON argv is executed directly in user's shell
+- Tampered state file = arbitrary command execution on restore
+- Fix: Validate argv[1] against known-safe executables; consider HMAC on state files
+
+### Medium
+
+**S5. Incomplete filename sanitization (state_manager.lua lines 11-21)**
+- No null byte check, no Windows reserved name check (CON, PRN, NUL, etc.)
+- Fix: Add whitelist validation after sanitization
+
+**S6. Encryption key exposure via process arguments (encryption.lua lines 70, 90)**
+- Private key path and public key visible in `ps aux` on shared systems
+- Fix: Document risk; use --recipients-file where possible
+
+**S8. Non-atomic file writes (file_io.lua lines 11-22)**
+- Direct open-write-close; crash during write corrupts state file
+- Fix: Write to `.tmp` file, then atomic rename
+
+**S12. Unquoted path in VBS WshShell.Run (fuzzy_loader.lua lines 101-107)**
+- Fix: Quote the path with VBS double-quote escaping
+
+### Low
+
+**S9. Probe file TOCTOU race (utils.lua lines 140-149)** - Negligible in practice
+**S10. Unix shell_mkdir goes through sh -c unnecessarily (utils.lua lines 82-84)** - Could use direct mkdir
+
+---
+
+## Optimization Findings
+
+### Dead Code
+
+**O1. pane_tree.map() never called (pane_tree.lua line 257)** - LOW
+- Only pub.fold() is used. Remove or document as public API.
+
+**O2. Unused require("resurrect") in window_state.lua line 90** - LOW
+- Dead import inside save_window_action(). Remove it.
+
+### Duplication
+
+**O3. is_windows/separator duplicated (init.lua lines 7-8 vs utils.lua lines 5-7)** - LOW
+- init.lua should import from utils instead of recomputing.
+
+**O4. Save logic duplicated between periodic_save and event_driven_save** - MEDIUM
+- ~40 lines of near-identical save iteration code. Extract shared helper.
+
+**O5. "title not empty" guard repeated 4 times** - LOW
+- Extract `has_title(title)` helper.
+
+### Code Quality
+
+**O6. Duck typing for state type (state_manager.lua lines 27-33)** - MEDIUM
+- Silent no-op if state object is malformed. Add explicit type field or error logging.
+
+**O7. active_tab:activate() crashes if no tab marked active (window_state.lua line 84)** - HIGH
+- Nil crash during restore if no is_active flag in saved state.
+- Fix: Guard with `if active_tab then active_tab:activate() end`
+
+**O8. Shadowing Lua built-in `type` keyword** - LOW
+- Multiple functions use `type` as parameter name. Rename to `state_type`.
+
+**O9. resurrect_on_gui_startup swallows errors (state_manager.lua lines 181-202)** - MEDIUM
+- pcall catches errors but doesn't log them. Add wezterm.log_error.
+
+**O17. Log says "Decryption" in encryption error path (file_io.lua line 83)** - LOW
+- Should say "Encryption failed".
+
+### Performance
+
+**O12. Double sanitize_json on write + read (file_io.lua lines 75, 123)** - LOW
+- Sanitize only on write; reading already-sanitized files is wasteful.
+
+**O13. Line-by-line read when read_file exists (file_io.lua lines 114-118)** - LOW
+- Use pub.read_file() for consistency and performance.
+
+**O14. Heavyweight VBS temp-file dance on Windows (fuzzy_loader.lua lines 56-158)** - MEDIUM
+- Replace with wezterm.run_child_process for dir listing.
+
+**O18. sanitize_json emits multi-MB data as event argument (file_io.lua line 61)** - MEDIUM
+- Pass string length, not the full payload.
+
+### Architecture
+
+**O10. os.execute in fuzzy_loader contradicts #125 fix (line 123)** - HIGH
+- Same as S1. Inconsistent process execution pattern.
+
+**O11. io.popen vs run_child_process inconsistency** - MEDIUM
+- Standardize on wezterm.run_child_process throughout.
+
+**O15. Event handlers accumulate on config reload (state_manager.lua lines 141-164)** - MEDIUM
+- event_driven_save registers new handlers each call; needs dedup guard.
+
+**O16. periodic_save silently stops on error (state_manager.lua line 89)** - LOW
+- Wrap in pcall, always re-schedule. (Already in our Phase 2 plan for #129)
+
+**O19. Fragile pre-flight test in encryption fallback (encryption.lua lines 40-64)** - MEDIUM
+
+**O20. Hardcoded "/" instead of utils.separator (state_manager.lua line 227)** - LOW
+
+---
+
+## Action Items
+
+### Must fix before release (Critical/High security + HIGH quality)
+
+- [ ] **[CRITICAL]** S1: Replace os.execute in fuzzy_loader.lua:123 with wezterm.run_child_process
+- [ ] **[HIGH]** S2: Replace utils.execute io.popen with array-based process invocation
+- [ ] **[HIGH]** S3: Fix VBScript injection - escape double quotes or replace VBS approach
+- [ ] **[HIGH]** S4: Add path confinement to delete_state - reject .. segments
+- [ ] **[HIGH]** S7: Fix encrypt() shell injection - use array args like decrypt()
+- [ ] **[HIGH]** S11: Validate process.argv before send_text execution on restore
+- [ ] **[HIGH]** O7: Guard active_tab:activate() against nil
+
+### Should fix before release (Medium security + MEDIUM optimization)
+
+- [ ] **[MEDIUM]** S5: Add null byte and Windows reserved name validation to filename sanitization
+- [ ] **[MEDIUM]** S8: Implement atomic file writes (write to .tmp then rename)
+- [ ] **[MEDIUM]** O4: Extract shared save helper to eliminate duplication
+- [ ] **[MEDIUM]** O6: Add explicit type field to state objects or log on unknown type
+- [ ] **[MEDIUM]** O9: Log errors in resurrect_on_gui_startup instead of swallowing
+- [ ] **[MEDIUM]** O14: Replace VBS file listing with wezterm.run_child_process
+- [ ] **[MEDIUM]** O15: Add dedup guard for event_driven_save handler registration
+- [ ] **[MEDIUM]** O18: Don't emit multi-MB data strings as event arguments
+
+### Can fix later (Low severity)
+
+- [ ] **[LOW]** O1: Remove or document pane_tree.map()
+- [ ] **[LOW]** O2: Remove dead require in window_state.lua
+- [ ] **[LOW]** O3: Use utils.separator in init.lua instead of recomputing
+- [ ] **[LOW]** O5: Extract has_title() helper
+- [ ] **[LOW]** O8: Rename `type` parameter to `state_type` throughout
+- [ ] **[LOW]** O12: Remove double sanitize_json
+- [ ] **[LOW]** O13: Use read_file() in load_json
+- [ ] **[LOW]** O17: Fix "Decryption" typo in encryption error log
+- [ ] **[LOW]** O20: Use utils.separator in change_state_save_dir
+- [ ] **[LOW]** S9, S10, S12: Minor probe race, Unix mkdir, VBS quoting

--- a/planning/deep-review-multi-instance.md
+++ b/planning/deep-review-multi-instance.md
@@ -1,0 +1,186 @@
+# Deep Review: Multi-Instance State Management + Claude2 Support
+**Date:** 2026-03-16
+**Branch:** feat/multi-instance-state
+**Files Reviewed:** 10 (plugin modules) + 2 (spec files) + 3 (docs)
+
+---
+
+## Executive Summary
+
+The implementation is **functionally correct** -- all 6 call chains verified with 0 broken links. Security posture is strong on Windows (proper PowerShell quoting, instance ID validation, path traversal prevention) but has **3 HIGH shell injection risks on Unix** from `sh -c` string interpolation. The main optimization opportunities are consolidating duplicated save logic into a single "full save" function and extracting the repeated fuzzy-restore callback.
+
+---
+
+## Security Findings
+
+### High
+
+**H1. Shell injection via `base_path` in `fuzzy_loader.lua` (Unix branch)**
+- File: `fuzzy_loader.lua:80-88`
+- The Unix `find_json_files_recursive` embeds `base_path` in `sh -c` with only `"` escaping. `$()` and backticks can inject commands.
+- Fix: Use `wezterm.run_child_process` with argument arrays instead of `sh -c`.
+
+**H2. Shell injection via `instances_dir` in `instance_manager.lua` (Unix branch)**
+- File: `instance_manager.lua:233-239`
+- Same pattern as H1: `ls "..." | xargs` with only `"` escaping.
+- Fix: Use argument arrays or `find -maxdepth 1` with `run_child_process`.
+
+**H3. `shell_mkdir` in `utils.lua` vulnerable to command injection on Unix**
+- File: `utils.lua:77-90`
+- `os.execute('mkdir -p "' .. path .. '"')` with no metacharacter guard on Unix (Windows has `"` rejection).
+- Fix: Add metacharacter rejection for Unix paths, matching the Windows guard.
+
+### Medium
+
+**M1. TOCTOU race in `file_io.write_file` atomic rename on Windows**
+- File: `file_io.lua:23-31`
+- `os.remove(file_path)` then `os.rename(tmp_path, file_path)` has a window where another process can interfere.
+- Fix: Accept last-writer-wins for per-instance files (unique IDs prevent collision).
+
+**M2. `pane_sessions_dir` path injected into bash command in hook setup**
+- File: `process_handlers.lua:352-356`
+- Single quotes in `HOME` path could break the bash command stored in `settings.json`.
+- Fix: Escape single quotes (`'` -> `'\''`) in `pane_sessions_dir`.
+
+**M3. No validation of `display_name` content in `rename_instance`**
+- File: `instance_manager.lua:356-372`
+- ANSI escape sequences in display names could manipulate terminal UI.
+- Fix: Strip control characters before storing.
+
+**M4. `delete_state` path confinement is fragile**
+- File: `state_manager.lua:263-291`
+- Path concatenation relies on implicit format of `file_path` from `insert_choices`.
+- Fix: Canonicalize and verify path is under `save_state_dir` after concatenation.
+
+**M5. Weak instance ID randomness**
+- File: `instance_manager.lua:33-36`
+- `math.randomseed(os.time())` -- two processes in the same second collide.
+- Fix: Add `os.clock()` or PID to seed: `math.randomseed(os.time() * 1000 + os.clock() * 1000)`.
+
+### Low
+
+**L1. Deserialized state data not validated before use**
+- File: `instance_manager.lua:188-209`
+- `load_instance` returns `parsed.workspace_state` without schema validation.
+- Fix: Check `workspace_state` is a table with `window_states` array.
+
+**L2. `current_state` file written without locking**
+- File: `state_manager.lua:217-230`
+- Multiple instances can corrupt. Low impact since multi-instance mode supersedes it.
+- Fix: Skip writing `current_state` when instance mode is active.
+
+**L3. Unbounded recursion in `insert_panes`**
+- File: `pane_tree.lua:74-283`
+- Crafted state files could cause stack overflow.
+- Fix: Add recursion depth guard (max 100).
+
+**L4. `tab_summaries` displayed without sanitization**
+- File: `instance_manager.lua:308-351`
+- ANSI escapes in `.meta` files rendered in UI.
+- Fix: Strip control characters from summaries before display.
+
+---
+
+## Optimization Findings
+
+### Duplication
+
+**O1. Fuzzy-restore callback copied twice (HIGH)**
+- File: `instance_manager.lua:389-406` and `434-451`
+- Same callback logic (parse id, dispatch to workspace/window/tab restore) is duplicated.
+- Fix: Extract into `local function make_fuzzy_restore_callback(restore_opts)`.
+
+**O2. Dedup-and-count display logic duplicated (MEDIUM)**
+- Files: `init.lua:107-125` (status bar) and `instance_manager.lua:313-329` (format_instance_summary)
+- Identical algorithm for counting duplicate titles.
+- Fix: Extract `utils.deduplicate_with_counts(items)`.
+
+**O3. `write_current_state` called redundantly (MEDIUM)**
+- File: `state_manager.lua:33,71,141` + `init.lua:183`
+- Called inside `save_state` AND by callers. Runs 2-3x per save cycle.
+- Fix: Pick one canonical location.
+
+**O4. `instance_manager.save_instance` called from 3 places (MEDIUM)**
+- Files: `state_manager.lua:74-77,143-146` + `init.lua:184-186`
+- Fix: Create `pub.save_workspace_full()` that does save_state + write_current_state + save_instance.
+
+### Dead Code
+
+**O5. `is_windows`/`separator` in `init.lua` (LOW)**
+- File: `init.lua:7-8`
+- Duplicates `utils.is_windows`/`utils.separator`, only used on line 18.
+- Fix: Use `require("resurrect.utils").separator` directly.
+
+### Performance
+
+**O6. `list_instances` shells out to PowerShell (MEDIUM)**
+- File: `instance_manager.lua:214-265`
+- Spawns PowerShell (~200-400ms) on every selector display.
+- Fix: Use `io.popen` for lighter listing, or maintain an index file.
+
+**O7. `get_instances_dir()` re-requires `state_manager` on every call (LOW)**
+- File: `instance_manager.lua:45-48`
+- Fix: Cache as module-level local.
+
+### Code Quality
+
+**O8. `delete_state` path joining missing explicit separator (MEDIUM)**
+- File: `state_manager.lua:284`
+- Fix: Use `save_state_dir .. utils.separator .. file_path`.
+
+**O9. Alt+S emits misleading event name (LOW)**
+- File: `init.lua:187`
+- Emits `event_driven_save.finished` from a manual save.
+- Fix: Use a dedicated `resurrect.manual_save.finished` event.
+
+---
+
+## Traceability Findings
+
+### All 6 Call Chains: VERIFIED
+
+| Chain | Status | Issues |
+|-------|--------|--------|
+| 1. Setup (init -> instance_manager + state_manager) | OK | All calls match signatures |
+| 2. Save (state_manager -> workspace_state -> file_io) | OK | Data flows correctly |
+| 3. Pane detection (pane_tree -> process_handlers) | OK | Fallback path works |
+| 4. Restore (instance_manager -> workspace_state -> tab_state) | OK | All types match |
+| 5. Alt+S (init -> save functions) | OK | 1 WARNING below |
+| 6. Startup (gui-startup -> instance_manager auto-restore) | OK | 2 WARNINGs below |
+
+### Warnings (non-blocking)
+
+| Caller | Callee | Status | Issue |
+|--------|--------|--------|-------|
+| init.lua:187 | wezterm.emit(...) | WARNING | Alt+S emits event_driven_save.finished without `opts` arg. Listeners expecting opts get nil. Status bar listener works fine (takes 0 args). |
+| instance_manager.lua:389 | fuzzy_loader.fuzzy_load callback | WARNING | Callback declares `(id, label)` but receives `(id, label, save_state_dir)`. 3rd arg silently ignored in Lua. Functionally correct. |
+| instance_manager.lua:617 | show_instance_selector(gui_win, pane) | WARNING | Docstring says MuxWindow but receives GuiWindow. Works because perform_action is a GuiWindow method. |
+| instance_manager.lua:47 | state_manager.save_state_dir | WARNING | No nil guard. Safe due to call ordering (init sets it first) but fragile. |
+| tab_state.lua:183 | SAFE_RESTORE_PROCESSES | WARNING | `claude` in allowlist is defense-in-depth fallback. If handler pcall fails, falls through to raw argv replay bypassing handler's validations. |
+
+---
+
+## Action Items
+
+### Must fix before merge (Critical/High security)
+- [ ] **[HIGH]** Fix Unix shell injection in `fuzzy_loader.lua:80-88` -- use argument arrays
+- [ ] **[HIGH]** Fix Unix shell injection in `instance_manager.lua:233-239` -- use argument arrays
+- [ ] **[HIGH]** Fix Unix shell injection in `utils.lua:77-90` -- add metacharacter guard
+
+### Should fix before merge
+- [ ] **[MEDIUM]** Escape single quotes in hook command path (`process_handlers.lua:352-356`)
+- [ ] **[MEDIUM]** Strengthen instance ID seeding (`instance_manager.lua:33-36`)
+- [ ] **[MEDIUM]** Strip control chars from display_name and tab_summaries
+- [ ] **[HIGH-OPT]** Extract duplicated fuzzy-restore callback (`instance_manager.lua`)
+- [ ] **[MEDIUM-OPT]** Consolidate save logic into single `save_workspace_full()` function
+
+### Can fix later
+- [ ] **[MEDIUM]** Canonicalize path in `delete_state` (`state_manager.lua:284`)
+- [ ] **[MEDIUM]** Lighter directory listing for `list_instances` (avoid PowerShell spawn)
+- [ ] **[LOW]** Add schema validation to `load_instance`
+- [ ] **[LOW]** Skip `write_current_state` when instance mode is active
+- [ ] **[LOW]** Add recursion depth guard to `insert_panes`
+- [ ] **[LOW]** Fix `pane_tree.map` return type annotation
+- [ ] **[LOW]** Remove dead `is_windows`/`separator` from `init.lua`
+- [ ] **[LOW]** Use dedicated event name for Alt+S manual save
+- [ ] **[LOW]** Cache `state_manager` require in `instance_manager`

--- a/planning/per-instance-state-user-journey.md
+++ b/planning/per-instance-state-user-journey.md
@@ -1,0 +1,369 @@
+# Per-Instance State Management: Complete User Journey Map
+
+## 1. First-Time Setup
+
+### 1.1 User installs the plugin
+- Adds `resurrect.setup(config)` to their `wezterm.lua`
+- On first WezTerm launch:
+  - Plugin downloads from GitHub
+  - `setup()` runs:
+    - Creates `state/instances/` directory
+    - Configures Claude Code SessionStart hook in `~/.claude/settings.json` (idempotent)
+    - Registers auto-save handlers
+    - Registers keybindings
+    - Registers status bar
+  - Status bar appears: shows tab titles, no save time yet
+  - Within seconds, first auto-save fires via `update-status` event
+  - Status bar updates: "saved 14:30:05 | PowerShell"
+
+### 1.2 User has Claude Code
+- User runs `claude` or `claude2` in a pane
+- Claude Code's SessionStart hook fires, writes session ID to `~/.claude/pane-sessions/<pane_id>.json`
+- Next auto-save detects Claude Code via pane-session file (even if bash is the foreground process)
+- State file captures: `{ name: "claude", argv: ["claude", "--resume", "<session-id>", "--dangerously-skip-permissions"] }`
+- Status bar: "saved 14:30:15 | Claude Code, PowerShell"
+
+---
+
+## 2. Single Instance Daily Use
+
+### 2.1 User opens WezTerm
+- WezTerm starts, plugin loads
+- Instance ID generated: `<pid>_<start_timestamp>` (e.g., `20184_1741873200`)
+- Auto-save begins writing to `state/instances/20184_1741873200.json`
+- Metadata written to `state/instances/20184_1741873200.meta`
+- Status bar shows current tabs and save time
+- NO auto-restore happens (tmux model: save auto, restore manual)
+- If user wants previous sessions: presses Alt+R, sees saved instances, picks which to restore
+
+### 2.2 User opens tabs and splits panes
+- Opens new tab: `pane-focus-changed` fires (structure change), auto-save triggers
+- Splits pane: same trigger, auto-save captures the new layout
+- State file now includes the full pane tree (splits, CWDs, processes)
+- Status bar updates save time
+
+### 2.3 User closes a tab (intentionally done with it)
+- Closes tab via Ctrl+W or clicking X
+- `pane-focus-changed` fires (structure change)
+- Auto-save triggers, captures current state WITHOUT the closed tab
+- Instance state file updated: closed tab is gone
+- Next restore will NOT include that tab
+- This is the desired behavior: closed tab = user is done with it
+
+### 2.4 User works normally for hours
+- Periodic save fires every 5 minutes as a safety net
+- Event-driven save fires on any structural change
+- Claude Code pane-session files updated on each new Claude session
+- Status bar continuously shows latest save time and tab titles
+
+### 2.5 User closes WezTerm cleanly (clicks X / Alt+F4)
+- WezTerm begins shutdown
+- The last auto-save already captured the current state
+- No special shutdown save needed (continuous save already has it)
+- Instance state file remains in `state/instances/` for future restore
+- User opens WezTerm later: can restore via Alt+R if desired
+
+---
+
+## 3. Multiple Instances
+
+### 3.1 User opens three WezTerm windows
+- Window A: PID 20184, instance_id = `20184_1741873200`
+  - Tab 1: Claude Code (orahvision project)
+  - Tab 2: Claude Code (wezterm-resurrect project)
+- Window B: PID 29588, instance_id = `29588_1741873205`
+  - Tab 1: Claude Code (personal project)
+  - Tab 2: PowerShell
+- Window C: PID 8916, instance_id = `8916_1741873210`
+  - Tab 1: Claude Code (another project)
+
+### 3.2 Each instance saves independently
+- Instance A saves to `state/instances/20184_1741873200.json`
+- Instance B saves to `state/instances/29588_1741873205.json`
+- Instance C saves to `state/instances/8916_1741873210.json`
+- No clobbering: each instance owns its own file
+
+### 3.3 Metadata files show human-readable summaries
+- `20184_1741873200.meta`:
+  ```json
+  {
+    "instance_id": "20184_1741873200",
+    "pid": 20184,
+    "start_time": "2026-03-13T14:00:00",
+    "last_save": "2026-03-13T16:45:12",
+    "window_count": 1,
+    "tab_count": 2,
+    "tab_summaries": ["Claude Code (orahvision)", "Claude Code (wezterm-resurrect)"]
+  }
+  ```
+
+### 3.4 User closes one tab in Window A
+- Tab 2 (wezterm-resurrect) closed
+- Instance A auto-saves: now only has Tab 1 (orahvision)
+- Instances B and C are unaffected
+- If user restores Instance A later, only Tab 1 comes back
+
+### 3.5 Windows Update kills everything
+- All three WezTerm processes killed
+- No shutdown save fires (processes are dead)
+- State files retain the last auto-save for each instance
+- Instance A: 1 tab (orahvision) -- because the user already closed the other tab
+- Instance B: 2 tabs (personal project + PowerShell)
+- Instance C: 1 tab (another project)
+
+### 3.6 User opens WezTerm after restart
+- Fresh WezTerm window opens (no auto-restore)
+- User presses Alt+R
+- Selector shows:
+  ```
+  [x] Mar 13 16:45 -- Claude Code (orahvision) [1 tab]
+  [x] Mar 13 16:44 -- Claude Code (personal), PowerShell [2 tabs]
+  [x] Mar 13 16:43 -- Claude Code (another project) [1 tab]
+  ```
+- User checks all three, confirms
+- Three windows open, each with their tabs and Claude sessions restored
+- Each Claude Code session resumes via `claude --resume <exact-session-id>`
+- Old instance state files are deleted (they now have new instance IDs)
+
+---
+
+## 4. Crash Recovery
+
+### 4.1 WezTerm crashes mid-session
+- Process dies unexpectedly
+- No save fires (process is dead)
+- Instance state file has the last auto-save (at most 5 minutes old, usually seconds)
+- User reopens WezTerm, presses Alt+R, selects the crashed instance
+- All tabs and Claude sessions restored from last save
+
+### 4.2 System BSOD / power loss
+- Same as crash: all instances die
+- All instance state files retain their last save
+- On reboot, user opens WezTerm, presses Alt+R
+- All instances available for restore
+
+### 4.3 WezTerm hangs (unresponsive)
+- User kills via Task Manager
+- Same as crash: no save fires, last state preserved
+- Restore works normally
+
+---
+
+## 5. Manual Save and Restore (Keybindings)
+
+### 5.1 Alt+W: Save workspace NOW
+- Forces an immediate save of the current instance
+- Useful before intentionally closing WezTerm
+- Status bar updates save time
+
+### 5.2 Alt+R: Restore from saved state
+- Opens selector showing all saved instances
+- Each entry shows: save time, tab summaries, tab count
+- User selects one or more instances to restore
+- Selected instances open as new windows
+- Restored instance state files are cleaned up
+- New instance IDs assigned to the restored windows
+
+### 5.3 Alt+Shift+W: Save current window
+- Saves just the current window (not the whole instance)
+- Stored separately from instance saves
+- Available in Alt+R alongside instance saves
+
+### 5.4 Alt+Shift+T: Save current tab
+- Saves just the current tab
+- Available in Alt+R alongside instance saves
+
+---
+
+## 6. Claude Code Specific Journeys
+
+### 6.1 Fresh Claude Code session (no --resume)
+- User types `claude` or `claude --dangerously-skip-permissions`
+- Claude Code starts, SessionStart hook fires
+- Hook writes `{ session_id: "abc-123", ... }` to `~/.claude/pane-sessions/<pane_id>.json`
+- Auto-save detects Claude Code via pane-session file
+- Sanitize function reads session_id from pane-session file
+- State saves: `argv: ["claude", "--resume", "abc-123", "--dangerously-skip-permissions"]`
+
+### 6.2 Claude Code running a tool (bash command)
+- Claude Code executes a bash command
+- Foreground process changes to `bash` (not `claude`)
+- Auto-save fires: foreground process is bash, no handler match
+- Falls back to pane-session file check: file exists with session_id
+- Builds synthetic process_info for claude
+- State correctly saves Claude Code's info, not bash
+
+### 6.3 Multiple Claude Code sessions across instances
+- Instance A: pane 0 has Claude session abc-123, pane 1 has session def-456
+- Instance B: pane 0 has Claude session ghi-789
+- Each pane's session ID captured independently via WEZTERM_PANE env var
+- Each instance's state file has the correct session IDs per pane
+- On restore: each pane sends `claude --resume <correct-session-id>`
+
+### 6.4 claude vs claude2 (multi-account)
+- User runs `claude` (account 1) and `claude2` (account 2) in different panes
+- detect() matches both via `^claude%d*$` pattern
+- sanitize() preserves the original binary name (`claude` vs `claude2`)
+- On restore: `claude --resume <id>` in one pane, `claude2 --resume <id>` in another
+
+### 6.5 Restore sends command with delay
+- On restore, PowerShell pane opens
+- 3-second delay (configurable) allows PowerShell to initialize
+- After delay: `claude --resume abc-123 --dangerously-skip-permissions` sent to pane
+- Claude Code resumes the exact session
+
+---
+
+## 7. Status Bar
+
+### 7.1 What the user sees
+- Right side of tab bar shows:
+  - Before first save: just tab titles (e.g., "Claude Code, PowerShell")
+  - After first save: "saved 14:30:05 | Claude Code, PowerShell"
+  - Multiple of same title: "saved 14:30:05 | Claude Code x3, PowerShell"
+
+### 7.2 Updates
+- Save time updates on every auto-save (event-driven or periodic)
+- Tab titles update on every `update-status` event (frequently)
+- User can glance at the status bar to know: what's saved and when
+
+---
+
+## 8. Cleanup and Retention
+
+### 8.1 Automatic cleanup on startup
+- On WezTerm startup, scan `state/instances/` for old files
+- Delete instance state files older than 7 days (configurable)
+- Prevents unbounded disk growth
+
+### 8.2 Cleanup after restore (auto-delete)
+- When user restores an instance, its old `.json` and `.meta` files are automatically deleted
+- The restored windows get new instance IDs and start saving under those
+- If the old instance had a `display_name`, it carries over to the new instance
+- Prevents duplicate/stale entries in the selector
+
+### 8.3 Manual cleanup
+- Alt+R shows all saved instances
+- User can choose to delete saved states they don't want
+- Or user deletes files directly from `state/instances/`
+
+---
+
+## 9. Edge Cases
+
+### 9.1 WezTerm opened but no tabs created
+- Instance ID generated, but state has just one empty PowerShell pane
+- Saved as a minimal state file
+- On restore: just opens a PowerShell window (harmless)
+
+### 9.2 Instance state file is corrupt
+- `wezterm.json_parse` fails in pcall
+- Log error, skip that instance in the selector
+- Other instances still available for restore
+- Graceful degradation: one corrupt file doesn't break everything
+
+### 9.3 Pane-session file missing for a Claude Code pane
+- SessionStart hook didn't fire (Claude Code started before hook was configured)
+- Foreground process detection is also unreliable (might be bash)
+- Falls back to saving as a text pane (scrollback)
+- On restore: user gets a shell with scrollback text instead of Claude session
+- Not ideal but not broken -- user can manually run `claude --resume`
+
+### 9.4 Two instances have the same PID (PID reuse after reboot)
+- Instance ID includes timestamp, not just PID
+- `20184_1741873200` vs `20184_1741959600` are different instances
+- No collision
+
+### 9.5 Very long WezTerm session (days/weeks)
+- Periodic save keeps state fresh every 5 minutes
+- Instance state file stays small (process info, not scrollback)
+- Claude Code pane-session files updated on each new session
+- No memory or disk growth issues
+
+### 9.6 User opens 20+ instances
+- Each saves to its own file (20 files, each a few KB)
+- Alt+R selector shows all 20 with summaries
+- User can select/deselect which to restore
+- Cleanup removes files older than 7 days
+
+### 9.7 User restores into an instance that already has tabs
+- Restored tabs open as NEW windows (not merged into existing)
+- Existing tabs are untouched
+- User now has their existing work PLUS the restored sessions
+
+---
+
+## 10. Configuration Options
+
+All optional, sane defaults:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `periodic_interval` | 300 | Seconds between periodic saves |
+| `restore_delay` | 3 | Seconds to wait before sending restore commands |
+| `retention_days` | 7 | Auto-delete instance states older than this |
+| `save_workspaces` | true | Save workspace-level state |
+| `save_windows` | true | Save window-level state |
+| `save_tabs` | true | Save tab-level state |
+| `keybindings` | true | Register Alt+W/R/Shift+W/Shift+T |
+| `status_bar` | true | Show save time + tab titles |
+| `claude_hooks` | true | Auto-configure Claude Code SessionStart hook |
+| `auto_restore_prompt` | true | Show instance selector on startup if saved instances exist |
+
+---
+
+## 11. Auto-Start Selector on Startup
+
+On WezTerm startup, if saved instance files exist in `state/instances/`, the plugin
+automatically shows the instance selector (InputSelector). This replaces the old
+behavior of silently restoring `current_state`.
+
+- **Config option**: `auto_restore_prompt` (default `true`)
+- If `true` and saved instances exist: spawn a default window, then show selector after 1s delay
+- If `true` but no instances: fall back to `resurrect_on_gui_startup()` (backward compat)
+- If `false`: do nothing on startup; user can manually press Alt+R
+
+User can dismiss the selector (Esc) to start fresh with the default window.
+
+---
+
+## 12. Delete Mode in Selector
+
+The instance selector (shown on startup or via Alt+R) includes action entries at the bottom:
+
+- **[Browse named saves]**: Opens the fuzzy_loader for workspace/window/tab named saves
+- **[Rename an instance]**: Shows instance list; picking one prompts for a name
+- **[Delete saved instances]**: Switches to delete mode
+
+### Delete Mode
+- Shows the same instance list, but selecting an instance **deletes** it (both `.json` and `.meta`)
+- After each deletion, the delete selector re-shows (for deleting multiple instances)
+- **[Back to main selector]** entry at the bottom returns to the restore selector
+- Pressing Esc also exits delete mode
+
+### Auto-Delete After Restore
+- When the user restores an instance, the old instance files are automatically deleted
+- The restored windows get new instance IDs and start saving under those
+- If the old instance had a `display_name`, it carries over to the new instance
+
+---
+
+## 13. Persistent Instance Names
+
+Instances can have a user-assigned `display_name` that persists across saves and restores.
+
+### How It Works
+- `.meta` files have a `display_name` field (nil by default)
+- **Named instances** show as: `"Orahvision Dev -- Claude Code, PowerShell [2 tabs]"`
+- **Unnamed instances** show as: `"Mar 13 16:45 -- Claude Code, PowerShell [2 tabs]"`
+
+### Renaming
+- In the main selector, pick **[Rename an instance]**
+- Select which instance to rename from the list
+- Enter a name in the text prompt
+- Name is written to the `.meta` file and immediately reflected
+- If renaming the current instance, the in-memory `display_name` also updates
+
+### Carry-Over on Restore
+- When restoring an instance, its `display_name` carries over to the new instance ID
+- The user does not need to re-name the instance after each restore

--- a/planning/user-journeys.md
+++ b/planning/user-journeys.md
@@ -1,0 +1,157 @@
+# Resurrect: User Journey Map
+
+Everything below is from the user's point of view. No implementation details.
+
+---
+
+## Journey 1: Normal Workday
+
+1. I open WezTerm. Fresh window with PowerShell.
+2. I open 3 tabs. In each one I start a Claude Code session for different projects.
+3. I work for a few hours. The status bar in the top right says "saved 14:30:05 | Claude Code x3".
+4. I finish one project. I close that tab.
+5. Status bar updates: "saved 14:30:12 | Claude Code x2". The closed tab is gone from the save.
+6. End of day. I close WezTerm.
+7. Next morning I open WezTerm. Fresh window.
+8. I press Alt+R. I see:
+   ```
+   Mar 13 14:30 -- Claude Code x2 [2 tabs]
+   ```
+9. I select it and hit enter.
+10. A window opens with 2 tabs. Each tab has my exact Claude Code session resumed right where I left off.
+11. The third tab (the one I closed yesterday) is not there. Good, I was done with it.
+
+---
+
+## Journey 2: Multiple WezTerm Windows
+
+1. I open WezTerm window A. Start Claude Code for the orahvision project.
+2. I open WezTerm window B. Start Claude Code for a personal project and a PowerShell tab for git work.
+3. I open WezTerm window C. Start two Claude Code sessions for a client project.
+4. Status bars show independently:
+   - Window A: "saved 14:00 | Claude Code"
+   - Window B: "saved 14:01 | Claude Code, PowerShell"
+   - Window C: "saved 14:02 | Claude Code x2"
+5. In window B, I close the PowerShell tab. I'm done with it.
+6. Window B status bar updates: "saved 14:03 | Claude Code". PowerShell tab is gone from the save.
+7. I close all three windows and go to lunch.
+8. After lunch I open WezTerm. Fresh window.
+9. I press Alt+R. I see:
+   ```
+   Mar 13 14:03 -- Claude Code [1 tab]
+   Mar 13 14:02 -- Claude Code x2 [2 tabs]
+   Mar 13 14:00 -- Claude Code [1 tab]
+   ```
+10. I select all three and hit enter.
+11. Three windows open. Each has exactly the tabs I left open (not the ones I closed).
+12. All five Claude Code sessions resume to their exact conversations.
+
+---
+
+## Journey 3: Windows Update Kills Everything
+
+1. I have 3 WezTerm windows open with 8 Claude Code sessions across them.
+2. Windows says "Restarting in 5 minutes" and I ignore it.
+3. Windows kills everything. WezTerm didn't get a chance to do anything special.
+4. Computer restarts. I log in. I open WezTerm.
+5. I press Alt+R. All three instances are there with all 8 sessions.
+6. I select all three, hit enter.
+7. Three windows open. All 8 Claude Code sessions resume exactly where they were.
+8. I lost at most 5 minutes of state (the periodic save interval).
+
+---
+
+## Journey 4: WezTerm Crashes
+
+1. I'm working in WezTerm. One window has 3 Claude Code sessions.
+2. WezTerm freezes. I kill it in Task Manager.
+3. I reopen WezTerm. Fresh window.
+4. I press Alt+R. My crashed instance is there:
+   ```
+   Mar 13 16:42 -- Claude Code x3 [3 tabs]
+   ```
+5. I select it, hit enter.
+6. Window opens with all 3 sessions restored.
+
+---
+
+## Journey 5: I Only Want Some of My Old Sessions
+
+1. Yesterday I had 4 WezTerm windows open. I closed them all at end of day.
+2. Today I only need 2 of those projects.
+3. I open WezTerm, press Alt+R. I see all 4 instances:
+   ```
+   Mar 12 17:30 -- Claude Code (orahvision) [3 tabs]
+   Mar 12 17:28 -- Claude Code, PowerShell [2 tabs]
+   Mar 12 17:25 -- Claude Code (client project) [2 tabs]
+   Mar 12 17:20 -- PowerShell [1 tab]
+   ```
+4. I select only the first two. Hit enter.
+5. Two windows open with those sessions. The other two stay saved in case I want them later.
+6. After 7 days, the unrestored ones get automatically cleaned up.
+
+---
+
+## Journey 6: I Close a Tab by Mistake
+
+1. I accidentally close a tab with a Claude Code session.
+2. The auto-save fires and saves the state WITHOUT that tab.
+3. BUT: the previous save (from before I closed it) is gone because the instance state file was overwritten.
+4. However, Claude Code sessions persist on their end. I can always run `claude --continue` or `claude --resume <id>` manually to get that session back.
+5. Resurrect handles windows and panes. Claude Code handles session persistence. They complement each other.
+
+---
+
+## Journey 7: I Open WezTerm But Don't Want to Restore Anything
+
+1. I open WezTerm. Fresh window with PowerShell.
+2. I don't press Alt+R. I just start working.
+3. Old saved instances sit in storage. I can restore them anytime with Alt+R.
+4. After 7 days they auto-delete.
+5. No popups, no prompts, no interruptions.
+
+---
+
+## Journey 8: I Want to Save a Specific Layout to Reuse Later
+
+1. I set up a perfect window layout: 4 panes split just right, each with the right CWD.
+2. I press Alt+W to manually save this workspace. It saves alongside the auto-saves.
+3. Days later, I press Alt+R and see my named save alongside the instance auto-saves.
+4. I select it. My layout is restored exactly.
+5. Unlike instance auto-saves, manual saves don't auto-delete after 7 days.
+
+---
+
+## Journey 9: First Time Using the Plugin
+
+1. I add two lines to my wezterm.lua:
+   ```lua
+   local resurrect = wezterm.plugin.require("https://github.com/YedPool/resurrect.wezterm")
+   resurrect.setup(config)
+   ```
+2. I restart WezTerm. Plugin downloads.
+3. I see a status bar in the top right that says "saved 14:00:01 | PowerShell".
+4. I don't need to configure anything else. Claude Code hooks are set up automatically. Save is automatic. Keybindings work.
+5. I open some Claude Code sessions, work for a while, close WezTerm.
+6. Next time I open WezTerm, I press Alt+R and my sessions are there.
+
+---
+
+## Journey 10: Running claude and claude2 (Multiple Accounts)
+
+1. I have two Claude Code binaries: `claude` (work account) and `claude2` (personal account).
+2. I open a WezTerm window. Tab 1 runs `claude`, Tab 2 runs `claude2`.
+3. Auto-save captures both, remembering which binary each tab used.
+4. I close WezTerm, reopen, press Alt+R.
+5. Tab 1 restores with `claude --resume <session-id>`. Tab 2 restores with `claude2 --resume <session-id>`.
+6. Each resumes in the correct account.
+
+---
+
+## What the User Never Sees or Thinks About
+
+- Instance IDs, PIDs, timestamps -- all hidden behind human-readable summaries
+- Pane-session files, SessionStart hooks -- set up automatically
+- State file format, directory structure -- just works
+- Cleanup of old files -- happens silently on startup
+- The distinction between "foreground process is bash but Claude Code is running" -- handled automatically

--- a/planning/wezterm-resurrect-fork-plan.md
+++ b/planning/wezterm-resurrect-fork-plan.md
@@ -1,0 +1,292 @@
+# wezterm-resurrect Fork Plan
+
+## Project Overview
+
+**Original repo:** MLFlexer/resurrect.wezterm (283 stars, 25 forks, MIT license)
+**Our fork:** YedPool/resurrect.wezterm
+**Status:** Semi-maintained upstream - last commit July 2025, 29 open issues, 9 unmerged PRs
+**Architecture:** WezTerm Lua plugin, ~1,489 lines across 12 files, depends on dev.wezterm
+**Decision:** Fork (not rewrite) - bugs are surface-level, core architecture is sound
+
+## Why Fork Over Rewrite
+
+1. Only 1,489 lines of Lua - small enough to fully understand
+2. Bugs are surface-level (Windows paths, os.execute, module loading), not architectural
+3. Core pane-tree algorithm and hierarchical state model are sound
+4. 9 PRs with confirmed fixes already exist - just need to be landed
+5. Valuable WezTerm API tribal knowledge embedded (Windows CWD munging, alt-screen detection, split ratios)
+6. Rewrite would only save ~500-700 lines - not worth losing edge case handling
+
+## Repository Structure
+
+```
+C:/Users/yedid/Documents/Code/wezterm-resurrect/          # main repo
+C:/Users/yedid/Documents/Code/wezterm-resurrect Worktrees/ # worktrees
+```
+
+## Branch Strategy
+
+```
+main (fork, synced with upstream)
+  |
+  +-- integrate-community-fixes  (Phase 1: merge PRs)
+       |
+       +-- fix/115-windows-hang-on-require
+       +-- fix/129-periodic-save-silent-failure
+       +-- fix/124-fuzzy-loader-nil-str-date
+       +-- fix/68-glob-chars-in-titles
+       +-- fix/111-cwd-save-overwrite
+       +-- fix/110-cursor-position-after-restore
+       +-- fix/108-first-window-cwd
+       +-- feature/claude-code-restoration
+```
+
+After each fix branch is tested, merge into main via PR (squash and merge). Never commit directly to main.
+
+---
+
+## Phase 1: Merge Existing Fix PRs
+
+Merge order matters due to file overlap. Skip PR #134 (subsumed by #136).
+
+### PR #123 - Fix module 'resurrect' not found (fixes #117, #119)
+
+**Commits:** c7df652, a160481
+**Files:** tab_state.lua, window_state.lua
+**Change:** Replaces `require("resurrect")` with `require("resurrect.state_manager")` - the module is not in the standard require path.
+
+### PR #127 - Fix nil pane access in symmetric layouts (fixes #98)
+
+**Commit:** ec66651
+**Files:** pane_tree.lua
+**Change:** Adds guard clause at top of `insert_panes()` to check if `root.pane == nil` before calling `root.pane:get_domain_name()`. In symmetric layouts (e.g., 2x2 grid), a pane can appear in both right and bottom branches. After the first encounter sets `root.pane = nil`, the second would crash.
+
+### PR #118 - Fix workspace name not restored (fixes #114)
+
+**Commit:** 9a51cf5
+**Files:** workspace_state.lua
+**Change:** Adds `wezterm.mux.set_active_workspace()` after restore so workspace identity is preserved instead of staying as "default".
+
+### PR #136 - Fix Windows path handling + tests (fixes #107)
+
+**Commits:** 2204a55, efef173, d7a3e82
+**Files:** utils.lua, state_manager.lua, pane_tree.lua, spec files, README.md
+**Changes:**
+- Complete rewrite of `ensure_folder_exists()` with `shell_mkdir()`, `parse_root()`, `dir_is_accessible()`, `mkdir_if_missing()`
+- Handles drive letters, UNC paths, spaces in paths, proper quoting
+- Fixes `get_file_path()` - adds missing separator, expands filename sanitization for `:`, `[`, `]`, `?`, `/`
+- Adds WSL `/mnt/c/...` to `C:\...` conversion at save time
+- Adds Busted test specs
+
+### PR #130 - Fix flickering cmd.exe windows (fixes #125)
+
+**Commit:** From PR branch
+**Files:** utils.lua, init.lua
+**Change:** Replaces `os.execute('mkdir ...')` with pure Lua alternative. NOTE: #136 also touches utils.lua - may need manual conflict resolution. Take #136's structure but ensure we eliminate ALL os.execute calls for mkdir on Windows.
+
+### PR #137 - Event-driven save (new feature)
+
+**Commits:** From PR branch
+**Files:** New event-driven save module
+**Change:** Adds event-based saving triggered by structural changes (tab open/close, pane split, etc.) instead of only periodic timer.
+
+### PR #128 - NixOS nix store path sanitization
+
+**Commit:** a24d52a
+**Files:** pane_tree.lua
+**Change:** Strips `/nix/store/*` paths from saved vim/nvim process info. NixOS-specific, no effect on Windows.
+
+### Step: Fix init.lua keywords for fork
+
+The `keywords` in `plugin/init.lua` must match the fork URL path. Change:
+```lua
+-- FROM:
+keywords = { "github", "MLFlexer", "resurrect", "wezterm" },
+-- TO:
+keywords = { "resurrect", "wezterm" },
+```
+This matches both upstream and any fork URL.
+
+---
+
+## Phase 2: Fix Remaining Issues Without PRs
+
+### #115 - Plugin hangs WezTerm on Windows at require()
+
+**Root cause:** `dev.wezterm` dependency does network fetch on init; `os.execute('mkdir')` blocks WezTerm's Lua event loop.
+**Fix:** Eliminate `dev.wezterm` dependency. Replace with direct path detection (~5 lines). Replace remaining `os.execute` mkdir calls with `wezterm.run_child_process` (non-blocking, no visible window).
+
+### #129 - periodic_save silently fails
+
+**Root cause:** No error handling in `wezterm.time.call_after` callback. If any error occurs, the recursive re-schedule never executes, killing auto-save permanently.
+**Fix:** Wrap callback body in `pcall`, always re-schedule regardless of errors, log errors via `wezterm.log_error`.
+
+### #124 - Fuzzy loader crashes on nil str_date
+
+**Root cause:** `fmt_cost.str_date` is nil when no files were parsed but stdout was non-empty.
+**Fix:** Add nil guards: `(fmt_cost.str_date or 0)`. Add early return if no files parsed.
+
+### #68 - Glob characters in pane titles crash periodic save
+
+**Root cause:** Shell metacharacters (`*`, `~`, `!`, `{`, `}`, etc.) in pane titles become part of save file paths, causing shell expansion errors.
+**Fix:** Expand sanitization in `get_file_path()` to cover ALL shell-unsafe characters. Fix encryption.lua to use proper shell quoting.
+
+### #111 - CWD not saved, subsequent saves overwrite ignored
+
+**Root cause:** Partially fixed by #136 (missing path separator). Additional fix needed: guard against empty CWD in `workspace_state.lua`.
+
+### #110 - Cursor at bottom of window after restore
+
+**Root cause:** `inject_output()` positions cursor at end of injected content.
+**Fix:** After injecting output, send `\r\n` to trigger a fresh shell prompt at the correct position.
+
+### #108 - First window restores to zoxide path not actual CWD
+
+**Root cause:** First window reuses existing pane which inherits whatever CWD it already has. No CWD is set for the reused pane.
+**Fix:** When using existing pane, explicitly `cd` to the saved CWD via `pane:send_text("cd " .. path .. "\r\n")`.
+
+---
+
+## Phase 3: Claude Code Session Restoration
+
+### Discovery: Session Detection via Process argv
+
+From actual running processes on the system:
+```
+node cli.js --dangerously-skip-permissions
+node cli.js --dangerously-skip-permissions --resume 3e55cd6d-52cc-4921-aa75-add4ea080b1f
+```
+
+Everything we need is in the process argv that WezTerm's `pane:get_foreground_process_info()` provides:
+- `--resume <uuid>` or `-r <uuid>` = session ID
+- `--dangerously-skip-permissions` = permission flag to preserve
+- `--session-id <uuid>` = alternative session ID flag
+- CWD already captured by existing pane tree logic
+
+### Restore command construction
+
+```
+-- If --resume <uuid> captured from argv:
+claude --resume <uuid> --dangerously-skip-permissions
+
+-- If no session ID in argv (fresh session), fall back to:
+claude --continue --dangerously-skip-permissions
+
+-- Flags only included if they were present in the original argv
+```
+
+### New module: plugin/resurrect/process_handlers.lua
+
+Extensible process handler registry. Each handler has:
+- `detect(process_info)` -> boolean
+- `get_restore_cmd(process_info, pane_tree)` -> string
+
+Built-in handlers:
+1. **claude_code** - detects `claude` or `node` with `claude-code` in argv
+   - Parses `--resume <uuid>`, `--dangerously-skip-permissions`, `--session-id`
+   - Constructs restore command with all captured flags
+2. **vim** (existing behavior, refactored into handler)
+
+Users can register custom handlers in their wezterm.lua:
+```lua
+resurrect.process_handlers.register({
+    name = "htop",
+    detect = function(info) return info.name == "htop" end,
+    get_restore_cmd = function(info, _) return "htop" end,
+})
+```
+
+### Integration into tab_state.lua
+
+Modify `default_on_pane_restore()`:
+1. Check process_handlers for a matching handler first
+2. If found, use handler's restore command
+3. If not, fall back to existing behavior (replay argv)
+
+### Save-time sanitization in pane_tree.lua
+
+When saving Claude Code process info:
+- Store clean argv: `{"claude", "--resume", "<uuid>", "--dangerously-skip-permissions"}`
+- Strip the full node path and cli.js path (not portable)
+- Preserve all relevant flags
+
+---
+
+## Phase 4: Comment on Original Issues
+
+For each fix, comment on the original issue at MLFlexer/resurrect.wezterm:
+
+```
+gh issue comment <NUMBER> --repo MLFlexer/resurrect.wezterm --body "..."
+```
+
+Template:
+```
+I've addressed this in a maintained fork: https://github.com/YedPool/resurrect.wezterm
+
+The fix is on the `<branch>` branch. You can use the fork by changing your plugin require to:
+
+local resurrect = wezterm.plugin.require("https://github.com/YedPool/resurrect.wezterm")
+
+[Brief description of the fix]
+```
+
+---
+
+## Phase 5: User Configuration
+
+Update wezterm config to use the fork with auto-save and Claude Code restoration.
+
+Key config points:
+- `periodic_save` with 5-minute interval
+- `resurrect_on_gui_startup` event handler
+- Keybindings for manual save (ALT+SHIFT+S) and restore (ALT+SHIFT+R)
+- `default_on_pane_restore` with process handler integration
+
+---
+
+## Testing Strategy
+
+For each fix:
+1. Apply change in worktree
+2. Run Busted test suite (`busted` from repo root)
+3. Point wezterm config at local plugin path for manual testing
+4. Check WezTerm debug overlay (Ctrl+Shift+L) for Lua errors
+5. User confirms everything works before committing
+
+For Claude Code restoration:
+1. Open WezTerm, start `claude` in a pane
+2. Save workspace state
+3. Close WezTerm
+4. Reopen, restore saved workspace
+5. Verify Claude Code resumes with correct session ID and flags
+
+---
+
+## Critical Files
+
+| File | Purpose | Phases |
+|------|---------|--------|
+| plugin/init.lua | Entry point, module exports, keywords | 1, 3 |
+| plugin/resurrect/pane_tree.lua | Core pane tree serialization | 1, 3 |
+| plugin/resurrect/utils.lua | Platform utilities, ensure_folder_exists | 1, 2 |
+| plugin/resurrect/state_manager.lua | State persistence, periodic_save, file paths | 1, 2 |
+| plugin/resurrect/tab_state.lua | Save/restore tabs, default_on_pane_restore | 1, 2, 3 |
+| plugin/resurrect/workspace_state.lua | Save/restore workspaces | 1, 2 |
+| plugin/resurrect/window_state.lua | Save/restore windows | 1 |
+| plugin/resurrect/fuzzy_loader.lua | UI for selecting saved states | 2 |
+| plugin/resurrect/encryption.lua | age/gpg encryption | 2 |
+| plugin/resurrect/file_io.lua | JSON read/write | - |
+| plugin/resurrect/process_handlers.lua | NEW - extensible process handler registry | 3 |
+
+---
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|------|-----------|
+| Cherry-pick conflicts between PRs | Ordered by file overlap; #127/#118/#123 touch different files; #136 conflicts documented |
+| os.execute still flashes on first run | Replace with wezterm.run_child_process entirely |
+| Claude process shows as "node" not "claude" | Handler checks both process name AND argv for claude-code markers |
+| dev.wezterm elimination breaks something | Test thoroughly; the dependency only provides path detection |
+| Session ID not in argv for fresh sessions | Fall back to claude --continue which finds most recent session in CWD |

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -11,7 +11,7 @@ local function init()
 	-- enable_sub_modules()
 	local opts = {
 		auto = true,
-		keywords = { "github", "MLFlexer", "resurrect", "wezterm" },
+		keywords = { "resurrect", "wezterm" },
 	}
 	local plugin_path = dev.setup(opts)
 

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -3,10 +3,6 @@ local dev = wezterm.plugin.require("https://github.com/chrisgve/dev.wezterm")
 
 local pub = {}
 
---- checks if the user is on windows
-local is_windows = wezterm.target_triple == "x86_64-pc-windows-msvc"
-local separator = is_windows and "\\" or "/"
-
 local function init()
 	-- enable_sub_modules()
 	local opts = {
@@ -15,7 +11,8 @@ local function init()
 	}
 	local plugin_path = dev.setup(opts)
 
-	require("resurrect.state_manager").change_state_save_dir(plugin_path .. separator .. "state" .. separator)
+	local sep = require("resurrect.utils").separator
+	require("resurrect.state_manager").change_state_save_dir(plugin_path .. sep .. "state" .. sep)
 
 	-- Export submodules
 	pub.workspace_state = require("resurrect.workspace_state")
@@ -24,6 +21,7 @@ local function init()
 	pub.fuzzy_loader = require("resurrect.fuzzy_loader")
 	pub.state_manager = require("resurrect.state_manager")
 	pub.process_handlers = require("resurrect.process_handlers")
+	pub.instance_manager = require("resurrect.instance_manager")
 end
 
 init()
@@ -35,14 +33,16 @@ init()
 ---   resurrect.setup(config)  -- or resurrect.setup(config, opts)
 ---
 --- Options (all optional):
----   periodic_interval  = 300    -- seconds between periodic saves
----   restore_delay      = 3      -- seconds to wait before sending restore commands
----   save_workspaces    = true
----   save_windows       = true
----   save_tabs          = true
----   keybindings        = true   -- add Alt+W/R/Shift+W/Shift+T bindings
----   status_bar         = true   -- show save time + tab titles in right status
----   claude_hooks       = true   -- auto-configure Claude Code SessionStart hook
+---   periodic_interval    = 300    -- seconds between periodic saves
+---   restore_delay        = 3      -- seconds to wait before sending restore commands
+---   save_workspaces      = true
+---   save_windows         = true
+---   save_tabs            = true
+---   keybindings          = true   -- add Alt+S/R/W/Shift+W/Shift+T bindings
+---   status_bar           = true   -- show save time + tab titles in right status
+---   claude_hooks         = true   -- auto-configure Claude Code SessionStart hook
+---   auto_restore_prompt  = true   -- show instance selector on startup if saved instances exist
+---   retention_days       = 7      -- auto-delete instance states older than this
 ---
 ---@param config table wezterm config_builder object
 ---@param opts? table optional overrides
@@ -51,6 +51,11 @@ function pub.setup(config, opts)
 	local save_workspaces = opts.save_workspaces ~= false
 	local save_windows = opts.save_windows ~= false
 	local save_tabs = opts.save_tabs ~= false
+
+	-- Initialize per-instance state management
+	pub.instance_manager.init_instance_id()
+	pub.instance_manager.retention_days = opts.retention_days or 7
+	pub.instance_manager.auto_restore_prompt = opts.auto_restore_prompt ~= false
 
 	-- Claude Code session hook setup (idempotent)
 	if opts.claude_hooks ~= false then
@@ -77,18 +82,26 @@ function pub.setup(config, opts)
 		pub.tab_state.process_restore_delay_seconds = opts.restore_delay
 	end
 
-	-- Restore workspace on startup
-	wezterm.on("gui-startup", pub.state_manager.resurrect_on_gui_startup)
+	-- Restore on startup: show instance selector if saved instances exist,
+	-- otherwise fall back to current_state mechanism for backward compat
+	wezterm.on("gui-startup", function()
+		pub.instance_manager.auto_restore_on_startup()
+	end)
 
 	-- Status bar: show save time + tab titles
 	if opts.status_bar ~= false then
 		local last_save_time = nil
 
+		-- Listen to all save-finished events for status bar updates
 		wezterm.on("resurrect.state_manager.event_driven_save.finished", function()
 			last_save_time = os.date("%H:%M:%S")
 		end)
 
 		wezterm.on("resurrect.state_manager.periodic_save.finished", function()
+			last_save_time = os.date("%H:%M:%S")
+		end)
+
+		wezterm.on("resurrect.save.finished", function()
 			last_save_time = os.date("%H:%M:%S")
 		end)
 
@@ -162,28 +175,22 @@ function pub.setup(config, opts)
 			action = pub.tab_state.save_tab_action(),
 		})
 
-		-- Alt+R: fuzzy load saved state
+		-- Alt+S: full save (workspace + instance + status bar update)
+		table.insert(config.keys, {
+			key = "s",
+			mods = "ALT",
+			action = wezterm.action_callback(function(win, pane)
+				pub.state_manager.save_workspace_full()
+				wezterm.emit("resurrect.save.finished")
+			end),
+		})
+
+		-- Alt+R: show instance selector (with fallthrough to named saves)
 		table.insert(config.keys, {
 			key = "r",
 			mods = "ALT",
 			action = wezterm.action_callback(function(win, pane)
-				pub.fuzzy_loader.fuzzy_load(win, pane, function(id, label)
-					local state_type = id:match("^([^/\\]+)")
-					local name = id:match("[/\\](.+)$")
-					if name then
-						name = name:gsub("%.json$", "")
-					end
-					if state_type == "workspace" then
-						local state = pub.state_manager.load_state(name, "workspace")
-						pub.workspace_state.restore_workspace(state, restore_opts)
-					elseif state_type == "window" then
-						local state = pub.state_manager.load_state(name, "window")
-						pub.window_state.restore_window(pane:window(), state, restore_opts)
-					elseif state_type == "tab" then
-						local state = pub.state_manager.load_state(name, "tab")
-						pub.tab_state.restore_tab(pane:tab(), state, restore_opts)
-					end
-				end)
+				pub.instance_manager.show_instance_selector(win, pane, restore_opts)
 			end),
 		})
 	end

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -23,6 +23,7 @@ local function init()
 	pub.tab_state = require("resurrect.tab_state")
 	pub.fuzzy_loader = require("resurrect.fuzzy_loader")
 	pub.state_manager = require("resurrect.state_manager")
+	pub.process_handlers = require("resurrect.process_handlers")
 end
 
 init()

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -28,4 +28,165 @@ end
 
 init()
 
+--- One-call setup that configures everything for session persistence
+--- and Claude Code restoration. Users call this from their wezterm.lua:
+---
+---   local resurrect = wezterm.plugin.require("https://github.com/YedPool/resurrect.wezterm")
+---   resurrect.setup(config)  -- or resurrect.setup(config, opts)
+---
+--- Options (all optional):
+---   periodic_interval  = 300    -- seconds between periodic saves
+---   restore_delay      = 3      -- seconds to wait before sending restore commands
+---   save_workspaces    = true
+---   save_windows       = true
+---   save_tabs          = true
+---   keybindings        = true   -- add Alt+W/R/Shift+W/Shift+T bindings
+---   status_bar         = true   -- show save time + tab titles in right status
+---   claude_hooks       = true   -- auto-configure Claude Code SessionStart hook
+---
+---@param config table wezterm config_builder object
+---@param opts? table optional overrides
+function pub.setup(config, opts)
+	opts = opts or {}
+	local save_workspaces = opts.save_workspaces ~= false
+	local save_windows = opts.save_windows ~= false
+	local save_tabs = opts.save_tabs ~= false
+
+	-- Claude Code session hook setup (idempotent)
+	if opts.claude_hooks ~= false then
+		pub.process_handlers.setup_claude_session_hooks()
+	end
+
+	-- Event-driven save: fires on pane/tab structure changes
+	pub.state_manager.event_driven_save({
+		save_workspaces = save_workspaces,
+		save_windows = save_windows,
+		save_tabs = save_tabs,
+	})
+
+	-- Periodic save as a safety net
+	pub.state_manager.periodic_save({
+		interval_seconds = opts.periodic_interval or 300,
+		save_workspaces = save_workspaces,
+		save_windows = save_windows,
+		save_tabs = save_tabs,
+	})
+
+	-- Restore delay for process commands (shells need time to init)
+	if opts.restore_delay then
+		pub.tab_state.process_restore_delay_seconds = opts.restore_delay
+	end
+
+	-- Restore workspace on startup
+	wezterm.on("gui-startup", pub.state_manager.resurrect_on_gui_startup)
+
+	-- Status bar: show save time + tab titles
+	if opts.status_bar ~= false then
+		local last_save_time = nil
+
+		wezterm.on("resurrect.state_manager.event_driven_save.finished", function()
+			last_save_time = os.date("%H:%M:%S")
+		end)
+
+		wezterm.on("resurrect.state_manager.periodic_save.finished", function()
+			last_save_time = os.date("%H:%M:%S")
+		end)
+
+		wezterm.on("update-right-status", function(window, pane)
+			local titles = {}
+			local mux_win = window:mux_window()
+			for _, tab in ipairs(mux_win:tabs()) do
+				local title = tab:get_title() or ""
+				if title ~= "" then
+					titles[title] = (titles[title] or 0) + 1
+				end
+			end
+
+			local parts = {}
+			for title, count in pairs(titles) do
+				if count > 1 then
+					table.insert(parts, title .. " x" .. count)
+				else
+					table.insert(parts, title)
+				end
+			end
+			table.sort(parts)
+			local title_str = table.concat(parts, ", ")
+
+			local status = ""
+			if last_save_time then
+				status = "saved " .. last_save_time .. " | " .. title_str
+			elseif title_str ~= "" then
+				status = title_str
+			end
+
+			window:set_right_status(wezterm.format({
+				{ Foreground = { AnsiColor = "Green" } },
+				{ Text = status },
+			}))
+		end)
+	end
+
+	-- Keybindings for manual save/restore
+	if opts.keybindings ~= false then
+		local restore_opts = {
+			relative = true,
+			restore_text = true,
+			on_pane_restore = pub.tab_state.default_on_pane_restore,
+		}
+
+		config.keys = config.keys or {}
+
+		-- Alt+W: save workspace
+		table.insert(config.keys, {
+			key = "w",
+			mods = "ALT",
+			action = wezterm.action_callback(function(win, pane)
+				pub.state_manager.save_state(
+					pub.workspace_state.get_workspace_state()
+				)
+			end),
+		})
+
+		-- Alt+Shift+W: save window
+		table.insert(config.keys, {
+			key = "W",
+			mods = "ALT|SHIFT",
+			action = pub.window_state.save_window_action(),
+		})
+
+		-- Alt+Shift+T: save tab
+		table.insert(config.keys, {
+			key = "T",
+			mods = "ALT|SHIFT",
+			action = pub.tab_state.save_tab_action(),
+		})
+
+		-- Alt+R: fuzzy load saved state
+		table.insert(config.keys, {
+			key = "r",
+			mods = "ALT",
+			action = wezterm.action_callback(function(win, pane)
+				pub.fuzzy_loader.fuzzy_load(win, pane, function(id, label)
+					local state_type = id:match("^([^/\\]+)")
+					local name = id:match("[/\\](.+)$")
+					if name then
+						name = name:gsub("%.json$", "")
+					end
+					if state_type == "workspace" then
+						local state = pub.state_manager.load_state(name, "workspace")
+						pub.workspace_state.restore_workspace(state, restore_opts)
+					elseif state_type == "window" then
+						local state = pub.state_manager.load_state(name, "window")
+						pub.window_state.restore_window(pane:window(), state, restore_opts)
+					elseif state_type == "tab" then
+						local state = pub.state_manager.load_state(name, "tab")
+						pub.tab_state.restore_tab(pane:tab(), state, restore_opts)
+					end
+				end)
+			end),
+		})
+	end
+end
+
 return pub

--- a/plugin/resurrect/encryption.lua
+++ b/plugin/resurrect/encryption.lua
@@ -67,20 +67,33 @@ end
 ---@param file_path string
 ---@param lines string
 function pub.encrypt(file_path, lines)
-	local cmd = string.format("%s -r %s -o %s", pub.method, pub.public_key, file_path:gsub(" ", "\\ "))
+	-- Write data to a temp file, then encrypt from file to avoid shell injection
+	-- and command-line length limits
+	local temp_input = os.tmpname()
+	local f = io.open(temp_input, "w")
+	if not f then
+		error("Encryption failed: could not create temp file")
+	end
+	f:write(lines)
+	f:flush()
+	f:close()
 
+	local cmd
 	if pub.method:find("gpg") then
-		cmd = string.format(
-			"%s --batch --yes --encrypt --recipient %s --output %s",
-			pub.method,
-			pub.public_key,
-			file_path:gsub(" ", "\\ ")
-		)
+		cmd = {
+			pub.method, "--batch", "--yes", "--encrypt",
+			"--recipient", pub.public_key,
+			"--output", file_path,
+			temp_input,
+		}
+	else
+		cmd = { pub.method, "-r", pub.public_key, "-o", file_path, temp_input }
 	end
 
-	local success, output = execute_cmd_with_stdin(cmd, lines)
+	local success, _, stderr = wezterm.run_child_process(cmd)
+	os.remove(temp_input)
 	if not success then
-		error("Encryption failed:" .. output)
+		error("Encryption failed: " .. (stderr or "unknown error"))
 	end
 end
 

--- a/plugin/resurrect/file_io.lua
+++ b/plugin/resurrect/file_io.lua
@@ -4,20 +4,35 @@ local pub = {
 	encryption = { enable = false },
 }
 
--- Write a file with the content of a string
+-- Write a file atomically: writes to a temp file first, then renames.
+-- This prevents data loss if the process crashes mid-write.
 ---@param file_path string full filename
 ---@return boolean success result
 ---@return string|nil error
 function pub.write_file(file_path, str)
+	local tmp_path = file_path .. ".tmp"
 	local suc, err = pcall(function()
-		local handle = io.open(file_path, "w+")
+		local handle = io.open(tmp_path, "w+")
 		if not handle then
-			error("Could not open file: " .. file_path)
+			error("Could not open file: " .. tmp_path)
 		end
 		handle:write(str)
 		handle:flush()
 		handle:close()
+		-- Atomic rename (on same filesystem)
+		local ok, rename_err = os.rename(tmp_path, file_path)
+		if not ok then
+			-- Fallback: on Windows os.rename can fail if target exists
+			os.remove(file_path)
+			ok, rename_err = os.rename(tmp_path, file_path)
+			if not ok then
+				error("Could not rename temp file: " .. (rename_err or "unknown"))
+			end
+		end
 	end)
+	if not suc then
+		os.remove(tmp_path)
+	end
 	return suc, err
 end
 
@@ -57,7 +72,7 @@ end
 --- @param data string
 --- @return string
 local function sanitize_json(data)
-	wezterm.emit("resurrect.file_io.sanitize_json.start", data)
+	wezterm.emit("resurrect.file_io.sanitize_json.start", #data)
 	-- escapes control characters to ensure valid json
 	data = data:gsub("[\x00-\x1F]", function(c)
 		return string.format("\\u00%02X", string.byte(c))
@@ -80,7 +95,7 @@ function pub.write_state(file_path, state, event_type)
 		end)
 		if not ok then
 			wezterm.emit("resurrect.error", "Encryption failed: " .. tostring(err))
-			wezterm.log_error("Decryption failed: " .. tostring(err))
+			wezterm.log_error("Encryption failed: " .. tostring(err))
 		else
 			wezterm.emit("resurrect.file_io.encrypt.finished", file_path)
 		end
@@ -111,16 +126,14 @@ function pub.load_json(file_path)
 			wezterm.emit("resurrect.file_io.decrypt.finished", file_path)
 		end
 	else
-		local lines = {}
-		for line in io.lines(file_path) do
-			table.insert(lines, line)
+		local ok, content = pub.read_file(file_path)
+		if ok then
+			json = content
 		end
-		json = table.concat(lines)
 	end
 	if not json then
 		return nil
 	end
-	json = sanitize_json(json)
 
 	return wezterm.json_parse(json)
 end

--- a/plugin/resurrect/fuzzy_loader.lua
+++ b/plugin/resurrect/fuzzy_loader.lua
@@ -19,6 +19,7 @@ pub.default_fuzzy_load_opts = {
 	ignore_workspaces = false,
 	ignore_windows = false,
 	ignore_tabs = false,
+	ignore_instances = true,
 	ignore_screen_width = true,
 	date_format = "%d-%m-%Y %H:%M:%S",
 	show_state_with_date = false,
@@ -75,16 +76,20 @@ local function find_json_files_recursive(base_path)
 			ps_cmd,
 		})
 	elseif utils.is_mac then
+		-- Use single-quote escaping to prevent shell injection via $() and backticks
+		local safe_path = base_path:gsub("'", "'\\''")
 		success, stdout, stderr = wezterm.run_child_process({
 			"sh",
 			"-c",
-			'find "' .. base_path:gsub('"', '\\"') .. '" -type f -name "*.json" -print0 | xargs -0 stat -f "%m %N"',
+			"find '" .. safe_path .. "' -type f -name '*.json' -print0 | xargs -0 stat -f '%m %N'",
 		})
 	else
+		-- Use single-quote escaping to prevent shell injection via $() and backticks
+		local safe_path = base_path:gsub("'", "'\\''")
 		success, stdout, stderr = wezterm.run_child_process({
 			"sh",
 			"-c",
-			'find "' .. base_path:gsub('"', '\\"') .. '" -type f -name "*.json" -printf "%T@ %p\\n" | awk \'{split($1, a, "."); print a[1], $2}\'',
+			"find '" .. safe_path .. "' -type f -name '*.json' -printf '%T@ %p\\n' | awk '{split($1, a, \".\"); print a[1], $2}'",
 		})
 	end
 
@@ -125,7 +130,10 @@ local function insert_choices(stdout, opts)
 		-- MacOS it is from January 1st, 1904 0 UTC
 		-- Windows NTFS (up to Win 11) it is from January 1st, 1601 0 UTC
 		-- The function `os.date()` used later on will convert the date according to the host OS
-		if epoch and file and type and not opts[string.format("ignore_%ss", type)] then
+		-- Skip instance files when ignore_instances is set (they use their own selector)
+		if type == "instances" and opts.ignore_instances then
+			-- fall through: do not add instance files to the fuzzy loader
+		elseif epoch and file and type and not opts[string.format("ignore_%ss", type)] then
 			-- consider the "cost" of the formatting of the filename, i.e., if the format function adds characters
 			-- to the visible part of the file section, we test the three possible formatter to get the highest cost
 			-- we use a real entry instead of an empty string to prevent formatting error if the format function has

--- a/plugin/resurrect/fuzzy_loader.lua
+++ b/plugin/resurrect/fuzzy_loader.lua
@@ -50,110 +50,49 @@ pub.default_fuzzy_load_opts = {
 	end,
 }
 
--- Optimized recursive JSON file finder for all platforms
+-- Recursive JSON file finder using wezterm.run_child_process (no os.execute, no VBS).
+-- Returns lines of "epoch filepath" for each .json file found.
 ---@param base_path string starting path from which the recursive search takes place
 ---@return string|nil
 local function find_json_files_recursive(base_path)
-	local cmd
-	local stdout
-	local suc, err
+	local success, stdout, stderr
 
 	if utils.is_windows then
-		-- For Windows, use VBS for better performance and truly invisible execution
-		local temp_vbs = os.tmpname() .. ".vbs"
-		local temp_out = os.tmpname() .. ".txt"
-
-		local vbs_script = string.format(
-			[[
-                Set fso = CreateObject("Scripting.FileSystemObject")
-                Set outFile = fso.CreateTextFile("%s", True)
-                
-                Sub ProcessFolder(folderPath)
-                    On Error Resume Next
-                    Set folder = fso.GetFolder(folderPath)
-                    If Err.Number <> 0 Then
-                        Exit Sub
-                    End If
-                    
-                    ' Process files in current folder
-                    For Each file in folder.Files
-                        If LCase(fso.GetExtensionName(file.Name)) = "json" Then
-                            epoch = DateDiff("s", "01/01/1970 00:00:00", file.DateLastModified)
-                            outFile.WriteLine(epoch & " " & file.Path)
-                        End If
-                    Next
-                    
-                    ' Process subfolders recursively
-                    For Each subFolder in folder.SubFolders
-                        ProcessFolder(subFolder.Path)
-                    Next
-                End Sub
-                
-                ProcessFolder("%s")
-                outFile.Close
-            ]],
-			temp_out:gsub("\\", "\\\\"),
-			base_path:gsub("\\", "\\\\")
+		-- Use PowerShell via run_child_process -- no visible window, no VBS temp files.
+		-- PowerShell Get-ChildItem is available on all modern Windows.
+		local ps_cmd = string.format(
+			"Get-ChildItem -Path '%s' -Recurse -Filter '*.json' -File | "
+				.. "ForEach-Object { "
+				.. "[int][double]::Parse(($_.LastWriteTimeUtc - [datetime]'1970-01-01').TotalSeconds) "
+				.. ".ToString() + ' ' + $_.FullName }",
+			base_path:gsub("'", "''")
 		)
-
-		-- Create a second VBS script that will run the first one invisibly
-		local launcher_vbs = os.tmpname() .. "_launcher.vbs"
-		local launcher_script = string.format(
-			[[
-                Set WshShell = CreateObject("WScript.Shell")
-                WshShell.Run "wscript.exe //nologo %s", 0, True
-            ]],
-			temp_vbs
-		)
-
-		-- Write the scripts
-		suc, err = file_io.write_file(temp_vbs, vbs_script)
-		if not suc then
-			wezterm.emit("resurrect.error", err)
-			return
-		end
-
-		suc, err = file_io.write_file(launcher_vbs, launcher_script)
-		if not suc then
-			wezterm.emit("resurrect.error", err)
-			os.remove(temp_vbs) -- by the time we are here the `temb_vbs` file already exists so we should clean up
-			return
-		end
-		-- Execute using launcher (completely hidden)
-		os.execute("wscript.exe //nologo " .. launcher_vbs)
-
-		suc, stdout = file_io.read_file(temp_out)
-
-		-- Clean up temp files
-		os.remove(temp_vbs)
-		os.remove(launcher_vbs)
-		os.remove(temp_out)
-
-		if suc then
-			return stdout
-		else
-			wezterm.emit("resurrect.error", stdout)
-			return
-		end
+		success, stdout, stderr = wezterm.run_child_process({
+			"powershell.exe",
+			"-NoProfile",
+			"-NoLogo",
+			"-Command",
+			ps_cmd,
+		})
 	elseif utils.is_mac then
-		-- macOS recursive find command for JSON files
-		cmd = 'find "' .. base_path .. '" -type f -name "*.json" -print0 | xargs -0 stat -f "%m %N"'
+		success, stdout, stderr = wezterm.run_child_process({
+			"sh",
+			"-c",
+			'find "' .. base_path:gsub('"', '\\"') .. '" -type f -name "*.json" -print0 | xargs -0 stat -f "%m %N"',
+		})
 	else
-		-- Linux optimized recursive find command for JSON files
-		cmd = string.format(
-			'find "$(realpath %q)" -type f -name "*.json" -printf "%%T@ %%p\\n" | awk \'{split($1, a, "."); print a[1], $2}\'',
-			base_path
-		)
+		success, stdout, stderr = wezterm.run_child_process({
+			"sh",
+			"-c",
+			'find "' .. base_path:gsub('"', '\\"') .. '" -type f -name "*.json" -printf "%T@ %p\\n" | awk \'{split($1, a, "."); print a[1], $2}\'',
+		})
 	end
 
-	-- Execute the command and capture stdout for non-Windows
-	suc, stdout = utils.execute(cmd)
-
-	if suc then
+	if success then
 		return stdout
 	else
-		wezterm.emit("resurrect.error", stdout)
-		return
+		wezterm.emit("resurrect.error", stderr or "Failed to list state files")
+		return nil
 	end
 end
 
@@ -247,9 +186,13 @@ local function insert_choices(stdout, opts)
 		end
 	end
 
+	if max_length == 0 then
+		return state_files
+	end
+
 	local available_width
 	if opts.ignore_screen_width then
-		available_width = max_length + fmt_cost.str_date + fmt_cost.fmt_date
+		available_width = max_length + (fmt_cost.str_date or 0) + (fmt_cost.fmt_date or 0)
 	else
 		-- During the selection view, InputSelector will take 4 characters on the left and 2 characters
 		-- on the right of the window

--- a/plugin/resurrect/instance_manager.lua
+++ b/plugin/resurrect/instance_manager.lua
@@ -1,0 +1,736 @@
+-- instance_manager.lua -- Per-instance state management
+--
+-- Each WezTerm process gets a unique instance ID (time + random) and saves
+-- independently to state/instances/. On startup or Alt+R, an InputSelector
+-- shows all saved instances for restore/delete/rename.
+--
+-- This module owns all instance lifecycle logic. state_manager.lua stays
+-- focused on named workspace/window/tab saves.
+
+local wezterm = require("wezterm") --[[@as Wezterm]]
+local file_io = require("resurrect.file_io")
+local utils = require("resurrect.utils")
+
+local pub = {}
+
+-- Generated once per WezTerm process at setup() time
+pub.instance_id = nil
+
+-- Persistent display name for this instance (carries over on restore)
+pub.display_name = nil
+
+-- Configuration (set via setup())
+pub.retention_days = 7
+pub.auto_restore_prompt = true
+
+-- Cached reference to state_manager (avoids re-requiring on every call)
+local _state_manager = nil
+local function get_state_manager()
+	if not _state_manager then
+		_state_manager = require("resurrect.state_manager")
+	end
+	return _state_manager
+end
+
+-- ---------------------------------------------------------------------------
+-- Instance ID
+-- ---------------------------------------------------------------------------
+
+--- Generate a unique instance ID: epoch seconds + underscore + 5-digit random.
+--- Called once during setup(). Uses os.clock() for sub-second entropy to reduce
+--- collision risk when multiple WezTerm processes start in the same second.
+function pub.init_instance_id()
+	math.randomseed(os.time() * 1000 + math.floor(os.clock() * 1000000))
+	pub.instance_id = tostring(os.time()) .. "_" .. tostring(math.random(10000, 99999))
+	return pub.instance_id
+end
+
+-- ---------------------------------------------------------------------------
+-- Paths
+-- ---------------------------------------------------------------------------
+
+--- Return the absolute path to the instances directory.
+---@return string
+function pub.get_instances_dir()
+	return get_state_manager().save_state_dir .. utils.separator .. "instances"
+end
+
+--- Validate that an instance ID matches the expected format.
+--- Rejects anything that could be a path traversal attempt.
+---@param id string
+---@return boolean
+local function is_valid_instance_id(id)
+	return type(id) == "string" and id:match("^%d+_%d+$") ~= nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Sanitization helpers
+-- ---------------------------------------------------------------------------
+
+--- Strip control characters (ASCII 0-31) and ANSI escape sequences from a
+--- string. Used to sanitize display_name and tab_summaries before rendering
+--- in the UI, preventing terminal escape injection from tampered .meta files.
+---@param str string
+---@return string
+local function sanitize_display_string(str)
+	if not str or type(str) ~= "string" then
+		return ""
+	end
+	-- Strip ANSI escape sequences (ESC [ ... m and similar)
+	str = str:gsub(string.char(27) .. "%[[^m]*m", "")
+	-- Strip all remaining control characters (ASCII 0-31 except tab/newline)
+	str = str:gsub("[\0-\8\11-\12\14-\31]", "")
+	-- Replace tabs and newlines with spaces
+	str = str:gsub("[\9\10\13]", " ")
+	return str
+end
+
+-- ---------------------------------------------------------------------------
+-- Meta helpers
+-- ---------------------------------------------------------------------------
+
+--- Build the .meta file path for a given instance ID.
+---@param instance_id string
+---@return string
+local function meta_path(instance_id)
+	return pub.get_instances_dir() .. utils.separator .. instance_id .. ".meta"
+end
+
+--- Build the .json state file path for a given instance ID.
+---@param instance_id string
+---@return string
+local function state_path(instance_id)
+	return pub.get_instances_dir() .. utils.separator .. instance_id .. ".json"
+end
+
+--- Read and parse a .meta file. Returns nil on any failure.
+---@param instance_id string
+---@return table|nil
+local function read_meta(instance_id)
+	local path = meta_path(instance_id)
+	local ok, content = file_io.read_file(path)
+	if not ok or not content then
+		return nil
+	end
+	local success, parsed = pcall(wezterm.json_parse, content)
+	if not success then
+		return nil
+	end
+	return parsed
+end
+
+--- Write a .meta file as JSON.
+---@param instance_id string
+---@param meta table
+local function write_meta(instance_id, meta)
+	local path = meta_path(instance_id)
+	local json = wezterm.json_encode(meta)
+	local ok, err = file_io.write_file(path, json)
+	if not ok then
+		wezterm.log_error("resurrect: failed to write instance meta: " .. tostring(err))
+	end
+end
+
+--- Build tab summaries from workspace state for display in the selector.
+--- Returns an array of short strings like "Claude Code", "PowerShell".
+---@param workspace_state table
+---@return string[]
+local function build_tab_summaries(workspace_state)
+	local summaries = {}
+	if not workspace_state or not workspace_state.window_states then
+		return summaries
+	end
+	for _, win_state in ipairs(workspace_state.window_states) do
+		if win_state.tabs then
+			for _, tab in ipairs(win_state.tabs) do
+				local title = tab.title or ""
+				if title ~= "" then
+					table.insert(summaries, title)
+				end
+			end
+		end
+	end
+	return summaries
+end
+
+--- Count tabs across all windows in a workspace state.
+---@param workspace_state table
+---@return number
+local function count_tabs(workspace_state)
+	local count = 0
+	if not workspace_state or not workspace_state.window_states then
+		return count
+	end
+	for _, win_state in ipairs(workspace_state.window_states) do
+		if win_state.tabs then
+			count = count + #win_state.tabs
+		end
+	end
+	return count
+end
+
+-- ---------------------------------------------------------------------------
+-- Core CRUD
+-- ---------------------------------------------------------------------------
+
+--- Save the current instance state and metadata.
+--- Wraps workspace_state with instance_id, writes both .json and .meta files.
+---@param workspace_state table
+function pub.save_instance(workspace_state)
+	if not pub.instance_id then
+		return
+	end
+
+	-- Wrap state with instance ID
+	local instance_state = {
+		instance_id = pub.instance_id,
+		workspace_state = workspace_state,
+	}
+
+	-- Write state JSON
+	local json = wezterm.json_encode(instance_state)
+	local ok, err = file_io.write_file(state_path(pub.instance_id), json)
+	if not ok then
+		wezterm.log_error("resurrect: failed to write instance state: " .. tostring(err))
+		wezterm.emit("resurrect.error", "Failed to save instance state: " .. tostring(err))
+		return
+	end
+
+	-- Write metadata (lightweight, for fast listing)
+	local tab_summaries = build_tab_summaries(workspace_state)
+	local meta = {
+		instance_id = pub.instance_id,
+		display_name = pub.display_name,
+		last_save_epoch = os.time(),
+		last_save = os.date("%Y-%m-%dT%H:%M:%S"),
+		tab_count = count_tabs(workspace_state),
+		tab_summaries = tab_summaries,
+	}
+	write_meta(pub.instance_id, meta)
+
+	wezterm.emit("resurrect.instance_manager.save_instance.finished", pub.instance_id)
+end
+
+--- Load an instance's workspace state from disk.
+--- Returns the workspace_state portion, or nil on failure.
+--- Validates basic schema (workspace_state must be a table with window_states).
+---@param instance_id string
+---@return table|nil
+function pub.load_instance(instance_id)
+	if not is_valid_instance_id(instance_id) then
+		wezterm.log_error("resurrect: load_instance rejected invalid ID: " .. tostring(instance_id))
+		wezterm.emit("resurrect.error", "Invalid instance ID")
+		return nil
+	end
+
+	local path = state_path(instance_id)
+	local ok, content = file_io.read_file(path)
+	if not ok or not content then
+		wezterm.log_error("resurrect: could not read instance state: " .. path)
+		return nil
+	end
+
+	local success, parsed = pcall(wezterm.json_parse, content)
+	if not success or not parsed then
+		wezterm.log_error("resurrect: invalid JSON in instance state: " .. path)
+		return nil
+	end
+
+	-- Schema validation: workspace_state must be a table with window_states
+	local ws = parsed.workspace_state
+	if type(ws) ~= "table" or type(ws.window_states) ~= "table" then
+		wezterm.log_error("resurrect: malformed instance state (missing workspace_state.window_states): " .. path)
+		return nil
+	end
+
+	return ws
+end
+
+--- List all saved instances, newest first.
+--- Reads only .meta files for speed, falls back gracefully if meta is missing.
+---@return table[] array of { instance_id: string, meta: table }
+function pub.list_instances()
+	local instances_dir = pub.get_instances_dir()
+	local results = {}
+
+	-- Scan for .json files to find instance IDs, then read their .meta
+	-- Use platform-appropriate directory listing
+	local stdout
+	if utils.is_windows then
+		local success, output = wezterm.run_child_process({
+			"powershell.exe", "-NoProfile", "-NoLogo", "-Command",
+			string.format(
+				"Get-ChildItem -Path '%s' -Filter '*.json' -File -ErrorAction SilentlyContinue | ForEach-Object { $_.BaseName }",
+				instances_dir:gsub("'", "''")
+			),
+		})
+		if success then
+			stdout = output
+		end
+	else
+		-- Use single-quote escaping (safe against $(), backticks, etc.)
+		local safe_dir = instances_dir:gsub("'", "'\\''")
+		local success, output = wezterm.run_child_process({
+			"sh", "-c",
+			"ls '" .. safe_dir .. "'/*.json 2>/dev/null | xargs -I{} basename {} .json",
+		})
+		if success then
+			stdout = output
+		end
+	end
+
+	if not stdout then
+		return results
+	end
+
+	for id in stdout:gmatch("[^\r\n]+") do
+		id = id:match("^%s*(.-)%s*$") -- trim whitespace
+		if is_valid_instance_id(id) then
+			local meta = read_meta(id) or {
+				instance_id = id,
+				last_save_epoch = 0,
+				tab_count = 0,
+				tab_summaries = {},
+			}
+			table.insert(results, { instance_id = id, meta = meta })
+		end
+	end
+
+	-- Sort newest first by last_save_epoch
+	table.sort(results, function(a, b)
+		return (a.meta.last_save_epoch or 0) > (b.meta.last_save_epoch or 0)
+	end)
+
+	return results
+end
+
+--- Delete an instance's .json and .meta files.
+---@param instance_id string
+---@return boolean
+function pub.delete_instance(instance_id)
+	if not is_valid_instance_id(instance_id) then
+		wezterm.log_error("resurrect: delete_instance rejected invalid ID: " .. tostring(instance_id))
+		wezterm.emit("resurrect.error", "Invalid instance ID: path traversal rejected")
+		return false
+	end
+
+	local json_path = state_path(instance_id)
+	local meta_file = meta_path(instance_id)
+
+	os.remove(json_path)
+	os.remove(meta_file)
+
+	wezterm.log_info("resurrect: deleted instance " .. instance_id)
+	wezterm.emit("resurrect.instance_manager.delete_instance.finished", instance_id)
+	return true
+end
+
+--- Remove instances older than retention_days.
+function pub.cleanup_old_instances()
+	local cutoff = os.time() - (pub.retention_days * 86400)
+	local instances = pub.list_instances()
+	for _, entry in ipairs(instances) do
+		if (entry.meta.last_save_epoch or 0) < cutoff then
+			pub.delete_instance(entry.instance_id)
+		end
+	end
+end
+
+-- ---------------------------------------------------------------------------
+-- Display formatting
+-- ---------------------------------------------------------------------------
+
+--- Deduplicate an array of strings and format with counts.
+--- {"A", "B", "A"} -> {"A x2", "B"}. Preserves first-seen order.
+---@param items string[]
+---@return string[]
+local function deduplicate_with_counts(items)
+	local counts = {}
+	local order = {}
+	for _, s in ipairs(items) do
+		if not counts[s] then
+			counts[s] = 0
+			table.insert(order, s)
+		end
+		counts[s] = counts[s] + 1
+	end
+	local parts = {}
+	for _, name in ipairs(order) do
+		if counts[name] > 1 then
+			table.insert(parts, name .. " x" .. counts[name])
+		else
+			table.insert(parts, name)
+		end
+	end
+	return parts
+end
+
+--- Format an instance summary line for the InputSelector.
+--- Named:   "Orahvision Dev -- Claude Code, PowerShell [2 tabs]"
+--- Unnamed: "Mar 13 16:45 -- Claude Code, PowerShell [2 tabs]"
+---@param meta table
+---@return string
+function pub.format_instance_summary(meta)
+	-- Sanitize tab summaries to prevent terminal escape injection
+	local summaries = {}
+	for _, s in ipairs(meta.tab_summaries or {}) do
+		table.insert(summaries, sanitize_display_string(s))
+	end
+
+	local parts = deduplicate_with_counts(summaries)
+	local tab_str = table.concat(parts, ", ")
+	if tab_str == "" then
+		tab_str = "(empty)"
+	end
+
+	local tab_count = meta.tab_count or 0
+	local tab_label = tab_count == 1 and "1 tab" or (tab_count .. " tabs")
+
+	-- Prefix: display_name or formatted date (sanitized)
+	local prefix
+	if meta.display_name and meta.display_name ~= "" then
+		prefix = sanitize_display_string(meta.display_name)
+	else
+		local epoch = meta.last_save_epoch or 0
+		if epoch > 0 then
+			prefix = os.date("%b %d %H:%M", epoch)
+		else
+			prefix = "Unknown"
+		end
+	end
+
+	return prefix .. " -- " .. tab_str .. " [" .. tab_label .. "]"
+end
+
+--- Rename an instance by updating its .meta display_name field.
+--- Strips control characters from the name to prevent terminal escape injection.
+---@param instance_id string
+---@param new_name string
+function pub.rename_instance(instance_id, new_name)
+	if not is_valid_instance_id(instance_id) then
+		return
+	end
+
+	-- Sanitize display name before storing
+	new_name = sanitize_display_string(new_name)
+
+	local meta = read_meta(instance_id)
+	if not meta then
+		meta = { instance_id = instance_id }
+	end
+	meta.display_name = new_name
+	write_meta(instance_id, meta)
+
+	-- If this is the current instance, update in memory too
+	if instance_id == pub.instance_id then
+		pub.display_name = new_name
+	end
+end
+
+-- ---------------------------------------------------------------------------
+-- Shared fuzzy-load restore callback
+-- ---------------------------------------------------------------------------
+
+--- Create a callback for fuzzy_loader.fuzzy_load that dispatches restore
+--- based on state type (workspace/window/tab). Extracted to avoid duplication
+--- between the "no instances" path and the "[Browse named saves]" action.
+---@param restore_opts table
+---@param fallback_pane table Pane to use for window/tab restore
+---@return fun(id: string, label: string)
+local function make_fuzzy_restore_callback(restore_opts, fallback_pane)
+	return function(id, label)
+		local state_type = id:match("^([^/\\]+)")
+		local name = id:match("[/\\](.+)$")
+		if name then
+			name = name:gsub("%.json$", "")
+		end
+		local sm = get_state_manager()
+		if state_type == "workspace" then
+			local state = sm.load_state(name, "workspace")
+			require("resurrect.workspace_state").restore_workspace(state, restore_opts)
+		elseif state_type == "window" then
+			local state = sm.load_state(name, "window")
+			require("resurrect.window_state").restore_window(fallback_pane:window(), state, restore_opts)
+		elseif state_type == "tab" then
+			local state = sm.load_state(name, "tab")
+			require("resurrect.tab_state").restore_tab(fallback_pane:tab(), state, restore_opts)
+		end
+	end
+end
+
+-- ---------------------------------------------------------------------------
+-- Selector UI
+-- ---------------------------------------------------------------------------
+
+--- Restore one or more instances. The first instance reuses the existing
+--- window (via restore_opts.window) to avoid spawning an extra blank window.
+--- Subsequent instances get their own new windows.
+---@param instance_ids string[] array of instance IDs to restore
+---@param window table GuiWindow whose MuxWindow to reuse for the first restore
+---@param pane table Pane in that window
+---@param restore_opts table options passed to restore_workspace
+local function restore_instances(instance_ids, window, pane, restore_opts)
+	for i, id in ipairs(instance_ids) do
+		local old_meta = read_meta(id)
+		local workspace_state = pub.load_instance(id)
+		if workspace_state then
+			-- First instance reuses the current window to avoid extra blank shell
+			local opts = utils.tbl_deep_extend("force", restore_opts, {})
+			if i == 1 then
+				opts.window = pane:window()
+				opts.pane = pane
+			end
+
+			require("resurrect.workspace_state").restore_workspace(workspace_state, opts)
+
+			-- Carry over display_name from first restored instance
+			if i == 1 and old_meta and old_meta.display_name and old_meta.display_name ~= "" then
+				pub.display_name = old_meta.display_name
+			end
+
+			-- Auto-delete old instance after restore (it now has a new ID)
+			pub.delete_instance(id)
+		end
+	end
+end
+
+--- Show the main instance selector with multi-select support.
+--- Space (Enter) toggles selection, then pick "Restore selected" to restore all.
+--- Esc dismisses to start a fresh terminal session.
+---@param window table GuiWindow
+---@param pane table Pane
+---@param restore_opts table options passed to restore_workspace
+---@param selected? table set of already-selected instance IDs (for re-showing after toggle)
+function pub.show_instance_selector(window, pane, restore_opts, selected)
+	selected = selected or {}
+	local instances = pub.list_instances()
+
+	-- If no instances, fall through to fuzzy_load for named saves
+	if #instances == 0 then
+		local fuzzy_loader = require("resurrect.fuzzy_loader")
+		fuzzy_loader.fuzzy_load(window, pane, make_fuzzy_restore_callback(restore_opts, pane))
+		return
+	end
+
+	-- Build choices with selection markers
+	local choices = {}
+
+	-- Count selections
+	local sel_count = 0
+	for _ in pairs(selected) do sel_count = sel_count + 1 end
+
+	-- "Restore selected" at the top when there are selections
+	if sel_count > 0 then
+		table.insert(choices, {
+			id = "__RESTORE_SELECTED__",
+			label = ">>> Restore " .. sel_count .. " selected instance" .. (sel_count > 1 and "s" or "") .. " <<<",
+		})
+	end
+
+	-- Instance entries with [x] / [ ] markers
+	for _, entry in ipairs(instances) do
+		local marker = selected[entry.instance_id] and "[x] " or "[ ] "
+		table.insert(choices, {
+			id = entry.instance_id,
+			label = marker .. pub.format_instance_summary(entry.meta),
+		})
+	end
+
+	-- Action entries at the bottom
+	table.insert(choices, { id = "__BROWSE_NAMED__", label = "[Browse named saves]" })
+	table.insert(choices, { id = "__RENAME_MODE__", label = "[Rename an instance]" })
+	table.insert(choices, { id = "__DELETE_MODE__", label = "[Delete saved instances]" })
+
+	window:perform_action(
+		wezterm.action.InputSelector({
+			action = wezterm.action_callback(function(inner_win, inner_pane, id, label)
+				if not id then
+					-- Esc pressed: start fresh terminal (do nothing)
+					return
+				end
+
+				if id == "__RESTORE_SELECTED__" then
+					-- Restore all selected instances
+					local ids = {}
+					for _, entry in ipairs(instances) do
+						if selected[entry.instance_id] then
+							table.insert(ids, entry.instance_id)
+						end
+					end
+					restore_instances(ids, inner_win, inner_pane, restore_opts)
+					return
+				end
+
+				if id == "__BROWSE_NAMED__" then
+					local fuzzy_loader = require("resurrect.fuzzy_loader")
+					fuzzy_loader.fuzzy_load(
+						inner_win, inner_pane,
+						make_fuzzy_restore_callback(restore_opts, inner_pane),
+						{ ignore_instances = true }
+					)
+					return
+				end
+
+				if id == "__RENAME_MODE__" then
+					pub.show_rename_selector(inner_win, inner_pane, restore_opts)
+					return
+				end
+
+				if id == "__DELETE_MODE__" then
+					pub.show_delete_selector(inner_win, inner_pane, restore_opts)
+					return
+				end
+
+				-- Toggle selection on this instance and re-show the selector
+				if selected[id] then
+					selected[id] = nil
+				else
+					selected[id] = true
+				end
+				pub.show_instance_selector(inner_win, inner_pane, restore_opts, selected)
+			end),
+			title = "Restore Instances",
+			description = "Enter = toggle selection, then pick 'Restore selected'. Esc = start fresh terminal",
+			choices = choices,
+			fuzzy = false,
+		}),
+		pane
+	)
+end
+
+--- Show the rename selector: pick an instance, then enter a name.
+---@param window table
+---@param pane table
+---@param restore_opts table
+function pub.show_rename_selector(window, pane, restore_opts)
+	local instances = pub.list_instances()
+	if #instances == 0 then
+		return
+	end
+
+	local choices = {}
+	for _, entry in ipairs(instances) do
+		table.insert(choices, {
+			id = entry.instance_id,
+			label = pub.format_instance_summary(entry.meta),
+		})
+	end
+
+	window:perform_action(
+		wezterm.action.InputSelector({
+			action = wezterm.action_callback(function(inner_win, inner_pane, id, label)
+				if not id then
+					return
+				end
+
+				-- Prompt for a name using InputSelector with a text entry
+				inner_win:perform_action(
+					wezterm.action.PromptInputLine({
+						description = "Enter a name for this instance:",
+						action = wezterm.action_callback(function(name_win, name_pane, name)
+							if name and name ~= "" then
+								pub.rename_instance(id, name)
+							end
+							-- Re-show main selector after rename
+							pub.show_instance_selector(name_win, name_pane, restore_opts)
+						end),
+					}),
+					inner_pane
+				)
+			end),
+			title = "Rename Instance",
+			description = "Select an instance to rename",
+			choices = choices,
+			fuzzy = false,
+		}),
+		pane
+	)
+end
+
+--- Show the delete selector: pick instances to delete, one at a time.
+---@param window table
+---@param pane table
+---@param restore_opts table
+function pub.show_delete_selector(window, pane, restore_opts)
+	local instances = pub.list_instances()
+	if #instances == 0 then
+		-- No more instances to delete, return to main selector
+		pub.show_instance_selector(window, pane, restore_opts)
+		return
+	end
+
+	local choices = {}
+	for _, entry in ipairs(instances) do
+		table.insert(choices, {
+			id = entry.instance_id,
+			label = pub.format_instance_summary(entry.meta),
+		})
+	end
+	table.insert(choices, { id = "__BACK__", label = "[Back to main selector]" })
+
+	window:perform_action(
+		wezterm.action.InputSelector({
+			action = wezterm.action_callback(function(inner_win, inner_pane, id, label)
+				if not id or id == "__BACK__" then
+					pub.show_instance_selector(inner_win, inner_pane, restore_opts)
+					return
+				end
+
+				pub.delete_instance(id)
+				-- Re-show delete selector for deleting multiple
+				pub.show_delete_selector(inner_win, inner_pane, restore_opts)
+			end),
+			title = "Delete Instance",
+			description = "Select an instance to DELETE (permanent). Esc = back",
+			choices = choices,
+			fuzzy = false,
+		}),
+		pane
+	)
+end
+
+-- ---------------------------------------------------------------------------
+-- Startup integration
+-- ---------------------------------------------------------------------------
+
+--- Auto-restore callback for gui-startup.
+--- 1. Cleans up old instances
+--- 2. If instances exist and auto_restore_prompt: spawns window + shows selector
+--- 3. If no instances: falls back to state_manager.resurrect_on_gui_startup()
+function pub.auto_restore_on_startup()
+	pub.cleanup_old_instances()
+
+	local instances = pub.list_instances()
+
+	if #instances == 0 then
+		-- Backward compat: fall back to current_state mechanism
+		get_state_manager().resurrect_on_gui_startup()
+		return
+	end
+
+	if not pub.auto_restore_prompt then
+		-- User disabled auto-prompt; they can use Alt+R manually
+		return
+	end
+
+	-- Spawn a default window for the selector UI. The first restored instance
+	-- will reuse this window (via restore_opts.window) so no extra blank
+	-- shell window remains.
+	wezterm.mux.spawn_window({})
+
+	wezterm.time.call_after(1, function()
+		local gui_windows = wezterm.gui.gui_windows()
+		if #gui_windows > 0 then
+			local gui_win = gui_windows[1]
+			local active_pane = gui_win:active_pane()
+			local restore_opts = {
+				relative = true,
+				restore_text = true,
+				on_pane_restore = require("resurrect.tab_state").default_on_pane_restore,
+			}
+			pub.show_instance_selector(gui_win, active_pane, restore_opts)
+		end
+	end)
+end
+
+return pub

--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -110,8 +110,15 @@ local function insert_panes(root, panes)
 			-- only saving local scrollback because it would slow down the process
 			-- See: https://github.com/MLFlexer/resurrect.wezterm/issues/41
 			root.alt_screen_active = root.pane:is_alt_screen_active()
-			if root.alt_screen_active then
-				local process_info = root.pane:get_foreground_process_info()
+
+			-- Also check if the foreground process has a registered handler
+			-- (e.g., Claude Code). Some TUI apps don't use the alt screen
+			-- buffer, but we still need to save their process info for
+			-- proper restoration instead of dumping scrollback text.
+			local process_info = root.pane:get_foreground_process_info()
+			local has_handler = process_handlers.find_handler(process_info)
+
+			if root.alt_screen_active or has_handler then
 				process_info.children = nil
 				process_info.pid = nil
 				process_info.ppid = nil

--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -75,6 +75,13 @@ local function insert_panes(root, panes)
 		return nil
 	end
 
+	-- Guard against duplicate processing in symmetric layouts
+	-- In a perfect cross layout, a pane can appear in both right and bottom branches
+	-- If already processed by another branch, skip to avoid nil pane access
+	if root.pane == nil then
+		return root
+	end
+
 	local domain = root.pane:get_domain_name()
 	if not wezterm.mux.get_domain(domain):is_spawnable() then
 		wezterm.log_warn("Domain " .. domain .. " is not spawnable")
@@ -87,7 +94,13 @@ local function insert_panes(root, panes)
 		else
 			root.cwd = root.pane:get_current_working_dir().file_path
 			if utils.is_windows then
+				-- WezTerm returns file_path as /C:/... on Windows; strip the leading slash.
 				root.cwd = root.cwd:gsub("^/([a-zA-Z]):", "%1:")
+				-- WSL mounts Windows drives at /mnt/c/...; convert to C:\... so that
+				-- WezTerm's mux can validate the path in Windows context before spawning.
+				root.cwd = root.cwd:gsub("^/mnt/([a-zA-Z])(.*)", function(drive, rest)
+					return drive:upper() .. ":" .. rest:gsub("/", "\\")
+				end)
 			end
 		end
 
@@ -101,6 +114,93 @@ local function insert_panes(root, panes)
 				process_info.children = nil
 				process_info.pid = nil
 				process_info.ppid = nil
+
+				local nix_store = '/nix/store/'
+
+				-- Since NixOS uses immutable paths for executables,
+				-- we need to sanitize them before saving,
+				-- otherwise restoring sessions will be a pain.
+				if process_info.executable and process_info.executable:find(nix_store) then
+					-- Replace executable path with `process_info.name`,
+					-- because nix store paths are not stable across sessions,
+					-- as well as being long and ugly.
+					--
+					-- Plus they pollute shell history if restored as part of `executable` + `argv`.
+					process_info.executable = process_info.name or process_info.executable
+
+					-- Clean up `process_info.argv` by removing command flags followed by `*/nix/store/*` paths.
+					--
+					-- Original `argv` stored by `resurrect.wezterm` before sanitization:
+					--
+					-- [
+					--   "/nix/store/jx332jllgyrqbnzi8svnk8xbygc9nbmp-neovim-unwrapped-0.11.5/bin/nvim",
+					--   "--cmd",
+					--   "lua vim.g.loaded_node_provider=0;vim.g.loaded_perl_provider=0;vim.g.loaded_python_provider=0;vim.g.python3_host_prog='/nix/store/252cmdyhmr8ai7qz266yrawgmx7nfz5h-neovim-0.11.5/bin/nvim-python3';vim.g.ruby_host_prog='/nix/store/252cmdyhmr8ai7qz266yrawgmx7nfz5h-neovim-0.11.5/bin/nvim-ruby'",
+					--   "--cmd",
+					--   "set packpath^=/nix/store/g0f4d93y9q79q84qq4g41lyfcw3i1z7h-vim-pack-dir",
+					--   "--cmd",
+					--   "set rtp^=/nix/store/g0f4d93y9q79q84qq4g41lyfcw3i1z7h-vim-pack-dir",
+					--   "Cargo.toml"
+					-- ]
+					--
+					-- Sanitized `argv` after processing:
+					-- [
+					--   "nvim",
+					--   "Cargo.toml",
+					-- ]
+					--
+					-- Meaning that any `--cmd` or `-c` flags containing `/nix/store/*` paths are removed entirely from `argv`,
+					-- while keeping other arguments intact.
+					--
+					-- On restoration, the executable will be resolved via `PATH`,
+					-- so as long as `nvim`/`vim`/`gvim` is available in `PATH`, it should work fine.
+					if process_info.argv then
+						local args = {}
+						local flag = nil
+						local executables = {
+							nvim = true,
+							vim = true,
+							gvim = true,
+						}
+						local is_vim = executables[process_info.executable]
+
+						for i, arg in ipairs(process_info.argv) do
+							if i == 1 then
+								-- Ensure first element of `argv` is the `executable` path,
+								-- which we have already sanitized above.
+								args[#args + 1] = process_info.executable
+							else
+								if is_vim == nil then
+									-- For non-vim executables, we only need to sanitize the `executable` path,
+									-- so we can keep the rest of `argv` as is.
+
+									args[#args + 1] = arg
+								else
+									if arg == '--cmd' or arg == '-c' then
+										-- Save current flag for later use, in case next `arg` is `/nix/store/*` path (see next condition).
+										flag = arg
+									elseif flag ~= nil then
+										if arg:find(nix_store) then
+											-- Skip this `arg` as it contains `/nix/store/*` path
+											-- Do not add anything to `args`
+										else
+											-- Not a nix store path, keep both `flag` and `arg` (value).
+											args[#args + 1] = flag
+											args[#args + 1] = arg
+										end
+
+										flag = nil
+									else
+										args[#args + 1] = arg
+									end
+								end
+							end
+						end
+
+						process_info.argv = args
+					end
+				end
+
 				root.process = process_info
 			else
 				local nlines = root.pane:get_dimensions().scrollback_rows

--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -1,5 +1,6 @@
 local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
 local utils = require("resurrect.utils")
+local process_handlers = require("resurrect.process_handlers")
 
 ---@class pane_tree_module
 ---@field max_nlines integer
@@ -200,6 +201,10 @@ local function insert_panes(root, panes)
 						process_info.argv = args
 					end
 				end
+
+				-- Let registered process handlers sanitize argv for portable restoration
+				-- (e.g., Claude Code strips full node path, keeps session ID)
+				process_handlers.sanitize_for_save(process_info)
 
 				root.process = process_info
 			else

--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -68,12 +68,22 @@ local function pop_connected_right(root, panes)
 	end
 end
 
+-- Maximum recursion depth to prevent stack overflow from maliciously
+-- crafted state files with deeply nested pane trees.
+local MAX_PANE_DEPTH = 100
+
 ---@param root pane_tree | nil
 ---@param panes PaneInformation[]
+---@param depth? number current recursion depth (defaults to 0)
 ---@return pane_tree | nil
-local function insert_panes(root, panes)
+local function insert_panes(root, panes, depth)
+	depth = depth or 0
 	if root == nil then
 		return nil
+	end
+	if depth > MAX_PANE_DEPTH then
+		wezterm.log_error("resurrect: pane tree exceeds maximum depth of " .. MAX_PANE_DEPTH)
+		return root
 	end
 
 	-- Guard against duplicate processing in symmetric layouts
@@ -114,24 +124,36 @@ local function insert_panes(root, panes)
 			local process_info = root.pane:get_foreground_process_info()
 			local has_handler = process_handlers.find_handler(process_info)
 
-			-- If the foreground process doesn't match a handler, check the
-			-- pane-session file. When Claude Code runs a child process (bash,
-			-- node, etc.), that child becomes the foreground process and
-			-- find_handler misses Claude Code. The pane-session file written
-			-- by Claude Code's SessionStart hook is the reliable signal.
-			if not has_handler then
-				local pane_session = process_handlers.read_pane_session(root.pane:pane_id())
-				if pane_session and pane_session.session_id then
-					has_handler = true
-					-- Build synthetic process_info since the foreground
-					-- process is a child (bash, etc.), not claude itself.
-					process_info = {
-						name = "claude",
-						executable = "claude",
-						argv = {},
-						cwd = process_info.cwd or "",
-					}
+			-- Check the pane-session file for Claude Code detection and
+			-- binary disambiguation. This serves two purposes:
+			-- 1. Fallback: when Claude runs a child process (bash, node),
+			--    the foreground process isn't "claude" so find_handler misses it.
+			-- 2. Binary fix: claude2.bat wraps the same "claude" binary with
+			--    CLAUDE_CONFIG_DIR=~/.claude-alt. WezTerm reports name="claude"
+			--    for both, but the transcript_path reveals which config dir
+			--    was used, letting us restore with the correct binary.
+			local pane_session = process_handlers.read_pane_session(root.pane:pane_id())
+			if pane_session and pane_session.session_id then
+				-- Infer which claude binary from the transcript_path.
+				local bin = "claude"
+				local tp = pane_session.transcript_path or ""
+				if tp:find("[/\\]%.claude%-alt[/\\]") then
+					bin = "claude2"
 				end
+
+				if not has_handler then
+					-- Fallback: foreground process is a child, not claude
+					has_handler = true
+				end
+
+				-- Always rebuild process_info from pane-session data so
+				-- the correct binary name is used (claude vs claude2).
+				process_info = {
+					name = bin,
+					executable = bin,
+					argv = process_info.argv or {},
+					cwd = process_info.cwd or "",
+				}
 			end
 
 			if root.alt_screen_active or has_handler then
@@ -259,12 +281,12 @@ local function insert_panes(root, panes)
 
 	if #right > 0 then
 		local right_child = pop_connected_right(root, right)
-		root.right = insert_panes(right_child, right)
+		root.right = insert_panes(right_child, right, depth + 1)
 	end
 
 	if #bottom > 0 then
 		local bottom_child = pop_connected_bottom(root, bottom)
-		root.bottom = insert_panes(bottom_child, bottom)
+		root.bottom = insert_panes(bottom_child, bottom, depth + 1)
 	end
 
 	return root
@@ -279,10 +301,10 @@ function pub.create_pane_tree(panes)
 	return insert_panes(root, panes)
 end
 
----maps over the pane tree
+---maps over the pane tree (mutates in place)
 ---@param pane_tree pane_tree
 ---@param f fun(pane_tree: pane_tree): pane_tree
----@return nil
+---@return pane_tree|nil
 function pub.map(pane_tree, f)
 	if pane_tree == nil then
 		return nil

--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -202,9 +202,10 @@ local function insert_panes(root, panes)
 					end
 				end
 
-				-- Let registered process handlers sanitize argv for portable restoration
-				-- (e.g., Claude Code strips full node path, keeps session ID)
-				process_handlers.sanitize_for_save(process_info)
+				-- Let registered process handlers sanitize argv for portable restoration.
+				-- Pass pane_id so handlers can look up external state (e.g., Claude
+				-- Code reads session IDs from ~/.claude/pane-sessions/<pane_id>.json).
+				process_handlers.sanitize_for_save(process_info, root.pane:pane_id())
 
 				root.process = process_info
 			else

--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -119,9 +119,8 @@ local function insert_panes(root, panes)
 			-- node, etc.), that child becomes the foreground process and
 			-- find_handler misses Claude Code. The pane-session file written
 			-- by Claude Code's SessionStart hook is the reliable signal.
-			local pane_session = nil
 			if not has_handler then
-				pane_session = process_handlers.read_pane_session(root.pane:pane_id())
+				local pane_session = process_handlers.read_pane_session(root.pane:pane_id())
 				if pane_session and pane_session.session_id then
 					has_handler = true
 					-- Build synthetic process_info since the foreground

--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -111,12 +111,29 @@ local function insert_panes(root, panes)
 			-- See: https://github.com/MLFlexer/resurrect.wezterm/issues/41
 			root.alt_screen_active = root.pane:is_alt_screen_active()
 
-			-- Also check if the foreground process has a registered handler
-			-- (e.g., Claude Code). Some TUI apps don't use the alt screen
-			-- buffer, but we still need to save their process info for
-			-- proper restoration instead of dumping scrollback text.
 			local process_info = root.pane:get_foreground_process_info()
 			local has_handler = process_handlers.find_handler(process_info)
+
+			-- If the foreground process doesn't match a handler, check the
+			-- pane-session file. When Claude Code runs a child process (bash,
+			-- node, etc.), that child becomes the foreground process and
+			-- find_handler misses Claude Code. The pane-session file written
+			-- by Claude Code's SessionStart hook is the reliable signal.
+			local pane_session = nil
+			if not has_handler then
+				pane_session = process_handlers.read_pane_session(root.pane:pane_id())
+				if pane_session and pane_session.session_id then
+					has_handler = true
+					-- Build synthetic process_info since the foreground
+					-- process is a child (bash, etc.), not claude itself.
+					process_info = {
+						name = "claude",
+						executable = "claude",
+						argv = {},
+						cwd = process_info.cwd or "",
+					}
+				end
+			end
 
 			if root.alt_screen_active or has_handler then
 				process_info.children = nil

--- a/plugin/resurrect/process_handlers.lua
+++ b/plugin/resurrect/process_handlers.lua
@@ -1,0 +1,202 @@
+-- Extensible process handler registry for restoring TUI applications.
+-- Each handler detects a specific process type and generates the
+-- correct restore command, replacing the default argv replay.
+--
+-- Users can register custom handlers in their wezterm.lua:
+--   resurrect.process_handlers.register({
+--       name = "lazygit",
+--       detect = function(info) return info.name == "lazygit" end,
+--       get_restore_cmd = function(info, _) return "lazygit" end,
+--   })
+local wezterm = require("wezterm") --[[@as Wezterm]]
+
+local pub = {}
+
+-- Registry of process handlers.
+-- Each handler has:
+--   name: string          -- identifier for logging
+--   detect(process_info)  -- returns true if this handler should handle the process
+--   get_restore_cmd(process_info, pane_tree) -- returns the shell command string to restore
+--   sanitize(process_info) -- optional: clean up process_info at save time
+pub.handlers = {}
+
+--- Register a new process handler
+---@param handler table { name: string, detect: function, get_restore_cmd: function, sanitize: function? }
+function pub.register(handler)
+	if not handler.name or not handler.detect or not handler.get_restore_cmd then
+		wezterm.log_error("resurrect: process_handler missing required fields (name, detect, get_restore_cmd)")
+		return
+	end
+	table.insert(pub.handlers, handler)
+end
+
+--- Find the matching handler for a process, or nil if none match
+---@param process_info table
+---@return table|nil handler
+function pub.find_handler(process_info)
+	if not process_info then
+		return nil
+	end
+	for _, handler in ipairs(pub.handlers) do
+		local ok, match = pcall(handler.detect, process_info)
+		if ok and match then
+			return handler
+		end
+	end
+	return nil
+end
+
+--- Get the restore command for a process, or nil if no handler matches
+---@param process_info table
+---@param pane_tree table
+---@return string|nil
+function pub.get_restore_command(process_info, pane_tree)
+	local handler = pub.find_handler(process_info)
+	if handler then
+		local ok, cmd = pcall(handler.get_restore_cmd, process_info, pane_tree)
+		if ok and cmd then
+			return cmd
+		end
+	end
+	return nil
+end
+
+--- Sanitize process_info at save time if a handler provides a sanitize function.
+--- This cleans up argv for portable restoration (e.g., stripping full node paths).
+---@param process_info table
+---@return table process_info (possibly modified in place)
+function pub.sanitize_for_save(process_info)
+	local handler = pub.find_handler(process_info)
+	if handler and handler.sanitize then
+		local ok, err = pcall(handler.sanitize, process_info)
+		if not ok then
+			wezterm.log_error("resurrect: process_handler sanitize failed: " .. tostring(err))
+		end
+	end
+	return process_info
+end
+
+-- Helper: parse argv for a flag and return its value.
+-- Supports both "--flag value" and "--flag=value" forms.
+---@param argv string[]
+---@param flag string the flag to look for (e.g., "--resume")
+---@param short string? optional short form (e.g., "-r")
+---@return string|nil value
+local function parse_flag_value(argv, flag, short)
+	if not argv then
+		return nil
+	end
+	for i, arg in ipairs(argv) do
+		-- --flag=value form
+		if arg:find("^" .. flag .. "=") then
+			return arg:sub(#flag + 2)
+		end
+		-- --flag value form
+		if arg == flag or (short and arg == short) then
+			if argv[i + 1] and not argv[i + 1]:find("^%-") then
+				return argv[i + 1]
+			end
+		end
+	end
+	return nil
+end
+
+-- Helper: check if a flag exists in argv
+---@param argv string[]
+---@param flag string
+---@return boolean
+local function has_flag(argv, flag)
+	if not argv then
+		return false
+	end
+	for _, arg in ipairs(argv) do
+		if arg == flag then
+			return true
+		end
+	end
+	return false
+end
+
+---------------------------------------------------------------
+-- Built-in handler: Claude Code
+---------------------------------------------------------------
+pub.register({
+	name = "claude_code",
+
+	-- Claude Code appears as "claude" or "claude.exe" in process name,
+	-- or as "node" with claude-code/cli.js in argv.
+	detect = function(process_info)
+		if not process_info or not process_info.name then
+			return false
+		end
+		local name = (process_info.name or ""):lower():gsub("%.exe$", "")
+		if name == "claude" then
+			return true
+		end
+		-- When running via node, check argv for claude-code markers
+		if name == "node" and process_info.argv then
+			for _, arg in ipairs(process_info.argv) do
+				if arg:find("claude%-code") or arg:find("@anthropic%-ai") or arg:find("cli%.js") then
+					return true
+				end
+			end
+		end
+		return false
+	end,
+
+	-- Build the restore command from saved process info.
+	-- Prioritizes --resume <session-id> over --continue.
+	-- Preserves --dangerously-skip-permissions if it was present.
+	get_restore_cmd = function(process_info, pane_tree)
+		local argv = process_info.argv or {}
+		local parts = { "claude" }
+
+		-- Session ID: check --resume, -r, --session-id
+		local session_id = parse_flag_value(argv, "--resume", "-r")
+			or parse_flag_value(argv, "--session-id")
+		if session_id then
+			table.insert(parts, "--resume")
+			table.insert(parts, session_id)
+		else
+			-- No explicit session ID captured; use --continue to resume
+			-- the most recent session in this CWD
+			table.insert(parts, "--continue")
+		end
+
+		-- Preserve dangerous permissions flag
+		if has_flag(argv, "--dangerously-skip-permissions") then
+			table.insert(parts, "--dangerously-skip-permissions")
+		end
+
+		return wezterm.shell_join_args(parts)
+	end,
+
+	-- At save time, clean up the raw node argv into a portable form.
+	-- The raw argv looks like:
+	--   {"node", "C:/Users/.../cli.js", "--dangerously-skip-permissions", "--resume", "uuid"}
+	-- We normalize to:
+	--   {"claude", "--resume", "uuid", "--dangerously-skip-permissions"}
+	sanitize = function(process_info)
+		local argv = process_info.argv or {}
+		local clean = { "claude" }
+
+		-- Extract session ID
+		local session_id = parse_flag_value(argv, "--resume", "-r")
+			or parse_flag_value(argv, "--session-id")
+		if session_id then
+			table.insert(clean, "--resume")
+			table.insert(clean, session_id)
+		end
+
+		-- Extract permission flags
+		if has_flag(argv, "--dangerously-skip-permissions") then
+			table.insert(clean, "--dangerously-skip-permissions")
+		end
+
+		process_info.executable = "claude"
+		process_info.name = "claude"
+		process_info.argv = clean
+	end,
+})
+
+return pub

--- a/plugin/resurrect/process_handlers.lua
+++ b/plugin/resurrect/process_handlers.lua
@@ -163,7 +163,8 @@ pub.register({
 			return false
 		end
 		local name = (process_info.name or ""):lower():gsub("%.exe$", "")
-		if name == "claude" then
+		-- Match "claude", "claude2", "claude-dev", etc.
+		if name:match("^claude%d*$") or name:match("^claude%-") then
 			return true
 		end
 		-- When running via node, check argv for claude-code markers
@@ -182,7 +183,10 @@ pub.register({
 	-- Preserves --dangerously-skip-permissions if it was present.
 	get_restore_cmd = function(process_info, pane_tree)
 		local argv = process_info.argv or {}
-		local parts = { "claude" }
+		-- Use the saved executable name (e.g., "claude", "claude2") so
+		-- multi-account setups restore with the correct binary.
+		local bin = process_info.name or process_info.executable or "claude"
+		local parts = { bin }
 
 		-- Session ID: check --resume, -r, --session-id
 		local session_id = parse_flag_value(argv, "--resume", "-r")
@@ -216,7 +220,12 @@ pub.register({
 	-- gets its exact session ID saved, even when running 6-8 sessions at once.
 	sanitize = function(process_info, pane_id)
 		local argv = process_info.argv or {}
-		local clean = { "claude" }
+		-- Preserve the original binary name (e.g., "claude2") for multi-account setups
+		local bin = (process_info.name or ""):lower():gsub("%.exe$", "")
+		if not bin:match("^claude") then
+			bin = "claude"
+		end
+		local clean = { bin }
 
 		-- Extract session ID from argv first (explicit --resume or --session-id)
 		local session_id = parse_flag_value(argv, "--resume", "-r")
@@ -241,8 +250,8 @@ pub.register({
 			table.insert(clean, "--dangerously-skip-permissions")
 		end
 
-		process_info.executable = "claude"
-		process_info.name = "claude"
+		process_info.executable = bin
+		process_info.name = bin
 		process_info.argv = clean
 	end,
 })

--- a/plugin/resurrect/process_handlers.lua
+++ b/plugin/resurrect/process_handlers.lua
@@ -275,12 +275,12 @@ function pub.setup_claude_session_hooks(settings_path)
 	local pane_sessions_dir = claude_dir .. sep .. "pane-sessions"
 
 	-- Ensure pane-sessions directory exists.
-	-- Use wezterm.run_child_process to avoid cmd.exe flash on Windows.
+	-- Use os.execute because this may run during plugin init where
+	-- wezterm.run_child_process is forbidden (yields across C-call boundary).
 	if sep == "\\" then
-		-- Windows: mkdir does not need -p, but won't error if dir exists with 2>nul
-		wezterm.run_child_process({ "cmd", "/c", "if not exist \"" .. pane_sessions_dir .. "\" mkdir \"" .. pane_sessions_dir .. "\"" })
+		os.execute('cmd /c if not exist "' .. pane_sessions_dir .. '" mkdir "' .. pane_sessions_dir .. '" >nul 2>nul')
 	else
-		wezterm.run_child_process({ "mkdir", "-p", pane_sessions_dir })
+		os.execute('mkdir -p "' .. pane_sessions_dir .. '" 2>/dev/null')
 	end
 
 	-- Resolve settings path

--- a/plugin/resurrect/process_handlers.lua
+++ b/plugin/resurrect/process_handlers.lua
@@ -297,49 +297,15 @@ pub.register({
 	end,
 })
 
---- Ensure Claude Code's SessionStart hook is configured to capture session IDs
---- per WezTerm pane. This is idempotent -- safe to call on every WezTerm startup.
----
---- What it does:
----   1. Creates ~/.claude/pane-sessions/ directory (where session data is stored)
----   2. Reads ~/.claude/settings.json (or creates it if missing)
----   3. Adds a SessionStart hook that writes session metadata to
----      ~/.claude/pane-sessions/<WEZTERM_PANE>.json
----   4. Writes the updated settings back atomically
----
---- Usage in wezterm.lua:
----   local resurrect = wezterm.plugin.require("...")
----   resurrect.process_handlers.setup_claude_session_hooks()
----
----@param settings_path string|nil optional override for Claude settings file path
+-- Configure the SessionStart hook in a single Claude Code settings file.
+-- Returns true if hook is already present or was successfully added.
+---@param target_settings_path string path to settings.json
+---@param pane_sessions_dir string path to pane-sessions directory
 ---@return boolean success
-function pub.setup_claude_session_hooks(settings_path)
-	local home = os.getenv("HOME") or os.getenv("USERPROFILE")
-	if not home then
-		wezterm.log_error("resurrect: cannot determine home directory for Claude hook setup")
-		return false
-	end
-
-	local sep = utils.separator
-	local claude_dir = home .. sep .. ".claude"
-	local pane_sessions_dir = claude_dir .. sep .. "pane-sessions"
-
-	-- Ensure pane-sessions directory exists.
-	-- Use utils.shell_mkdir which validates the path (rejects shell
-	-- metacharacters) before passing it to os.execute.
-	if not utils.ensure_folder_exists(pane_sessions_dir) then
-		wezterm.log_error("resurrect: failed to create pane-sessions directory: " .. pane_sessions_dir)
-		return false
-	end
-
-	-- Resolve settings path
-	if not settings_path then
-		settings_path = claude_dir .. sep .. "settings.json"
-	end
-
+local function configure_hook_in_settings(target_settings_path, pane_sessions_dir)
 	-- Read existing settings (or start fresh)
 	local settings = {}
-	local f = io.open(settings_path, "r")
+	local f = io.open(target_settings_path, "r")
 	if f then
 		local content = f:read("*a")
 		f:close()
@@ -348,7 +314,7 @@ function pub.setup_claude_session_hooks(settings_path)
 			if ok and parsed then
 				settings = parsed
 			else
-				wezterm.log_warn("resurrect: could not parse " .. settings_path .. ", will add hooks to fresh object")
+				wezterm.log_warn("resurrect: could not parse " .. target_settings_path .. ", will add hooks to fresh object")
 			end
 		end
 	end
@@ -381,10 +347,13 @@ function pub.setup_claude_session_hooks(settings_path)
 	-- WEZTERM_PANE is set by WezTerm in child shells and inherited by Claude.
 	-- The pane ID is validated as numeric to prevent path traversal via
 	-- crafted WEZTERM_PANE values (e.g., "../../.bashrc").
+	-- All instances write to the same pane-sessions dir (~/.claude/pane-sessions/)
+	-- so the restore logic can find session data regardless of which binary ran.
+	local safe_dir = pane_sessions_dir:gsub("\\", "/"):gsub("'", "'\\''")
 	local hook_command = "bash -c '"
 		.. 'pane_id="${WEZTERM_PANE:-unknown}"; '
 		.. 'if [[ "$pane_id" =~ ^[0-9]+$ ]]; then '
-		.. 'cat > "$HOME/.claude/pane-sessions/${pane_id}.json"; '
+		.. 'cat > "' .. safe_dir .. '/${pane_id}.json"; '
 		.. "else echo \"resurrect: invalid WEZTERM_PANE: $pane_id\" >&2; cat > /dev/null; fi'"
 
 	table.insert(settings.hooks.SessionStart, {
@@ -400,17 +369,73 @@ function pub.setup_claude_session_hooks(settings_path)
 	-- Write directly (not atomic rename -- os.rename fails on Windows
 	-- when the target file already exists, causing silent failures).
 	local json_str = wezterm.json_encode(settings)
-	local wf = io.open(settings_path, "w")
+	local wf = io.open(target_settings_path, "w")
 	if not wf then
-		wezterm.log_error("resurrect: cannot write Claude settings to " .. settings_path)
+		wezterm.log_error("resurrect: cannot write Claude settings to " .. target_settings_path)
 		return false
 	end
 	wf:write(json_str)
 	wf:flush()
 	wf:close()
 
-	wezterm.log_info("resurrect: Claude Code SessionStart hook configured at " .. settings_path)
+	wezterm.log_info("resurrect: Claude Code SessionStart hook configured at " .. target_settings_path)
 	return true
+end
+
+--- Ensure Claude Code's SessionStart hook is configured to capture session IDs
+--- per WezTerm pane. This is idempotent -- safe to call on every WezTerm startup.
+---
+--- What it does:
+---   1. Creates ~/.claude/pane-sessions/ directory (where session data is stored)
+---   2. Configures the SessionStart hook in ~/.claude/settings.json
+---   3. Also configures ~/.claude-alt/settings.json if it exists (for claude2
+---      multi-account setups that use CLAUDE_CONFIG_DIR)
+---   4. All instances write to the same pane-sessions directory so restore
+---      logic can find session data regardless of which binary was used
+---
+--- Usage in wezterm.lua:
+---   local resurrect = wezterm.plugin.require("...")
+---   resurrect.process_handlers.setup_claude_session_hooks()
+---
+---@param settings_path string|nil optional override for Claude settings file path
+---@return boolean success
+function pub.setup_claude_session_hooks(settings_path)
+	local home = os.getenv("HOME") or os.getenv("USERPROFILE")
+	if not home then
+		wezterm.log_error("resurrect: cannot determine home directory for Claude hook setup")
+		return false
+	end
+
+	local sep = utils.separator
+	local claude_dir = home .. sep .. ".claude"
+	local pane_sessions_dir = claude_dir .. sep .. "pane-sessions"
+
+	-- Ensure pane-sessions directory exists.
+	if not utils.ensure_folder_exists(pane_sessions_dir) then
+		wezterm.log_error("resurrect: failed to create pane-sessions directory: " .. pane_sessions_dir)
+		return false
+	end
+
+	-- Configure the primary settings file
+	if settings_path then
+		return configure_hook_in_settings(settings_path, pane_sessions_dir)
+	end
+
+	local primary_path = claude_dir .. sep .. "settings.json"
+	local primary_ok = configure_hook_in_settings(primary_path, pane_sessions_dir)
+
+	-- Also configure alternate Claude config directories (e.g., .claude-alt for
+	-- claude2 multi-account setups). Only if the directory already exists --
+	-- we don't create new config dirs, just hook into existing ones.
+	local alt_dir = home .. sep .. ".claude-alt"
+	local alt_settings = alt_dir .. sep .. "settings.json"
+	local alt_f = io.open(alt_settings, "r")
+	if alt_f then
+		alt_f:close()
+		configure_hook_in_settings(alt_settings, pane_sessions_dir)
+	end
+
+	return primary_ok
 end
 
 return pub

--- a/plugin/resurrect/process_handlers.lua
+++ b/plugin/resurrect/process_handlers.lua
@@ -63,12 +63,14 @@ end
 
 --- Sanitize process_info at save time if a handler provides a sanitize function.
 --- This cleans up argv for portable restoration (e.g., stripping full node paths).
+--- The optional pane_id allows handlers to look up external state (e.g., session files).
 ---@param process_info table
+---@param pane_id number|string|nil WezTerm pane ID for external state lookup
 ---@return table process_info (possibly modified in place)
-function pub.sanitize_for_save(process_info)
+function pub.sanitize_for_save(process_info, pane_id)
 	local handler = pub.find_handler(process_info)
 	if handler and handler.sanitize then
-		local ok, err = pcall(handler.sanitize, process_info)
+		local ok, err = pcall(handler.sanitize, process_info, pane_id)
 		if not ok then
 			wezterm.log_error("resurrect: process_handler sanitize failed: " .. tostring(err))
 		end
@@ -115,6 +117,37 @@ local function has_flag(argv, flag)
 		end
 	end
 	return false
+end
+
+-- Read session data from Claude Code's pane-sessions directory.
+-- The SessionStart hook writes JSON to ~/.claude/pane-sessions/<pane_id>.json
+-- containing { session_id, transcript_path, cwd, hook_event_name, source }.
+---@param pane_id number|string WezTerm pane ID
+---@return table|nil session_data parsed JSON or nil on failure
+local function read_pane_session(pane_id)
+	if not pane_id then
+		return nil
+	end
+	local home = os.getenv("HOME") or os.getenv("USERPROFILE")
+	if not home then
+		return nil
+	end
+	local sep = package.config:sub(1, 1)
+	local path = home .. sep .. ".claude" .. sep .. "pane-sessions" .. sep .. tostring(pane_id) .. ".json"
+	local f = io.open(path, "r")
+	if not f then
+		return nil
+	end
+	local content = f:read("*a")
+	f:close()
+	if not content or content == "" then
+		return nil
+	end
+	local ok, data = pcall(wezterm.json_parse, content)
+	if ok and data then
+		return data
+	end
+	return nil
 end
 
 ---------------------------------------------------------------
@@ -176,13 +209,28 @@ pub.register({
 	--   {"node", "C:/Users/.../cli.js", "--dangerously-skip-permissions", "--resume", "uuid"}
 	-- We normalize to:
 	--   {"claude", "--resume", "uuid", "--dangerously-skip-permissions"}
-	sanitize = function(process_info)
+	--
+	-- If the session ID is not in argv (common for fresh sessions that were not
+	-- started with --resume), we look it up from the pane-sessions file written
+	-- by Claude Code's SessionStart hook. This ensures every Claude Code pane
+	-- gets its exact session ID saved, even when running 6-8 sessions at once.
+	sanitize = function(process_info, pane_id)
 		local argv = process_info.argv or {}
 		local clean = { "claude" }
 
-		-- Extract session ID
+		-- Extract session ID from argv first (explicit --resume or --session-id)
 		local session_id = parse_flag_value(argv, "--resume", "-r")
 			or parse_flag_value(argv, "--session-id")
+
+		-- Fall back to the pane-sessions file written by the SessionStart hook.
+		-- This covers fresh sessions that were started without --resume.
+		if not session_id and pane_id then
+			local session_data = read_pane_session(pane_id)
+			if session_data and session_data.session_id then
+				session_id = session_data.session_id
+			end
+		end
+
 		if session_id then
 			table.insert(clean, "--resume")
 			table.insert(clean, session_id)
@@ -198,5 +246,120 @@ pub.register({
 		process_info.argv = clean
 	end,
 })
+
+--- Ensure Claude Code's SessionStart hook is configured to capture session IDs
+--- per WezTerm pane. This is idempotent -- safe to call on every WezTerm startup.
+---
+--- What it does:
+---   1. Creates ~/.claude/pane-sessions/ directory (where session data is stored)
+---   2. Reads ~/.claude/settings.json (or creates it if missing)
+---   3. Adds a SessionStart hook that writes session metadata to
+---      ~/.claude/pane-sessions/<WEZTERM_PANE>.json
+---   4. Writes the updated settings back atomically
+---
+--- Usage in wezterm.lua:
+---   local resurrect = wezterm.plugin.require("...")
+---   resurrect.process_handlers.setup_claude_session_hooks()
+---
+---@param settings_path string|nil optional override for Claude settings file path
+---@return boolean success
+function pub.setup_claude_session_hooks(settings_path)
+	local home = os.getenv("HOME") or os.getenv("USERPROFILE")
+	if not home then
+		wezterm.log_error("resurrect: cannot determine home directory for Claude hook setup")
+		return false
+	end
+
+	local sep = package.config:sub(1, 1)
+	local claude_dir = home .. sep .. ".claude"
+	local pane_sessions_dir = claude_dir .. sep .. "pane-sessions"
+
+	-- Ensure pane-sessions directory exists.
+	-- Use wezterm.run_child_process to avoid cmd.exe flash on Windows.
+	if sep == "\\" then
+		-- Windows: mkdir does not need -p, but won't error if dir exists with 2>nul
+		wezterm.run_child_process({ "cmd", "/c", "if not exist \"" .. pane_sessions_dir .. "\" mkdir \"" .. pane_sessions_dir .. "\"" })
+	else
+		wezterm.run_child_process({ "mkdir", "-p", pane_sessions_dir })
+	end
+
+	-- Resolve settings path
+	if not settings_path then
+		settings_path = claude_dir .. sep .. "settings.json"
+	end
+
+	-- Read existing settings (or start fresh)
+	local settings = {}
+	local f = io.open(settings_path, "r")
+	if f then
+		local content = f:read("*a")
+		f:close()
+		if content and content ~= "" then
+			local ok, parsed = pcall(wezterm.json_parse, content)
+			if ok and parsed then
+				settings = parsed
+			else
+				wezterm.log_warn("resurrect: could not parse " .. settings_path .. ", will add hooks to fresh object")
+			end
+		end
+	end
+
+	-- Check if our hook is already present (idempotency check).
+	-- We look for any SessionStart hook whose command references "pane-sessions".
+	if settings.hooks and settings.hooks.SessionStart then
+		for _, entry in ipairs(settings.hooks.SessionStart) do
+			if entry.hooks then
+				for _, hook in ipairs(entry.hooks) do
+					if hook.command and hook.command:find("pane%-sessions") then
+						-- Already configured -- nothing to do
+						return true
+					end
+				end
+			end
+		end
+	end
+
+	-- Build the hook structure
+	if not settings.hooks then
+		settings.hooks = {}
+	end
+	if not settings.hooks.SessionStart then
+		settings.hooks.SessionStart = {}
+	end
+
+	-- The hook command: Claude Code sends session JSON on stdin via the
+	-- SessionStart hook. We write it to a file keyed by WEZTERM_PANE env var.
+	-- WEZTERM_PANE is set by WezTerm in child shells and inherited by Claude.
+	local hook_command = "bash -c 'cat > \"$HOME/.claude/pane-sessions/${WEZTERM_PANE:-unknown}.json\"'"
+
+	table.insert(settings.hooks.SessionStart, {
+		matcher = "",
+		hooks = {
+			{
+				type = "command",
+				command = hook_command,
+			},
+		},
+	})
+
+	-- Write back atomically (write to .tmp then rename)
+	local json_str = wezterm.json_encode(settings)
+	local tmp_path = settings_path .. ".tmp"
+	local wf = io.open(tmp_path, "w")
+	if not wf then
+		wezterm.log_error("resurrect: cannot write Claude settings to " .. tmp_path)
+		return false
+	end
+	wf:write(json_str)
+	wf:close()
+	local rename_ok, rename_err = os.rename(tmp_path, settings_path)
+	if not rename_ok then
+		wezterm.log_error("resurrect: failed to rename " .. tmp_path .. " -> " .. settings_path .. ": " .. tostring(rename_err))
+		return false
+	end
+
+	wezterm.log_info("resurrect: Claude Code SessionStart hook configured at " .. settings_path)
+	return true
+end
 
 return pub

--- a/plugin/resurrect/process_handlers.lua
+++ b/plugin/resurrect/process_handlers.lua
@@ -120,6 +120,22 @@ local function has_flag(argv, flag)
 	return false
 end
 
+-- Validate that a string looks like a UUID/hex-dash identifier.
+-- Used to sanitize session IDs before embedding them in shell commands.
+---@param s string
+---@return boolean
+local function is_valid_session_id(s)
+	return s and s:match("^[%x%-]+$") ~= nil
+end
+
+-- Validate that a binary name is a known Claude Code executable.
+-- Prevents command injection via tampered process_info.name in state files.
+---@param name string
+---@return boolean
+local function is_valid_claude_binary(name)
+	return name and (name:match("^claude%d*$") or name:match("^claude%-[%w%-]+$")) ~= nil
+end
+
 -- Read session data from Claude Code's pane-sessions directory.
 -- The SessionStart hook writes JSON to ~/.claude/pane-sessions/<pane_id>.json
 -- containing { session_id, transcript_path, cwd, hook_event_name, source }.
@@ -129,12 +145,18 @@ function pub.read_pane_session(pane_id)
 	if not pane_id then
 		return nil
 	end
+	-- Validate pane_id is numeric to prevent path traversal
+	local id_str = tostring(pane_id)
+	if not id_str:match("^%d+$") then
+		wezterm.log_error("resurrect: read_pane_session rejected non-numeric pane_id: " .. id_str)
+		return nil
+	end
 	local home = os.getenv("HOME") or os.getenv("USERPROFILE")
 	if not home then
 		return nil
 	end
 	local sep = utils.separator
-	local path = home .. sep .. ".claude" .. sep .. "pane-sessions" .. sep .. tostring(pane_id) .. ".json"
+	local path = home .. sep .. ".claude" .. sep .. "pane-sessions" .. sep .. id_str .. ".json"
 	local f = io.open(path, "r")
 	if not f then
 		return nil
@@ -182,16 +204,28 @@ pub.register({
 	-- Build the restore command from saved process info.
 	-- Prioritizes --resume <session-id> over --continue.
 	-- Preserves --dangerously-skip-permissions if it was present.
+	-- All values from state files are validated before use to prevent
+	-- command injection via tampered JSON (input sanitization).
 	get_restore_cmd = function(process_info, pane_tree)
 		local argv = process_info.argv or {}
 		-- Use the saved executable name (e.g., "claude", "claude2") so
 		-- multi-account setups restore with the correct binary.
+		-- Validate the name is actually a claude binary to prevent injection.
 		local bin = process_info.name or process_info.executable or "claude"
+		if not is_valid_claude_binary(bin) then
+			wezterm.log_warn("resurrect: rejected invalid claude binary name: " .. tostring(bin))
+			bin = "claude"
+		end
 		local parts = { bin }
 
 		-- Session ID: check --resume, -r, --session-id
 		local session_id = parse_flag_value(argv, "--resume", "-r")
 			or parse_flag_value(argv, "--session-id")
+		-- Validate session ID is a hex/dash string (UUID format)
+		if session_id and not is_valid_session_id(session_id) then
+			wezterm.log_warn("resurrect: rejected invalid session_id: " .. tostring(session_id))
+			session_id = nil
+		end
 		if session_id then
 			table.insert(parts, "--resume")
 			table.insert(parts, session_id)
@@ -241,6 +275,12 @@ pub.register({
 			end
 		end
 
+		-- Validate session ID format before embedding in argv
+		if session_id and not is_valid_session_id(session_id) then
+			wezterm.log_warn("resurrect: sanitize rejected invalid session_id: " .. tostring(session_id))
+			session_id = nil
+		end
+
 		if session_id then
 			table.insert(clean, "--resume")
 			table.insert(clean, session_id)
@@ -285,12 +325,11 @@ function pub.setup_claude_session_hooks(settings_path)
 	local pane_sessions_dir = claude_dir .. sep .. "pane-sessions"
 
 	-- Ensure pane-sessions directory exists.
-	-- Use os.execute because this runs during plugin init where
-	-- wezterm.run_child_process is forbidden (yields across C-call boundary).
-	if utils.is_windows then
-		os.execute('cmd /c if not exist "' .. pane_sessions_dir .. '" mkdir "' .. pane_sessions_dir .. '" >nul 2>nul')
-	else
-		os.execute('mkdir -p "' .. pane_sessions_dir .. '" 2>/dev/null')
+	-- Use utils.shell_mkdir which validates the path (rejects shell
+	-- metacharacters) before passing it to os.execute.
+	if not utils.ensure_folder_exists(pane_sessions_dir) then
+		wezterm.log_error("resurrect: failed to create pane-sessions directory: " .. pane_sessions_dir)
+		return false
 	end
 
 	-- Resolve settings path
@@ -340,7 +379,13 @@ function pub.setup_claude_session_hooks(settings_path)
 	-- The hook command: Claude Code sends session JSON on stdin via the
 	-- SessionStart hook. We write it to a file keyed by WEZTERM_PANE env var.
 	-- WEZTERM_PANE is set by WezTerm in child shells and inherited by Claude.
-	local hook_command = "bash -c 'cat > \"$HOME/.claude/pane-sessions/${WEZTERM_PANE:-unknown}.json\"'"
+	-- The pane ID is validated as numeric to prevent path traversal via
+	-- crafted WEZTERM_PANE values (e.g., "../../.bashrc").
+	local hook_command = "bash -c '"
+		.. 'pane_id="${WEZTERM_PANE:-unknown}"; '
+		.. 'if [[ "$pane_id" =~ ^[0-9]+$ ]]; then '
+		.. 'cat > "$HOME/.claude/pane-sessions/${pane_id}.json"; '
+		.. "else echo \"resurrect: invalid WEZTERM_PANE: $pane_id\" >&2; cat > /dev/null; fi'"
 
 	table.insert(settings.hooks.SessionStart, {
 		matcher = "",

--- a/plugin/resurrect/process_handlers.lua
+++ b/plugin/resurrect/process_handlers.lua
@@ -136,6 +136,23 @@ local function is_valid_claude_binary(name)
 	return name and (name:match("^claude%d*$") or name:match("^claude%-[%w%-]+$")) ~= nil
 end
 
+-- Characters that could enable command injection when a CWD is used in
+-- a shell command. Matches the same pattern used in tab_state.lua.
+local UNSAFE_CWD_PATTERN = "[;&|`$%(%)%{%}]"
+
+-- Validate that a CWD path is safe to embed in a shell command.
+---@param cwd string
+---@return boolean
+local function is_safe_cwd(cwd)
+	if not cwd or cwd == "" then
+		return false
+	end
+	if cwd:find(UNSAFE_CWD_PATTERN) then
+		return false
+	end
+	return true
+end
+
 -- Read session data from Claude Code's pane-sessions directory.
 -- The SessionStart hook writes JSON to ~/.claude/pane-sessions/<pane_id>.json
 -- containing { session_id, transcript_path, cwd, hook_event_name, source }.
@@ -240,7 +257,21 @@ pub.register({
 			table.insert(parts, "--dangerously-skip-permissions")
 		end
 
-		return wezterm.shell_join_args(parts)
+		local cmd = wezterm.shell_join_args(parts)
+
+		-- Claude Code must be started from the original working directory
+		-- for proper context loading and session restoration. Prepend a cd
+		-- command as a separate line so the shell changes directory before
+		-- launching Claude. Using \r\n between commands instead of && for
+		-- cross-shell compatibility (PowerShell 5.x does not support &&).
+		local cwd = process_info.cwd or (pane_tree and pane_tree.cwd)
+		if cwd and is_safe_cwd(cwd) then
+			cmd = "cd " .. wezterm.shell_join_args({ cwd }) .. "\r\n" .. cmd
+		elseif cwd then
+			wezterm.log_warn("resurrect: rejected unsafe CWD for Claude restore: " .. tostring(cwd))
+		end
+
+		return cmd
 	end,
 
 	-- At save time, clean up the raw node argv into a portable form.

--- a/plugin/resurrect/process_handlers.lua
+++ b/plugin/resurrect/process_handlers.lua
@@ -125,7 +125,7 @@ end
 -- containing { session_id, transcript_path, cwd, hook_event_name, source }.
 ---@param pane_id number|string WezTerm pane ID
 ---@return table|nil session_data parsed JSON or nil on failure
-local function read_pane_session(pane_id)
+function pub.read_pane_session(pane_id)
 	if not pane_id then
 		return nil
 	end
@@ -235,7 +235,7 @@ pub.register({
 		-- Fall back to the pane-sessions file written by the SessionStart hook.
 		-- This covers fresh sessions that were started without --resume.
 		if not session_id and pane_id then
-			local session_data = read_pane_session(pane_id)
+			local session_data = pub.read_pane_session(pane_id)
 			if session_data and session_data.session_id then
 				session_id = session_data.session_id
 			end

--- a/plugin/resurrect/process_handlers.lua
+++ b/plugin/resurrect/process_handlers.lua
@@ -9,6 +9,7 @@
 --       get_restore_cmd = function(info, _) return "lazygit" end,
 --   })
 local wezterm = require("wezterm") --[[@as Wezterm]]
+local utils = require("resurrect.utils")
 
 local pub = {}
 
@@ -132,7 +133,7 @@ local function read_pane_session(pane_id)
 	if not home then
 		return nil
 	end
-	local sep = package.config:sub(1, 1)
+	local sep = utils.separator
 	local path = home .. sep .. ".claude" .. sep .. "pane-sessions" .. sep .. tostring(pane_id) .. ".json"
 	local f = io.open(path, "r")
 	if not f then
@@ -279,14 +280,14 @@ function pub.setup_claude_session_hooks(settings_path)
 		return false
 	end
 
-	local sep = package.config:sub(1, 1)
+	local sep = utils.separator
 	local claude_dir = home .. sep .. ".claude"
 	local pane_sessions_dir = claude_dir .. sep .. "pane-sessions"
 
 	-- Ensure pane-sessions directory exists.
-	-- Use os.execute because this may run during plugin init where
+	-- Use os.execute because this runs during plugin init where
 	-- wezterm.run_child_process is forbidden (yields across C-call boundary).
-	if sep == "\\" then
+	if utils.is_windows then
 		os.execute('cmd /c if not exist "' .. pane_sessions_dir .. '" mkdir "' .. pane_sessions_dir .. '" >nul 2>nul')
 	else
 		os.execute('mkdir -p "' .. pane_sessions_dir .. '" 2>/dev/null')
@@ -351,21 +352,17 @@ function pub.setup_claude_session_hooks(settings_path)
 		},
 	})
 
-	-- Write back atomically (write to .tmp then rename)
+	-- Write directly (not atomic rename -- os.rename fails on Windows
+	-- when the target file already exists, causing silent failures).
 	local json_str = wezterm.json_encode(settings)
-	local tmp_path = settings_path .. ".tmp"
-	local wf = io.open(tmp_path, "w")
+	local wf = io.open(settings_path, "w")
 	if not wf then
-		wezterm.log_error("resurrect: cannot write Claude settings to " .. tmp_path)
+		wezterm.log_error("resurrect: cannot write Claude settings to " .. settings_path)
 		return false
 	end
 	wf:write(json_str)
+	wf:flush()
 	wf:close()
-	local rename_ok, rename_err = os.rename(tmp_path, settings_path)
-	if not rename_ok then
-		wezterm.log_error("resurrect: failed to rename " .. tmp_path .. " -> " .. settings_path .. ": " .. tostring(rename_err))
-		return false
-	end
 
 	wezterm.log_info("resurrect: Claude Code SessionStart hook configured at " .. settings_path)
 	return true

--- a/plugin/resurrect/process_handlers.lua
+++ b/plugin/resurrect/process_handlers.lua
@@ -136,22 +136,8 @@ local function is_valid_claude_binary(name)
 	return name and (name:match("^claude%d*$") or name:match("^claude%-[%w%-]+$")) ~= nil
 end
 
--- Characters that could enable command injection when a CWD is used in
--- a shell command. Matches the same pattern used in tab_state.lua.
-local UNSAFE_CWD_PATTERN = "[;&|`$%(%)%{%}]"
-
--- Validate that a CWD path is safe to embed in a shell command.
----@param cwd string
----@return boolean
-local function is_safe_cwd(cwd)
-	if not cwd or cwd == "" then
-		return false
-	end
-	if cwd:find(UNSAFE_CWD_PATTERN) then
-		return false
-	end
-	return true
-end
+-- Use shared CWD validation from utils to prevent command injection.
+local is_safe_cwd = utils.is_safe_cwd
 
 -- Read session data from Claude Code's pane-sessions directory.
 -- The SessionStart hook writes JSON to ~/.claude/pane-sessions/<pane_id>.json

--- a/plugin/resurrect/spec/ensure_folder_exists_spec.lua
+++ b/plugin/resurrect/spec/ensure_folder_exists_spec.lua
@@ -3,8 +3,40 @@ local function is_windows()
 end
 
 -- Minimal wezterm stub for utils.lua.
+-- run_child_process is required by shell_mkdir in utils.lua.
+-- This stub delegates to os.execute so that mkdir actually works in tests.
 local wezterm_stub = {
   target_triple = is_windows() and "x86_64-pc-windows-msvc" or "x86_64-unknown-linux-gnu",
+  run_child_process = function(cmd_args)
+    local cmd
+    if is_windows() then
+      -- cmd_args is {"cmd.exe", "/c", "mkdir", path}
+      local parts = {}
+      for i, v in ipairs(cmd_args) do
+        if v:find(" ") then
+          parts[i] = '"' .. v .. '"'
+        else
+          parts[i] = v
+        end
+      end
+      cmd = table.concat(parts, " ")
+    else
+      -- cmd_args is {"mkdir", path}
+      local parts = {}
+      for i, v in ipairs(cmd_args) do
+        parts[i] = "'" .. v:gsub("'", "'\\''") .. "'"
+      end
+      cmd = table.concat(parts, " ")
+    end
+    local ok = os.execute(cmd)
+    -- Lua 5.4: os.execute returns true/nil, "exit"/"signal", code
+    -- Lua 5.1: os.execute returns exit code (0 = success)
+    if ok == true or ok == 0 then
+      return true, "", ""
+    else
+      return false, "", "command failed"
+    end
+  end,
 }
 _G.wezterm = wezterm_stub
 package.preload["wezterm"] = function()

--- a/plugin/resurrect/spec/ensure_folder_exists_spec.lua
+++ b/plugin/resurrect/spec/ensure_folder_exists_spec.lua
@@ -1,0 +1,157 @@
+local function is_windows()
+  return package.config:sub(1, 1) == "\\"
+end
+
+-- Minimal wezterm stub for utils.lua.
+local wezterm_stub = {
+  target_triple = is_windows() and "x86_64-pc-windows-msvc" or "x86_64-unknown-linux-gnu",
+}
+_G.wezterm = wezterm_stub
+package.preload["wezterm"] = function()
+  return wezterm_stub
+end
+
+local search_paths = {
+  -- repo root
+  "./plugin/?.lua",
+  "./plugin/?/init.lua",
+  "./plugin/?/?.lua",
+  -- when cwd is plugin/resurrect
+  "../../plugin/?.lua",
+  "../../plugin/?/init.lua",
+  "../../plugin/?/?.lua",
+}
+
+package.path = table.concat(search_paths, ";") .. ";" .. package.path
+
+local utils = require("resurrect.utils")
+
+local sep = utils.is_windows and "\\" or "/"
+
+-- Probe by writing a temp file inside the directory.
+-- os.rename(dir, dir) can return nil on Windows for permission/lock reasons
+-- even when the directory exists, giving a misleading false negative.
+local function dir_exists(path)
+  local probe = path .. sep .. ".probe"
+  local f = io.open(probe, "w")
+  if f then
+    f:close()
+    os.remove(probe)
+    return true
+  end
+  return false
+end
+
+local function rmdir_recursive(path)
+  if utils.is_windows then
+    if not path:find('"') then
+      os.execute('rmdir /s /q "' .. path .. '" >nul 2>&1')
+    end
+  else
+    local quoted = "'" .. path:gsub("'", "'\\''") .. "'"
+    os.execute("rm -rf " .. quoted)
+  end
+end
+
+-- Returns a unique absolute temp path without creating it.
+-- tostring({}) yields a unique table address within this process; combined with
+-- os.time() it is extremely unlikely to collide across concurrent processes.
+local function unique_tmp_base()
+  local id = tostring(os.time()) .. "_" .. tostring({}):gsub("[^%w]", "")
+  if utils.is_windows then
+    local tmp_dir = os.getenv("TEMP") or os.getenv("TMP") or "C:\\Temp"
+    return tmp_dir .. "\\_resurrect_test_" .. id
+  else
+    return "/tmp/_resurrect_test_" .. id
+  end
+end
+
+describe("utils.ensure_folder_exists", function()
+  local test_base
+  local cleanup_extras  -- additional paths cleaned up by after_each
+
+  before_each(function()
+    test_base = unique_tmp_base()
+    cleanup_extras = {}
+  end)
+
+  after_each(function()
+    rmdir_recursive(test_base)
+    for _, path in ipairs(cleanup_extras) do
+      rmdir_recursive(path)
+    end
+  end)
+
+  it("creates a nested directory structure", function()
+    local nested = test_base .. sep .. "a" .. sep .. "b"
+    assert.is_true(utils.ensure_folder_exists(nested))
+    assert.is_true(dir_exists(test_base))
+    assert.is_true(dir_exists(nested))
+  end)
+
+  -- The open-handle false-negative scenario (Windows only, triggered when
+  -- WezTerm holds a handle to the directory) cannot be tested portably without
+  -- monkey-patching io.open. The idempotency test below exercises the
+  -- happy-path re-entry but not the open-handle scenario.
+  it("is idempotent on an existing path", function()
+    local nested = test_base .. sep .. "a" .. sep .. "b"
+    assert.is_true(utils.ensure_folder_exists(nested))
+    assert.is_true(utils.ensure_folder_exists(nested))
+  end)
+
+  it("handles directory names containing spaces", function()
+    local spaced = test_base .. sep .. "dir with spaces" .. sep .. "nested dir"
+    assert.is_true(utils.ensure_folder_exists(spaced))
+    assert.is_true(dir_exists(spaced))
+  end)
+
+  it("returns false when a path component is a file, not a directory", function()
+    assert.is_true(utils.ensure_folder_exists(test_base))
+    local obstacle = test_base .. sep .. "obstacle.txt"
+    local f = assert(io.open(obstacle, "w"))
+    f:write("x")
+    f:close()
+    assert.is_false(utils.ensure_folder_exists(obstacle .. sep .. "child"))
+  end)
+
+  it("handles relative paths", function()
+    local id = tostring({}):gsub("[^%w]", "")
+    local rel_base = "_resurrect_rel_" .. id
+    -- Register before asserting so after_each cleans up even on failure.
+    -- This path lands in CWD rather than the temp root, so it cannot be
+    -- covered by the test_base cleanup.
+    table.insert(cleanup_extras, rel_base)
+    local rel_nested = rel_base .. sep .. "a" .. sep .. "b"
+    assert.is_true(utils.ensure_folder_exists(rel_nested))
+    assert.is_true(dir_exists(rel_nested))
+  end)
+
+  -- Windows-only path form tests.
+  -- UNC paths (\\server\share\...) are not tested: the server and share
+  -- components cannot be created via mkdir, so a meaningful test would require
+  -- a live network share or privileged loopback (\\localhost\c$\...) that is
+  -- not suitable for a local or CI environment.
+  if utils.is_windows then
+    it("handles absolute paths with a drive letter", function()
+      local drive = (os.getenv("TEMP") or "C:\\"):match("^(%a:)") or "C:"
+      local abs_base = drive .. "\\_resurrect_abs_" .. tostring({}):gsub("[^%w]", "")
+      table.insert(cleanup_extras, abs_base)
+      local abs_nested = abs_base .. "\\x\\y"
+      assert.is_true(utils.ensure_folder_exists(abs_nested))
+      assert.is_true(dir_exists(abs_nested))
+    end)
+
+    it("normalises drive-relative paths (C:foo) to absolute from drive root", function()
+      local drive = (os.getenv("TEMP") or "C:\\"):match("^(%a:)") or "C:"
+      local id = tostring({}):gsub("[^%w]", "")
+      local abs_base = drive .. "\\_resurrect_driverel_" .. id
+      table.insert(cleanup_extras, abs_base)
+      -- Pass the path without a separator after the drive letter.
+      local driverel = drive .. "_resurrect_driverel_" .. id .. "\\sub"
+      -- The function should normalise this to drive:\... and create it there.
+      local expected = abs_base .. "\\sub"
+      assert.is_true(utils.ensure_folder_exists(driverel))
+      assert.is_true(dir_exists(expected))
+    end)
+  end
+end)

--- a/plugin/resurrect/spec/instance_manager_spec.lua
+++ b/plugin/resurrect/spec/instance_manager_spec.lua
@@ -1,0 +1,505 @@
+-- Unit tests for instance_manager.lua
+-- Tests cover: ID generation, save/load/delete, path traversal rejection,
+-- listing/sorting, cleanup, display formatting, and rename.
+
+local function is_windows()
+    return package.config:sub(1, 1) == "\\"
+end
+
+-- ---------------------------------------------------------------------------
+-- Stubs
+-- ---------------------------------------------------------------------------
+
+-- Clear cached modules so stubs from other spec files don't leak in
+package.loaded["resurrect.file_io"] = nil
+package.loaded["resurrect.utils"] = nil
+package.loaded["resurrect.state_manager"] = nil
+package.loaded["resurrect.instance_manager"] = nil
+package.loaded["resurrect.workspace_state"] = nil
+package.loaded["resurrect.window_state"] = nil
+package.loaded["resurrect.tab_state"] = nil
+package.loaded["resurrect.fuzzy_loader"] = nil
+
+local emitted_events = {}
+local written_files = {}
+local removed_files = {}
+
+-- Minimal recursive JSON encoder for test purposes
+local function json_encode_value(val)
+    if type(val) == "string" then
+        return '"' .. val:gsub('"', '\\"') .. '"'
+    elseif type(val) ~= "table" then
+        if val == nil then
+            return "null"
+        end
+        return tostring(val)
+    end
+    -- Check if array (has sequential integer keys)
+    if #val > 0 or next(val) == nil then
+        local parts = {}
+        for _, v in ipairs(val) do
+            table.insert(parts, json_encode_value(v))
+        end
+        return "[" .. table.concat(parts, ",") .. "]"
+    end
+    -- Object
+    local parts = {}
+    local keys = {}
+    for k in pairs(val) do
+        table.insert(keys, k)
+    end
+    table.sort(keys)
+    for _, k in ipairs(keys) do
+        table.insert(parts, '"' .. k .. '":' .. json_encode_value(val[k]))
+    end
+    return "{" .. table.concat(parts, ",") .. "}"
+end
+
+local wezterm_stub = {
+    target_triple = is_windows() and "x86_64-pc-windows-msvc" or "x86_64-unknown-linux-gnu",
+    emit = function(event, ...)
+        table.insert(emitted_events, { event = event, args = { ... } })
+    end,
+    log_error = function() end,
+    log_info = function() end,
+    json_encode = json_encode_value,
+    json_parse = function(str)
+        -- Use a basic approach: load as Lua with transformations
+        -- For test purposes, we store and retrieve via our file stubs
+        -- so we can just return the stored table directly
+        if not str or str == "" then
+            return nil
+        end
+        -- Parse simple JSON using pattern matching for our test cases
+        local result = {}
+        -- Try to detect if it is our instance state format
+        local iid = str:match('"instance_id":"([^"]+)"')
+        if iid then
+            result.instance_id = iid
+        end
+        local dn = str:match('"display_name":"([^"]*)"')
+        if dn and dn ~= "" then
+            result.display_name = dn
+        end
+        local epoch = str:match('"last_save_epoch":(%d+)')
+        if epoch then
+            result.last_save_epoch = tonumber(epoch)
+        end
+        local tc = str:match('"tab_count":(%d+)')
+        if tc then
+            result.tab_count = tonumber(tc)
+        end
+        -- Parse tab_summaries array
+        local summaries_str = str:match('"tab_summaries":%[([^%]]*)%]')
+        if summaries_str then
+            result.tab_summaries = {}
+            for s in summaries_str:gmatch('"([^"]*)"') do
+                table.insert(result.tab_summaries, s)
+            end
+        end
+        -- Parse workspace_state (just mark it present)
+        if str:find('"workspace_state"') then
+            result.workspace_state = { workspace = "test", window_states = {} }
+        end
+        return result
+    end,
+    run_child_process = function()
+        return false, nil, "stub"
+    end,
+    time = {
+        call_after = function() end,
+    },
+    gui = {
+        gui_windows = function() return {} end,
+    },
+    mux = {
+        spawn_window = function() return {}, {}, {} end,
+    },
+    action = {
+        InputSelector = function() return {} end,
+    },
+    action_callback = function(fn) return fn end,
+}
+
+_G.wezterm = wezterm_stub
+package.preload["wezterm"] = function()
+    return wezterm_stub
+end
+
+-- Stub file_io to capture file operations in memory.
+-- Also tracks last_load_path for compatibility with state_manager_spec
+-- (busted shares one Lua process, so whichever spec loads first wins).
+local file_store = {}
+_G._file_io_last_load_path = nil
+package.preload["resurrect.file_io"] = function()
+    return {
+        write_file = function(path, content)
+            written_files[path] = content
+            file_store[path] = content
+            return true, nil
+        end,
+        read_file = function(path)
+            if file_store[path] then
+                return true, file_store[path]
+            end
+            return false, "not found"
+        end,
+        load_json = function(path)
+            _G._file_io_last_load_path = path
+            if file_store[path] then
+                return wezterm_stub.json_parse(file_store[path])
+            end
+            return {}
+        end,
+        write_state = function() end,
+    }
+end
+
+-- Stub utils
+local sep = is_windows() and "\\" or "/"
+package.preload["resurrect.utils"] = function()
+    return {
+        is_windows = is_windows(),
+        is_mac = false,
+        separator = sep,
+        ensure_folder_exists = function() return true end,
+        tbl_deep_extend = function(behavior, ...)
+            local tables = { ... }
+            local result = {}
+            for _, t in ipairs(tables) do
+                for k, v in pairs(t) do
+                    result[k] = v
+                end
+            end
+            return result
+        end,
+    }
+end
+
+-- Stub state_manager
+package.preload["resurrect.state_manager"] = function()
+    return {
+        save_state_dir = is_windows()
+            and ((os.getenv("TEMP") or "C:\\Temp") .. "\\resurrect_im_test\\state")
+            or "/tmp/resurrect_im_test/state",
+        resurrect_on_gui_startup = function() return true end,
+        load_state = function() return {} end,
+    }
+end
+
+-- Stub other modules that instance_manager might require
+package.preload["resurrect.workspace_state"] = function()
+    return {
+        get_workspace_state = function()
+            return { workspace = "default", window_states = {} }
+        end,
+        restore_workspace = function() end,
+    }
+end
+package.preload["resurrect.window_state"] = function()
+    return { restore_window = function() end }
+end
+package.preload["resurrect.tab_state"] = function()
+    return {
+        default_on_pane_restore = function() end,
+        restore_tab = function() end,
+    }
+end
+package.preload["resurrect.fuzzy_loader"] = function()
+    return { fuzzy_load = function() end }
+end
+
+-- Set up package path
+local search_paths = {
+    "./plugin/?.lua",
+    "./plugin/?/init.lua",
+    "./plugin/?/?.lua",
+    "../../plugin/?.lua",
+    "../../plugin/?/init.lua",
+    "../../plugin/?/?.lua",
+}
+package.path = table.concat(search_paths, ";") .. ";" .. package.path
+
+-- Override os.remove to track deletions (rawset avoids luacheck read-only warning)
+rawset(os, "remove", function(path)
+    table.insert(removed_files, path)
+    file_store[path] = nil
+    return true
+end)
+
+-- Now require the module under test
+local instance_manager = require("resurrect.instance_manager")
+
+-- ---------------------------------------------------------------------------
+-- Tests
+-- ---------------------------------------------------------------------------
+
+describe("instance_manager", function()
+    before_each(function()
+        emitted_events = {}
+        written_files = {}
+        removed_files = {}
+        file_store = {}
+        instance_manager.instance_id = nil
+        instance_manager.display_name = nil
+        instance_manager.retention_days = 7
+        instance_manager.auto_restore_prompt = true
+    end)
+
+    -- ----- ID generation -----
+    describe("init_instance_id", function()
+        it("returns a string matching the expected format", function()
+            local id = instance_manager.init_instance_id()
+            assert.is_string(id)
+            assert.truthy(id:match("^%d+_%d+$"), "ID should match <digits>_<digits> but got: " .. id)
+        end)
+
+        it("sets pub.instance_id", function()
+            instance_manager.init_instance_id()
+            assert.is_not_nil(instance_manager.instance_id)
+            assert.truthy(instance_manager.instance_id:match("^%d+_%d+$"))
+        end)
+
+        it("generates different IDs on subsequent calls", function()
+            local id1 = instance_manager.init_instance_id()
+            -- Force a different random seed to ensure different output
+            math.randomseed(os.time() + 1)
+            local id2 = instance_manager.init_instance_id()
+            -- They might be the same if called within the same second
+            -- and random hits the same value, but the format should always be valid
+            assert.truthy(id1:match("^%d+_%d+$"))
+            assert.truthy(id2:match("^%d+_%d+$"))
+        end)
+    end)
+
+    -- ----- Save/Load/Delete -----
+    describe("save_instance", function()
+        it("creates .json and .meta files", function()
+            instance_manager.init_instance_id()
+            local ws = { workspace = "test_ws", window_states = {} }
+            instance_manager.save_instance(ws)
+
+            local dir = instance_manager.get_instances_dir()
+            local json_path = dir .. sep .. instance_manager.instance_id .. ".json"
+            local meta_path_val = dir .. sep .. instance_manager.instance_id .. ".meta"
+
+            assert.truthy(written_files[json_path], "should write .json file")
+            assert.truthy(written_files[meta_path_val], "should write .meta file")
+        end)
+
+        it("does nothing when instance_id is nil", function()
+            instance_manager.instance_id = nil
+            instance_manager.save_instance({ workspace = "test", window_states = {} })
+            local count = 0
+            for _ in pairs(written_files) do count = count + 1 end
+            assert.equals(0, count)
+        end)
+
+        it("includes display_name in meta when set", function()
+            instance_manager.init_instance_id()
+            instance_manager.display_name = "My Project"
+            instance_manager.save_instance({ workspace = "test", window_states = {} })
+
+            local dir = instance_manager.get_instances_dir()
+            local meta_content = written_files[dir .. sep .. instance_manager.instance_id .. ".meta"]
+            assert.truthy(meta_content)
+            assert.truthy(meta_content:find('"My Project"'), "meta should contain display_name")
+        end)
+    end)
+
+    describe("load_instance", function()
+        it("returns workspace_state from saved instance", function()
+            instance_manager.init_instance_id()
+            local ws = { workspace = "loaded_ws", window_states = {} }
+            instance_manager.save_instance(ws)
+
+            local loaded = instance_manager.load_instance(instance_manager.instance_id)
+            assert.is_not_nil(loaded)
+            assert.truthy(loaded.workspace)
+        end)
+
+        it("rejects invalid instance IDs", function()
+            local result = instance_manager.load_instance("../../../etc/passwd")
+            assert.is_nil(result)
+        end)
+
+        it("rejects IDs with path separators", function()
+            local result = instance_manager.load_instance("foo/bar")
+            assert.is_nil(result)
+        end)
+
+        it("rejects empty string", function()
+            local result = instance_manager.load_instance("")
+            assert.is_nil(result)
+        end)
+
+        it("returns nil for non-existent instance", function()
+            local result = instance_manager.load_instance("9999999999_99999")
+            assert.is_nil(result)
+        end)
+    end)
+
+    describe("delete_instance", function()
+        it("removes .json and .meta files", function()
+            instance_manager.init_instance_id()
+            local id = instance_manager.instance_id
+            instance_manager.save_instance({ workspace = "del_test", window_states = {} })
+
+            local result = instance_manager.delete_instance(id)
+            assert.is_true(result)
+            assert.truthy(#removed_files >= 2, "should remove at least 2 files")
+        end)
+
+        it("rejects invalid IDs (path traversal)", function()
+            local result = instance_manager.delete_instance("../../secrets")
+            assert.is_false(result)
+        end)
+
+        it("rejects IDs with letters", function()
+            local result = instance_manager.delete_instance("abc_12345")
+            assert.is_false(result)
+        end)
+
+        it("emits event on successful delete", function()
+            instance_manager.init_instance_id()
+            local id = instance_manager.instance_id
+            instance_manager.save_instance({ workspace = "test", window_states = {} })
+            emitted_events = {} -- reset
+            instance_manager.delete_instance(id)
+
+            local found = false
+            for _, e in ipairs(emitted_events) do
+                if e.event == "resurrect.instance_manager.delete_instance.finished" then
+                    found = true
+                end
+            end
+            assert.is_true(found, "should emit delete finished event")
+        end)
+    end)
+
+    -- ----- Listing -----
+    describe("list_instances", function()
+        it("returns empty array when no instances exist", function()
+            local instances = instance_manager.list_instances()
+            assert.equals(0, #instances)
+        end)
+    end)
+
+    -- ----- Cleanup -----
+    describe("cleanup_old_instances", function()
+        it("runs without error when no instances exist", function()
+            assert.has_no.errors(function()
+                instance_manager.cleanup_old_instances()
+            end)
+        end)
+    end)
+
+    -- ----- Display formatting -----
+    describe("format_instance_summary", function()
+        it("formats unnamed instance with date", function()
+            local meta = {
+                last_save_epoch = os.time(),
+                tab_count = 2,
+                tab_summaries = { "Claude Code", "PowerShell" },
+            }
+            local summary = instance_manager.format_instance_summary(meta)
+            assert.is_string(summary)
+            assert.truthy(summary:find("Claude Code"))
+            assert.truthy(summary:find("PowerShell"))
+            assert.truthy(summary:find("%[2 tabs%]"))
+            assert.truthy(summary:find(" -- "))
+        end)
+
+        it("formats named instance with display_name", function()
+            local meta = {
+                display_name = "Orahvision Dev",
+                last_save_epoch = os.time(),
+                tab_count = 3,
+                tab_summaries = { "Claude Code", "PowerShell", "Claude Code" },
+            }
+            local summary = instance_manager.format_instance_summary(meta)
+            assert.truthy(summary:find("Orahvision Dev"))
+            assert.truthy(summary:find("Claude Code x2"))
+            assert.truthy(summary:find("PowerShell"))
+            assert.truthy(summary:find("%[3 tabs%]"))
+        end)
+
+        it("shows singular 'tab' for single tab", function()
+            local meta = {
+                last_save_epoch = os.time(),
+                tab_count = 1,
+                tab_summaries = { "PowerShell" },
+            }
+            local summary = instance_manager.format_instance_summary(meta)
+            assert.truthy(summary:find("%[1 tab%]"))
+            -- Should NOT say "1 tabs"
+            assert.falsy(summary:find("%[1 tabs%]"))
+        end)
+
+        it("handles empty tab summaries", function()
+            local meta = {
+                last_save_epoch = os.time(),
+                tab_count = 0,
+                tab_summaries = {},
+            }
+            local summary = instance_manager.format_instance_summary(meta)
+            assert.truthy(summary:find("%(empty%)"))
+        end)
+
+        it("handles missing last_save_epoch", function()
+            local meta = {
+                tab_count = 1,
+                tab_summaries = { "Shell" },
+            }
+            local summary = instance_manager.format_instance_summary(meta)
+            assert.truthy(summary:find("Unknown"))
+        end)
+    end)
+
+    -- ----- Rename -----
+    describe("rename_instance", function()
+        it("updates display_name in meta file", function()
+            instance_manager.init_instance_id()
+            local id = instance_manager.instance_id
+            instance_manager.save_instance({ workspace = "rename_test", window_states = {} })
+
+            instance_manager.rename_instance(id, "My Project")
+
+            -- Check that the meta was rewritten with the new name
+            local dir = instance_manager.get_instances_dir()
+            local meta_content = file_store[dir .. sep .. id .. ".meta"]
+            assert.truthy(meta_content)
+            assert.truthy(meta_content:find("My Project"))
+        end)
+
+        it("updates pub.display_name when renaming current instance", function()
+            instance_manager.init_instance_id()
+            local id = instance_manager.instance_id
+            instance_manager.save_instance({ workspace = "test", window_states = {} })
+
+            instance_manager.rename_instance(id, "Current Name")
+            assert.equals("Current Name", instance_manager.display_name)
+        end)
+
+        it("does not update pub.display_name when renaming different instance", function()
+            instance_manager.init_instance_id()
+            instance_manager.save_instance({ workspace = "test", window_states = {} })
+            instance_manager.display_name = "Original"
+
+            -- Rename a different (fake) instance
+            local other_id = "1234567890_12345"
+            -- Write a meta file for it
+            local dir = instance_manager.get_instances_dir()
+            file_store[dir .. sep .. other_id .. ".meta"] = '{"instance_id":"1234567890_12345"}'
+
+            instance_manager.rename_instance(other_id, "Other Name")
+            assert.equals("Original", instance_manager.display_name)
+        end)
+
+        it("rejects invalid instance IDs", function()
+            assert.has_no.errors(function()
+                instance_manager.rename_instance("../evil", "Hacked")
+            end)
+        end)
+    end)
+end)

--- a/plugin/resurrect/spec/state_manager_spec.lua
+++ b/plugin/resurrect/spec/state_manager_spec.lua
@@ -2,12 +2,27 @@ local function is_windows()
   return package.config:sub(1, 1) == "\\"
 end
 
--- Minimal wezterm stub.
+-- Clear any previously cached modules AND preloads from other spec files
+-- (busted shares one Lua process, so earlier specs may have loaded different stubs).
+package.loaded["resurrect.file_io"] = nil
+package.loaded["resurrect.state_manager"] = nil
+package.loaded["resurrect.utils"] = nil
+package.loaded["resurrect.instance_manager"] = nil
+package.loaded["wezterm"] = nil
+package.preload["resurrect.file_io"] = nil
+package.preload["resurrect.state_manager"] = nil
+package.preload["resurrect.utils"] = nil
+package.preload["resurrect.instance_manager"] = nil
+
+-- Minimal wezterm stub (needs log_error/log_info for instance_manager compat).
 local wezterm_stub = {
   target_triple = is_windows() and "x86_64-pc-windows-msvc" or "x86_64-unknown-linux-gnu",
   emit = function() end,
+  log_error = function() end,
+  log_info = function() end,
 }
 _G.wezterm = wezterm_stub
+package.loaded["wezterm"] = wezterm_stub
 package.preload["wezterm"] = function()
   return wezterm_stub
 end
@@ -15,16 +30,28 @@ end
 -- Stub file_io and capture the path passed to load_json so we can assert
 -- on what get_file_path (a local function) actually produced.
 local last_load_path
-package.preload["resurrect.file_io"] = function()
-  return {
-    load_json = function(path)
-      last_load_path = path
-      return {}
-    end,
-    write_state = function() end,
-    write_file = function() end,
-  }
-end
+package.loaded["resurrect.file_io"] = {
+  load_json = function(path)
+    last_load_path = path
+    return {}
+  end,
+  write_state = function() end,
+  write_file = function() end,
+  read_file = function() return false, "stub" end,
+}
+
+-- Stub instance_manager so state_manager's require doesn't pull in the real module
+package.loaded["resurrect.instance_manager"] = {
+  instance_id = nil,
+  save_instance = function() end,
+}
+
+-- Stub workspace_state for save_workspace_full
+package.loaded["resurrect.workspace_state"] = {
+  get_workspace_state = function()
+    return { workspace = "test", window_states = {} }
+  end,
+}
 
 local search_paths = {
   -- repo root

--- a/plugin/resurrect/spec/state_manager_spec.lua
+++ b/plugin/resurrect/spec/state_manager_spec.lua
@@ -1,0 +1,75 @@
+local function is_windows()
+  return package.config:sub(1, 1) == "\\"
+end
+
+-- Minimal wezterm stub.
+local wezterm_stub = {
+  target_triple = is_windows() and "x86_64-pc-windows-msvc" or "x86_64-unknown-linux-gnu",
+  emit = function() end,
+}
+_G.wezterm = wezterm_stub
+package.preload["wezterm"] = function()
+  return wezterm_stub
+end
+
+-- Stub file_io and capture the path passed to load_json so we can assert
+-- on what get_file_path (a local function) actually produced.
+local last_load_path
+package.preload["resurrect.file_io"] = function()
+  return {
+    load_json = function(path)
+      last_load_path = path
+      return {}
+    end,
+    write_state = function() end,
+    write_file = function() end,
+  }
+end
+
+local search_paths = {
+  -- repo root
+  "./plugin/?.lua",
+  "./plugin/?/init.lua",
+  "./plugin/?/?.lua",
+  -- when cwd is plugin/resurrect
+  "../../plugin/?.lua",
+  "../../plugin/?/init.lua",
+  "../../plugin/?/?.lua",
+}
+
+package.path = table.concat(search_paths, ";") .. ";" .. package.path
+
+local state_manager = require("resurrect.state_manager")
+
+local sep = is_windows() and "\\" or "/"
+local base = is_windows()
+  and ((os.getenv("TEMP") or os.getenv("TMP") or "C:\\Temp") .. "\\resurrect_sm_test")
+  or "/tmp/resurrect_sm_test"
+
+-- get_file_path is a local function and cannot be called directly.
+-- These tests exercise it via load_state(), which passes its return value
+-- straight to file_io.load_json() with no intervening transformation.
+describe("state_manager path construction (via load_state)", function()
+  before_each(function()
+    last_load_path = nil
+    state_manager.save_state_dir = base
+  end)
+
+  it("separates save_state_dir and type with a path separator", function()
+    state_manager.load_state("myworkspace", "workspace")
+    assert.equals(base .. sep .. "workspace" .. sep .. "myworkspace.json", last_load_path)
+  end)
+
+  it("replaces path separator characters in file names with +", function()
+    state_manager.load_state("foo" .. sep .. "bar", "workspace")
+    assert.equals(base .. sep .. "workspace" .. sep .. "foo+bar.json", last_load_path)
+  end)
+
+  it("replaces reserved characters : [ ] ? / in file names with +", function()
+    state_manager.load_state("name:with[reserved]chars?and/slashes", "window")
+    assert.equals(
+      base .. sep .. "window" .. sep .. "name+with+reserved+chars+and+slashes.json",
+      last_load_path
+    )
+  end)
+end)

--- a/plugin/resurrect/state_manager.lua
+++ b/plugin/resurrect/state_manager.lua
@@ -27,14 +27,26 @@ function pub.save_state(state, opt_name)
 	if state.window_states then
 		file_io.write_state(get_file_path(state.workspace, "workspace", opt_name), state, "workspace")
 		-- Always update current_state when saving a workspace so that
-		-- resurrect_on_gui_startup knows what to restore. Previously this
-		-- was only called from event_driven_save, which often never fired
-		-- before the user restarted WezTerm.
+		-- resurrect_on_gui_startup knows what to restore.
 		pub.write_current_state(state.workspace, "workspace")
 	elseif state.tabs then
 		file_io.write_state(get_file_path(state.title, "window", opt_name), state, "window")
 	elseif state.pane_tree then
 		file_io.write_state(get_file_path(state.title, "tab", opt_name), state, "tab")
+	end
+end
+
+--- Full workspace save: saves workspace state, current_state, and instance state.
+--- Single entry point for the complete save operation, used by periodic_save,
+--- event_driven_save, and the Alt+S keybinding to avoid duplication.
+function pub.save_workspace_full()
+	local workspace_state = require("resurrect.workspace_state").get_workspace_state()
+	pub.save_state(workspace_state)
+
+	-- Save per-instance state if instance manager is active
+	local im = require("resurrect.instance_manager")
+	if im.instance_id then
+		im.save_instance(workspace_state)
 	end
 end
 
@@ -66,9 +78,7 @@ function pub.periodic_save(opts)
 		local ok, err = pcall(function()
 			wezterm.emit("resurrect.state_manager.periodic_save.start", opts)
 			if opts.save_workspaces then
-				local workspace_state = require("resurrect.workspace_state").get_workspace_state()
-				pub.save_state(workspace_state)
-				pub.write_current_state(workspace_state.workspace, "workspace")
+				pub.save_workspace_full()
 			end
 
 			if opts.save_windows then
@@ -105,11 +115,6 @@ function pub.periodic_save(opts)
 end
 
 ---Saves the state whenever the pane or tab structure changes.
----More responsive than periodic_save: fires immediately on splits, new tabs,
----and closed panes rather than waiting for a timer.
----Also supports an optional user variable trigger for shell-reported events
----such as directory changes (requires shell integration to send the OSC 1337
----SetUserVar sequence; see the README for details).
 ---@param opts? { save_workspaces: boolean?, save_windows: boolean?, save_tabs: boolean?, user_var: string? }
 local _event_driven_save_registered = false
 function pub.event_driven_save(opts)
@@ -130,9 +135,7 @@ function pub.event_driven_save(opts)
 		wezterm.emit("resurrect.state_manager.event_driven_save.start", opts)
 
 		if opts.save_workspaces then
-			local workspace_state = require("resurrect.workspace_state").get_workspace_state()
-			pub.save_state(workspace_state)
-			pub.write_current_state(workspace_state.workspace, "workspace")
+			pub.save_workspace_full()
 		end
 
 		if opts.save_windows then
@@ -157,9 +160,7 @@ function pub.event_driven_save(opts)
 	end
 
 	-- Save shortly after startup using update-status, which fires reliably
-	-- within seconds of window creation (unlike pane-focus-changed which
-	-- requires user interaction). This ensures current_state is written
-	-- before the user restarts WezTerm.
+	-- within seconds of window creation.
 	local initial_save_done = false
 	wezterm.on("update-status", function(window, pane)
 		if not initial_save_done then
@@ -169,8 +170,6 @@ function pub.event_driven_save(opts)
 	end)
 
 	-- Save when the pane/tab structure changes (new split, new tab, closed pane).
-	-- pane-focus-changed fires on every focus move, so we compare tab+pane counts
-	-- and only save when the structure actually changes.
 	wezterm.on("pane-focus-changed", function(window, pane)
 		local win_id = tostring(window:window_id())
 		local tabs = window:mux_window():tabs()
@@ -186,8 +185,6 @@ function pub.event_driven_save(opts)
 	end)
 
 	-- Optional: also save when the shell reports a user-defined variable change.
-	-- Useful for saving on directory change. Example shell integration (zsh/bash):
-	--   precmd() { printf "\033]1337;SetUserVar=WEZTERM_SAVE=%s\007" "$(printf 1 | base64)"; }
 	if opts.user_var then
 		wezterm.on("user-var-changed", function(window, pane, name, value)
 			if name == opts.user_var then
@@ -204,8 +201,6 @@ end
 ---@return string|nil
 function pub.write_current_state(name, type)
 	local file_path = pub.save_state_dir .. utils.separator .. "current_state"
-	-- Write directly instead of using file_io.write_file's atomic rename,
-	-- which can fail silently on Windows for small metadata files.
 	local handle = io.open(file_path, "w")
 	if not handle then
 		wezterm.log_error("resurrect: could not open current_state for writing: " .. file_path)
@@ -269,7 +264,8 @@ function pub.delete_state(file_path)
 		wezterm.emit("resurrect.error", "Invalid path: only .json files can be deleted")
 		return
 	end
-	local path = pub.save_state_dir .. file_path
+	-- Use explicit separator to avoid path join fragility
+	local path = pub.save_state_dir .. utils.separator .. file_path
 	local success = os.remove(path)
 	if not success then
 		wezterm.emit("resurrect.error", "Failed to delete state: " .. path)
@@ -287,7 +283,7 @@ end
 ---Changes the directory to save the state to
 ---@param directory string
 function pub.change_state_save_dir(directory)
-	local types = { "workspace", "window", "tab" }
+	local types = { "workspace", "window", "tab", "instances" }
 	for _, type in ipairs(types) do
 		utils.ensure_folder_exists(directory .. utils.separator .. type)
 	end

--- a/plugin/resurrect/state_manager.lua
+++ b/plugin/resurrect/state_manager.lua
@@ -197,8 +197,17 @@ end
 ---@return string|nil
 function pub.write_current_state(name, type)
 	local file_path = pub.save_state_dir .. utils.separator .. "current_state"
-	local suc, err = file_io.write_file(file_path, string.format("%s\n%s", name, type))
-	return suc, err
+	-- Write directly instead of using file_io.write_file's atomic rename,
+	-- which can fail silently on Windows for small metadata files.
+	local handle = io.open(file_path, "w")
+	if not handle then
+		wezterm.log_error("resurrect: could not open current_state for writing: " .. file_path)
+		return false, "could not open file"
+	end
+	handle:write(string.format("%s\n%s", name, type))
+	handle:flush()
+	handle:close()
+	return true, nil
 end
 
 ---callback for resurrecting workspaces on startup

--- a/plugin/resurrect/state_manager.lua
+++ b/plugin/resurrect/state_manager.lua
@@ -13,10 +13,10 @@ local function get_file_path(file_name, type, opt_name)
 		file_name = opt_name
 	end
 	return string.format(
-		"%s%s" .. utils.separator .. "%s.json",
+		"%s" .. utils.separator .. "%s" .. utils.separator .. "%s.json",
 		pub.save_state_dir,
 		type,
-		file_name:gsub(utils.separator, "+")
+		file_name:gsub("[" .. utils.separator .. ":%[%]?/]", "+")
 	)
 end
 
@@ -88,6 +88,80 @@ function pub.periodic_save(opts)
 		wezterm.emit("resurrect.state_manager.periodic_save.finished", opts)
 		pub.periodic_save(opts)
 	end)
+end
+
+---Saves the state whenever the pane or tab structure changes.
+---More responsive than periodic_save: fires immediately on splits, new tabs,
+---and closed panes rather than waiting for a timer.
+---Also supports an optional user variable trigger for shell-reported events
+---such as directory changes (requires shell integration to send the OSC 1337
+---SetUserVar sequence; see the README for details).
+---@param opts? { save_workspaces: boolean?, save_windows: boolean?, save_tabs: boolean?, user_var: string? }
+function pub.event_driven_save(opts)
+	opts = opts or {}
+	if opts.save_workspaces == nil then
+		opts.save_workspaces = true
+	end
+
+	local last_structure = {}
+
+	local function do_save(window)
+		wezterm.emit("resurrect.state_manager.event_driven_save.start", opts)
+
+		if opts.save_workspaces then
+			local workspace_state = require("resurrect.workspace_state").get_workspace_state()
+			pub.save_state(workspace_state)
+			pub.write_current_state(workspace_state.workspace, "workspace")
+		end
+
+		if opts.save_windows then
+			local mux_win = window:mux_window()
+			local title = mux_win:get_title()
+			if title ~= "" and title ~= nil then
+				pub.save_state(require("resurrect.window_state").get_window_state(mux_win))
+			end
+		end
+
+		if opts.save_tabs then
+			local mux_win = window:mux_window()
+			for _, mux_tab in ipairs(mux_win:tabs()) do
+				local title = mux_tab:get_title()
+				if title ~= "" and title ~= nil then
+					pub.save_state(require("resurrect.tab_state").get_tab_state(mux_tab))
+				end
+			end
+		end
+
+		wezterm.emit("resurrect.state_manager.event_driven_save.finished", opts)
+	end
+
+	-- Save when the pane/tab structure changes (new split, new tab, closed pane).
+	-- pane-focus-changed fires on every focus move, so we compare tab+pane counts
+	-- and only save when the structure actually changes.
+	wezterm.on("pane-focus-changed", function(window, pane)
+		local win_id = tostring(window:window_id())
+		local tabs = window:mux_window():tabs()
+		local pane_count = 0
+		for _, tab in ipairs(tabs) do
+			pane_count = pane_count + #tab:panes()
+		end
+		local sig = #tabs .. ":" .. pane_count
+		if last_structure[win_id] ~= sig then
+			last_structure[win_id] = sig
+			do_save(window)
+		end
+	end)
+
+	-- Optional: also save when the shell reports a user-defined variable change.
+	-- Useful for saving on directory change. Example shell integration (zsh/bash):
+	--   precmd() { printf "\033]1337;SetUserVar=WEZTERM_SAVE=%s\007" "$(printf 1 | base64)"; }
+	if opts.user_var then
+		wezterm.on("user-var-changed", function(window, pane, name, value)
+			if name == opts.user_var then
+				do_save(window)
+			end
+		end)
+	end
 end
 
 ---Writes the current state name and type

--- a/plugin/resurrect/state_manager.lua
+++ b/plugin/resurrect/state_manager.lua
@@ -16,7 +16,7 @@ local function get_file_path(file_name, type, opt_name)
 		"%s" .. utils.separator .. "%s" .. utils.separator .. "%s.json",
 		pub.save_state_dir,
 		type,
-		file_name:gsub("[" .. utils.separator .. ":%[%]?/]", "+")
+		file_name:gsub("[" .. utils.separator .. ":%[%]?/*~!{}()&|;<>$`\"' \0]", "+")
 	)
 end
 
@@ -58,34 +58,41 @@ function pub.periodic_save(opts)
 		opts.interval_seconds = 60 * 15
 	end
 	wezterm.time.call_after(opts.interval_seconds, function()
-		wezterm.emit("resurrect.state_manager.periodic_save.start", opts)
-		if opts.save_workspaces then
-			pub.save_state(require("resurrect.workspace_state").get_workspace_state())
-		end
-
-		if opts.save_windows then
-			for _, gui_win in ipairs(wezterm.gui.gui_windows()) do
-				local mux_win = gui_win:mux_window()
-				local title = mux_win:get_title()
-				if title ~= "" and title ~= nil then
-					pub.save_state(require("resurrect.window_state").get_window_state(mux_win))
-				end
+		local ok, err = pcall(function()
+			wezterm.emit("resurrect.state_manager.periodic_save.start", opts)
+			if opts.save_workspaces then
+				pub.save_state(require("resurrect.workspace_state").get_workspace_state())
 			end
-		end
 
-		if opts.save_tabs then
-			for _, gui_win in ipairs(wezterm.gui.gui_windows()) do
-				local mux_win = gui_win:mux_window()
-				for _, mux_tab in ipairs(mux_win:tabs()) do
-					local title = mux_tab:get_title()
-					if title ~= "" and title ~= nil then
-						pub.save_state(require("resurrect.tab_state").get_tab_state(mux_tab))
+			if opts.save_windows then
+				for _, gui_win in ipairs(wezterm.gui.gui_windows()) do
+					local mux_win = gui_win:mux_window()
+					local title = mux_win:get_title()
+					if title and title ~= "" then
+						pub.save_state(require("resurrect.window_state").get_window_state(mux_win))
 					end
 				end
 			end
-		end
 
-		wezterm.emit("resurrect.state_manager.periodic_save.finished", opts)
+			if opts.save_tabs then
+				for _, gui_win in ipairs(wezterm.gui.gui_windows()) do
+					local mux_win = gui_win:mux_window()
+					for _, mux_tab in ipairs(mux_win:tabs()) do
+						local title = mux_tab:get_title()
+						if title and title ~= "" then
+							pub.save_state(require("resurrect.tab_state").get_tab_state(mux_tab))
+						end
+					end
+				end
+			end
+
+			wezterm.emit("resurrect.state_manager.periodic_save.finished", opts)
+		end)
+		if not ok then
+			wezterm.log_error("resurrect: periodic_save failed: " .. tostring(err))
+			wezterm.emit("resurrect.error", "periodic_save failed: " .. tostring(err))
+		end
+		-- Always re-schedule, even after errors
 		pub.periodic_save(opts)
 	end)
 end
@@ -97,7 +104,14 @@ end
 ---such as directory changes (requires shell integration to send the OSC 1337
 ---SetUserVar sequence; see the README for details).
 ---@param opts? { save_workspaces: boolean?, save_windows: boolean?, save_tabs: boolean?, user_var: string? }
+local _event_driven_save_registered = false
 function pub.event_driven_save(opts)
+	if _event_driven_save_registered then
+		wezterm.log_info("resurrect: event_driven_save already registered, skipping")
+		return
+	end
+	_event_driven_save_registered = true
+
 	opts = opts or {}
 	if opts.save_workspaces == nil then
 		opts.save_workspaces = true
@@ -186,10 +200,10 @@ function pub.resurrect_on_gui_startup()
 			error("Could not open file: " .. file_path)
 		end
 		local name = file:read("*line")
-		local type = file:read("*line")
+		local state_type = file:read("*line")
 		file:close()
-		if type == "workspace" then
-			require("resurrect.workspace_state").restore_workspace(pub.load_state(name, type), {
+		if state_type == "workspace" then
+			require("resurrect.workspace_state").restore_workspace(pub.load_state(name, state_type), {
 				spawn_in_workspace = true,
 				relative = true,
 				restore_text = true,
@@ -198,12 +212,22 @@ function pub.resurrect_on_gui_startup()
 			wezterm.mux.set_active_workspace(name)
 		end
 	end)
+	if not suc then
+		wezterm.log_error("resurrect: gui_startup restore failed: " .. tostring(err))
+		wezterm.emit("resurrect.error", "gui_startup restore failed: " .. tostring(err))
+	end
 	return suc, err
 end
 
 ---@param file_path string
 function pub.delete_state(file_path)
 	wezterm.emit("resurrect.state_manager.delete_state.start", file_path)
+	-- Path confinement: reject traversal attempts
+	if file_path:find("%.%.") then
+		wezterm.log_error("resurrect: delete_state rejected path with '..': " .. file_path)
+		wezterm.emit("resurrect.error", "Invalid path: directory traversal not allowed")
+		return
+	end
 	local path = pub.save_state_dir .. file_path
 	local success = os.remove(path)
 	if not success then
@@ -224,7 +248,7 @@ end
 function pub.change_state_save_dir(directory)
 	local types = { "workspace", "window", "tab" }
 	for _, type in ipairs(types) do
-		utils.ensure_folder_exists(directory .. "/" .. type)
+		utils.ensure_folder_exists(directory .. utils.separator .. type)
 	end
 	pub.save_state_dir = directory
 end

--- a/plugin/resurrect/state_manager.lua
+++ b/plugin/resurrect/state_manager.lua
@@ -26,6 +26,11 @@ end
 function pub.save_state(state, opt_name)
 	if state.window_states then
 		file_io.write_state(get_file_path(state.workspace, "workspace", opt_name), state, "workspace")
+		-- Always update current_state when saving a workspace so that
+		-- resurrect_on_gui_startup knows what to restore. Previously this
+		-- was only called from event_driven_save, which often never fired
+		-- before the user restarted WezTerm.
+		pub.write_current_state(state.workspace, "workspace")
 	elseif state.tabs then
 		file_io.write_state(get_file_path(state.title, "window", opt_name), state, "window")
 	elseif state.pane_tree then
@@ -151,10 +156,12 @@ function pub.event_driven_save(opts)
 		wezterm.emit("resurrect.state_manager.event_driven_save.finished", opts)
 	end
 
-	-- Save on first pane focus after startup (ensures current_state is written
-	-- even if the pane structure never changes during the session).
+	-- Save shortly after startup using update-status, which fires reliably
+	-- within seconds of window creation (unlike pane-focus-changed which
+	-- requires user interaction). This ensures current_state is written
+	-- before the user restarts WezTerm.
 	local initial_save_done = false
-	wezterm.on("pane-focus-changed", function(window, pane)
+	wezterm.on("update-status", function(window, pane)
 		if not initial_save_done then
 			initial_save_done = true
 			do_save(window)

--- a/plugin/resurrect/state_manager.lua
+++ b/plugin/resurrect/state_manager.lua
@@ -250,10 +250,23 @@ end
 ---@param file_path string
 function pub.delete_state(file_path)
 	wezterm.emit("resurrect.state_manager.delete_state.start", file_path)
-	-- Path confinement: reject traversal attempts
+	-- Path confinement: reject traversal attempts, absolute paths, and
+	-- non-JSON files to prevent arbitrary file deletion.
 	if file_path:find("%.%.") then
 		wezterm.log_error("resurrect: delete_state rejected path with '..': " .. file_path)
 		wezterm.emit("resurrect.error", "Invalid path: directory traversal not allowed")
+		return
+	end
+	-- Reject absolute paths (Unix /... or Windows C:\...)
+	if file_path:match("^[/\\]") or file_path:match("^%a:") then
+		wezterm.log_error("resurrect: delete_state rejected absolute path: " .. file_path)
+		wezterm.emit("resurrect.error", "Invalid path: absolute paths not allowed")
+		return
+	end
+	-- Only allow deleting .json state files
+	if not file_path:match("%.json$") then
+		wezterm.log_error("resurrect: delete_state rejected non-JSON path: " .. file_path)
+		wezterm.emit("resurrect.error", "Invalid path: only .json files can be deleted")
 		return
 	end
 	local path = pub.save_state_dir .. file_path

--- a/plugin/resurrect/state_manager.lua
+++ b/plugin/resurrect/state_manager.lua
@@ -61,7 +61,9 @@ function pub.periodic_save(opts)
 		local ok, err = pcall(function()
 			wezterm.emit("resurrect.state_manager.periodic_save.start", opts)
 			if opts.save_workspaces then
-				pub.save_state(require("resurrect.workspace_state").get_workspace_state())
+				local workspace_state = require("resurrect.workspace_state").get_workspace_state()
+				pub.save_state(workspace_state)
+				pub.write_current_state(workspace_state.workspace, "workspace")
 			end
 
 			if opts.save_windows then
@@ -148,6 +150,16 @@ function pub.event_driven_save(opts)
 
 		wezterm.emit("resurrect.state_manager.event_driven_save.finished", opts)
 	end
+
+	-- Save on first pane focus after startup (ensures current_state is written
+	-- even if the pane structure never changes during the session).
+	local initial_save_done = false
+	wezterm.on("pane-focus-changed", function(window, pane)
+		if not initial_save_done then
+			initial_save_done = true
+			do_save(window)
+		end
+	end)
 
 	-- Save when the pane/tab structure changes (new split, new tab, closed pane).
 	-- pane-focus-changed fires on every focus move, so we compare tab+pane counts

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -172,8 +172,10 @@ pub.process_restore_delay_seconds = 3
 function pub.default_on_pane_restore(pane_tree)
 	local pane = pane_tree.pane
 
-	-- Spawn process if using alt screen, otherwise restore text
-	if pane_tree.alt_screen_active and pane_tree.process and pane_tree.process.argv then
+	-- Spawn process if process info was saved (alt screen OR registered handler),
+	-- otherwise restore scrollback text. Some TUI apps (e.g., Claude Code) don't
+	-- use the alt screen buffer but still need process-based restoration.
+	if pane_tree.process and pane_tree.process.argv then
 		-- Check registered process handlers first (e.g., Claude Code)
 		local restore_cmd = process_handlers.get_restore_command(pane_tree.process, pane_tree)
 		if not restore_cmd then

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -1,5 +1,6 @@
 local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
 local pane_tree_mod = require("resurrect.pane_tree")
+local state_manager_mod = require("resurrect.state_manager")
 local pub = {}
 
 ---Function used to split panes when mapping over the pane_tree
@@ -121,7 +122,6 @@ end
 
 function pub.save_tab_action()
 	return wezterm.action_callback(function(win, pane)
-		local resurrect = require("resurrect")
 		local tab = pane:tab()
 		if tab:get_title() == "" then
 			win:perform_action(
@@ -131,7 +131,7 @@ function pub.save_tab_action()
 						if title then
 							callback_pane:tab():set_title(title)
 							local state = pub.get_tab_state(tab)
-							resurrect.save_state(state)
+							state_manager_mod.save_state(state)
 						end
 					end),
 				}),
@@ -139,7 +139,7 @@ function pub.save_tab_action()
 			)
 		elseif tab:get_title() then
 			local state = pub.get_tab_state(tab)
-			resurrect.state_manager.save_state(state)
+			state_manager_mod.save_state(state)
 		end
 	end)
 end

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -161,6 +161,12 @@ local SAFE_RESTORE_PROCESSES = {
 	tmux = true, screen = true,
 }
 
+-- Delay in seconds before sending process restore commands.
+-- Shell interpreters (especially PowerShell on Windows) need time to initialize
+-- before they can accept input. Without this delay, commands sent during
+-- gui-startup get swallowed by the shell's init sequence.
+pub.process_restore_delay_seconds = 3
+
 --- Function to restore text or processes when restoring panes
 ---@param pane_tree pane_tree
 function pub.default_on_pane_restore(pane_tree)
@@ -170,22 +176,33 @@ function pub.default_on_pane_restore(pane_tree)
 	if pane_tree.alt_screen_active and pane_tree.process and pane_tree.process.argv then
 		-- Check registered process handlers first (e.g., Claude Code)
 		local restore_cmd = process_handlers.get_restore_command(pane_tree.process, pane_tree)
-		if restore_cmd then
-			pane:send_text(restore_cmd .. "\r\n")
-		else
+		if not restore_cmd then
 			-- Fall back to allowlist-based argv replay
 			local proc_name = pane_tree.process.name or ""
 			local base_name = proc_name:match("[/\\]?([^/\\]+)$") or proc_name
 			base_name = base_name:gsub("%.exe$", ""):lower()
 
 			if SAFE_RESTORE_PROCESSES[base_name] then
-				pane:send_text(wezterm.shell_join_args(pane_tree.process.argv) .. "\r\n")
+				restore_cmd = wezterm.shell_join_args(pane_tree.process.argv)
 			else
 				wezterm.log_warn(
 					"resurrect: skipping restore of unrecognized process: " .. base_name
 						.. " (add to SAFE_RESTORE_PROCESSES or register a process_handler)"
 				)
 			end
+		end
+
+		if restore_cmd then
+			-- Delay sending the command so the shell has time to initialize.
+			-- pane:send_text() during gui-startup fires before the shell is ready,
+			-- causing the command to be lost (especially on Windows with PowerShell).
+			local pane_id = pane:pane_id()
+			wezterm.time.call_after(pub.process_restore_delay_seconds, function()
+				local target_pane = wezterm.mux.get_pane(pane_id)
+				if target_pane then
+					target_pane:send_text(restore_cmd .. "\r\n")
+				end
+			end)
 		end
 	elseif pane_tree.text then
 		pane:inject_output(pane_tree.text:gsub("%s+$", ""))

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -98,6 +98,10 @@ function pub.restore_tab(tab, tab_state, opts)
 	wezterm.emit("resurrect.tab_state.restore_tab.start")
 	if opts.pane then
 		tab_state.pane_tree.pane = opts.pane
+		-- Set the CWD of the reused pane to match saved state
+		if tab_state.pane_tree.cwd and tab_state.pane_tree.cwd ~= "" then
+			opts.pane:send_text("cd " .. wezterm.shell_join_args({ tab_state.pane_tree.cwd }) .. "\r\n")
+		end
 	else
 		local split_args = { cwd = tab_state.pane_tree.cwd }
 		if tab_state.pane_tree.domain then
@@ -144,16 +148,42 @@ function pub.save_tab_action()
 	end)
 end
 
+-- Known safe executables that can be restored via send_text.
+-- Process names not in this set will be logged but not auto-launched,
+-- preventing arbitrary command execution from tampered state files.
+local SAFE_RESTORE_PROCESSES = {
+	vim = true, nvim = true, gvim = true, vi = true,
+	htop = true, btop = true, top = true,
+	less = true, more = true, man = true,
+	claude = true,
+	nano = true,
+	tmux = true, screen = true,
+}
+
 --- Function to restore text or processes when restoring panes
 ---@param pane_tree pane_tree
 function pub.default_on_pane_restore(pane_tree)
 	local pane = pane_tree.pane
 
 	-- Spawn process if using alt screen, otherwise restore text
-	if pane_tree.alt_screen_active then
-		pane:send_text(wezterm.shell_join_args(pane_tree.process.argv) .. "\r\n")
+	if pane_tree.alt_screen_active and pane_tree.process and pane_tree.process.argv then
+		local proc_name = pane_tree.process.name or ""
+		-- Extract base name without path
+		local base_name = proc_name:match("[/\\]?([^/\\]+)$") or proc_name
+		base_name = base_name:gsub("%.exe$", ""):lower()
+
+		if SAFE_RESTORE_PROCESSES[base_name] then
+			pane:send_text(wezterm.shell_join_args(pane_tree.process.argv) .. "\r\n")
+		else
+			wezterm.log_warn(
+				"resurrect: skipping restore of unrecognized process: " .. base_name
+				.. " (add to SAFE_RESTORE_PROCESSES if intended)"
+			)
+		end
 	elseif pane_tree.text then
 		pane:inject_output(pane_tree.text:gsub("%s+$", ""))
+		-- Send newline to trigger a fresh shell prompt at the correct position
+		pane:send_text("\r\n")
 	end
 end
 

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -1,6 +1,7 @@
 local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
 local pane_tree_mod = require("resurrect.pane_tree")
 local state_manager_mod = require("resurrect.state_manager")
+local process_handlers = require("resurrect.process_handlers")
 local pub = {}
 
 ---Function used to split panes when mapping over the pane_tree
@@ -167,18 +168,24 @@ function pub.default_on_pane_restore(pane_tree)
 
 	-- Spawn process if using alt screen, otherwise restore text
 	if pane_tree.alt_screen_active and pane_tree.process and pane_tree.process.argv then
-		local proc_name = pane_tree.process.name or ""
-		-- Extract base name without path
-		local base_name = proc_name:match("[/\\]?([^/\\]+)$") or proc_name
-		base_name = base_name:gsub("%.exe$", ""):lower()
-
-		if SAFE_RESTORE_PROCESSES[base_name] then
-			pane:send_text(wezterm.shell_join_args(pane_tree.process.argv) .. "\r\n")
+		-- Check registered process handlers first (e.g., Claude Code)
+		local restore_cmd = process_handlers.get_restore_command(pane_tree.process, pane_tree)
+		if restore_cmd then
+			pane:send_text(restore_cmd .. "\r\n")
 		else
-			wezterm.log_warn(
-				"resurrect: skipping restore of unrecognized process: " .. base_name
-				.. " (add to SAFE_RESTORE_PROCESSES if intended)"
-			)
+			-- Fall back to allowlist-based argv replay
+			local proc_name = pane_tree.process.name or ""
+			local base_name = proc_name:match("[/\\]?([^/\\]+)$") or proc_name
+			base_name = base_name:gsub("%.exe$", ""):lower()
+
+			if SAFE_RESTORE_PROCESSES[base_name] then
+				pane:send_text(wezterm.shell_join_args(pane_tree.process.argv) .. "\r\n")
+			else
+				wezterm.log_warn(
+					"resurrect: skipping restore of unrecognized process: " .. base_name
+						.. " (add to SAFE_RESTORE_PROCESSES or register a process_handler)"
+				)
+			end
 		end
 	elseif pane_tree.text then
 		pane:inject_output(pane_tree.text:gsub("%s+$", ""))

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -2,25 +2,12 @@ local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes 
 local pane_tree_mod = require("resurrect.pane_tree")
 local state_manager_mod = require("resurrect.state_manager")
 local process_handlers = require("resurrect.process_handlers")
+local utils = require("resurrect.utils")
 local pub = {}
 
--- Characters that could enable command injection when a CWD is sent to
--- a shell via send_text("cd <cwd>\r\n"). Even with shell_join_args quoting,
--- different shells handle these differently, so we reject them outright.
-local UNSAFE_CWD_PATTERN = "[;&|`$%(%)%{%}]"
-
--- Validate that a CWD path is safe to send as a shell command.
----@param cwd string
----@return boolean
-local function is_safe_cwd(cwd)
-	if not cwd or cwd == "" then
-		return false
-	end
-	if cwd:find(UNSAFE_CWD_PATTERN) then
-		return false
-	end
-	return true
-end
+-- Use shared CWD validation from utils to prevent command injection
+-- when sending cd commands via send_text().
+local is_safe_cwd = utils.is_safe_cwd
 
 ---Function used to split panes when mapping over the pane_tree
 ---@param opts restore_opts

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -4,6 +4,24 @@ local state_manager_mod = require("resurrect.state_manager")
 local process_handlers = require("resurrect.process_handlers")
 local pub = {}
 
+-- Characters that could enable command injection when a CWD is sent to
+-- a shell via send_text("cd <cwd>\r\n"). Even with shell_join_args quoting,
+-- different shells handle these differently, so we reject them outright.
+local UNSAFE_CWD_PATTERN = "[;&|`$%(%)%{%}]"
+
+-- Validate that a CWD path is safe to send as a shell command.
+---@param cwd string
+---@return boolean
+local function is_safe_cwd(cwd)
+	if not cwd or cwd == "" then
+		return false
+	end
+	if cwd:find(UNSAFE_CWD_PATTERN) then
+		return false
+	end
+	return true
+end
+
 ---Function used to split panes when mapping over the pane_tree
 ---@param opts restore_opts
 ---@return fun(acc: {active_pane: Pane, is_zoomed: boolean}, pane_tree: pane_tree): {active_pane: Pane, is_zoomed: boolean}
@@ -99,9 +117,13 @@ function pub.restore_tab(tab, tab_state, opts)
 	wezterm.emit("resurrect.tab_state.restore_tab.start")
 	if opts.pane then
 		tab_state.pane_tree.pane = opts.pane
-		-- Set the CWD of the reused pane to match saved state
-		if tab_state.pane_tree.cwd and tab_state.pane_tree.cwd ~= "" then
+		-- Set the CWD of the reused pane to match saved state.
+		-- Validate the CWD contains no shell metacharacters to prevent
+		-- command injection via tampered state files.
+		if is_safe_cwd(tab_state.pane_tree.cwd) then
 			opts.pane:send_text("cd " .. wezterm.shell_join_args({ tab_state.pane_tree.cwd }) .. "\r\n")
+		elseif tab_state.pane_tree.cwd and tab_state.pane_tree.cwd ~= "" then
+			wezterm.log_error("resurrect: rejected suspicious CWD: " .. tab_state.pane_tree.cwd)
 		end
 	else
 		local split_args = { cwd = tab_state.pane_tree.cwd }
@@ -121,7 +143,9 @@ function pub.restore_tab(tab, tab_state, opts)
 	end
 
 	local acc = pane_tree_mod.fold(tab_state.pane_tree, { is_zoomed = false }, make_splits(opts))
-	acc.active_pane:activate()
+	if acc.active_pane then
+		acc.active_pane:activate()
+	end
 	wezterm.emit("resurrect.tab_state.restore_tab.finished")
 end
 

--- a/plugin/resurrect/utils.lua
+++ b/plugin/resurrect/utils.lua
@@ -72,18 +72,20 @@ function utils.execute(cmd)
 end
 
 -- Shell-safe wrapper around mkdir for a single already-assembled path segment.
--- Uses wezterm.run_child_process instead of os.execute to avoid visible
--- cmd.exe window flashes on Windows (fixes #125).
+-- Uses os.execute because this runs during plugin init where
+-- wezterm.run_child_process is forbidden (yields across C-call boundary).
 local function shell_mkdir(path)
 	if utils.is_windows then
 		if path:find('"') then
 			return false
 		end
-		local success, _, _ = wezterm.run_child_process({ "cmd.exe", "/c", "mkdir", path })
-		return success
+		-- Use os.execute; the >nul suppresses output. A brief cmd.exe flash
+		-- may occur on first run only (dirs persist across restarts).
+		os.execute('cmd /c mkdir "' .. path .. '" >nul 2>nul')
+		return true
 	else
-		local success, _, _ = wezterm.run_child_process({ "mkdir", path })
-		return success
+		os.execute('mkdir -p "' .. path .. '" 2>/dev/null')
+		return true
 	end
 end
 

--- a/plugin/resurrect/utils.lua
+++ b/plugin/resurrect/utils.lua
@@ -44,27 +44,30 @@ function utils.utf8len(str)
 	return len
 end
 
--- Execute a cmd and return its stdout
+-- Execute a command array and return its stdout.
+-- Uses wezterm.run_child_process to avoid shell injection and cmd.exe flashes.
+---@param cmd_args string[] array of command and arguments
+---@return boolean success result
+---@return string|nil output
+function utils.exec(cmd_args)
+	local success, stdout, stderr = wezterm.run_child_process(cmd_args)
+	if success then
+		return true, stdout
+	else
+		return false, stderr or "Command failed"
+	end
+end
+
+-- Legacy wrapper: execute a shell command string via sh -c (Unix) or cmd /c (Windows).
+-- Prefer utils.exec() with argument arrays for new code.
 ---@param cmd string command
 ---@return boolean success result
 ---@return string|nil error
 function utils.execute(cmd)
-	local stdout
-	local suc, err = pcall(function()
-		local handle = io.popen(cmd)
-		if not handle then
-			error("Could not open process: " .. cmd)
-		end
-		stdout = handle:read("*a")
-		if stdout == nil then
-			error("Error running process: " .. cmd)
-		end
-		handle:close()
-	end)
-	if suc then
-		return suc, stdout
+	if utils.is_windows then
+		return utils.exec({ "cmd.exe", "/c", cmd })
 	else
-		return suc, err
+		return utils.exec({ "sh", "-c", cmd })
 	end
 end
 
@@ -79,8 +82,7 @@ local function shell_mkdir(path)
 		local success, _, _ = wezterm.run_child_process({ "cmd.exe", "/c", "mkdir", path })
 		return success
 	else
-		local quoted = "'" .. path:gsub("'", "'\\''") .. "'"
-		local success, _, _ = wezterm.run_child_process({ "sh", "-c", "mkdir " .. quoted })
+		local success, _, _ = wezterm.run_child_process({ "mkdir", path })
 		return success
 	end
 end

--- a/plugin/resurrect/utils.lua
+++ b/plugin/resurrect/utils.lua
@@ -84,6 +84,9 @@ local function shell_mkdir(path)
 		os.execute('cmd /c mkdir "' .. path .. '" >nul 2>nul')
 		return true
 	else
+		if path:find('["%$`\n;|&()]') then
+			return false
+		end
 		os.execute('mkdir -p "' .. path .. '" 2>/dev/null')
 		return true
 	end

--- a/plugin/resurrect/utils.lua
+++ b/plugin/resurrect/utils.lua
@@ -68,14 +68,128 @@ function utils.execute(cmd)
 	end
 end
 
--- Create the folder if it does not exist
----@param path string
-function utils.ensure_folder_exists(path)
+-- Shell-safe wrapper around mkdir for a single already-assembled path segment.
+-- Uses wezterm.run_child_process instead of os.execute to avoid visible
+-- cmd.exe window flashes on Windows (fixes #125).
+local function shell_mkdir(path)
 	if utils.is_windows then
-		os.execute('mkdir /p "' .. path:gsub("/", "\\" .. '"'))
+		if path:find('"') then
+			return false
+		end
+		local success, _, _ = wezterm.run_child_process({ "cmd.exe", "/c", "mkdir", path })
+		return success
 	else
-		os.execute('mkdir -p "' .. path .. '"')
+		local quoted = "'" .. path:gsub("'", "'\\''") .. "'"
+		local success, _, _ = wezterm.run_child_process({ "sh", "-c", "mkdir " .. quoted })
+		return success
 	end
+end
+
+-- Normalise separators and strip the root prefix from path.
+-- Returns the platform separator, the root component (e.g. "C:\", "/", "\\"),
+-- and the remaining path with the root removed.
+-- On Windows forward slashes are converted to backslashes before parsing.
+---@param path string
+---@return string sep, string root, string stripped
+local function parse_root(path)
+	local sep
+	if utils.is_windows then
+		sep = "\\"
+		path = path:gsub("/", sep)
+	else
+		sep = "/"
+	end
+
+	local root = ""
+	if utils.is_windows then
+		local drive = path:match("^(%a:)[/\\]")
+		if drive then
+			-- Absolute path (e.g. C:\foo): capture "C:", append sep to form "C:\",
+			-- then strip the 3-char prefix so the remainder is "foo\...".
+			root = drive .. sep
+			path = path:sub(4)
+		elseif path:match("^%a:[^/\\]") then
+			-- Drive-relative path (e.g. C:foo); normalise to absolute from drive root.
+			-- Strip the 2-char "C:" prefix; root gets the explicit separator added.
+			root = path:sub(1, 2) .. sep
+			path = path:sub(3)
+		elseif path:sub(1, 2) == "\\\\" then
+			-- UNC path (e.g. \\server\share\...): strip the 2-char "\\" prefix.
+			-- The server and share components cannot be created via mkdir;
+			-- this only works when the share already exists.
+			root = "\\\\"
+			path = path:sub(3)
+		end
+	else
+		if path:sub(1, 1) == "/" then
+			-- Absolute Unix path: strip the leading separator; root is "/".
+			root = "/"
+			path = path:sub(2)
+		end
+	end
+
+	return sep, root, path
+end
+
+-- Probe-write check: attempts to create and immediately remove a temp file
+-- inside path. More reliable than os.rename on Windows, where open handles
+-- held by WezTerm itself cause os.rename(dir, dir) to return nil even when
+-- the directory exists and is fully usable.
+-- A unique suffix from tostring({}) (table address) avoids collisions across
+-- concurrent processes or calls.
+local function dir_is_accessible(path)
+	local probe = path .. utils.separator .. ".resurrect_probe_" .. tostring({}):gsub("[^%w]", "")
+	local f = io.open(probe, "w")
+	if f then
+		f:close()
+		os.remove(probe)
+		return true
+	end
+	return false
+end
+
+-- Ensure a single already-assembled path exists, creating it if necessary.
+-- Returns false if the directory could not be created or verified.
+---@param path string
+---@return boolean
+local function mkdir_if_missing(path)
+	-- Probe-write is the primary existence check. os.rename is skipped because
+	-- it gives false negatives on Windows when WezTerm holds open handles,
+	-- which would cause shell_mkdir to be called on every startup for
+	-- directories that already exist, producing visible cmd.exe window flashes.
+	if dir_is_accessible(path) then
+		return true
+	end
+	if shell_mkdir(path) then
+		-- Post-verify: confirm the directory is actually usable after creation.
+		return dir_is_accessible(path)
+	end
+	return false
+end
+
+-- Create the folder if it does not exist.
+-- Drive-relative paths on Windows (e.g. C:foo\bar) are normalised to absolute
+-- from the drive root (C:\foo\bar). UNC paths (\\server\share\...) are
+-- supported only when the server and share components already exist.
+-- Path components are not sanitized; . and .. segments produce undefined behavior.
+---@param path string
+---@return boolean success
+function utils.ensure_folder_exists(path)
+	local sep, root, stripped = parse_root(path)
+	local current = root
+	for part in string.gmatch(stripped, "[^" .. sep .. "]+") do
+		if current == "" then
+			current = part
+		elseif current:sub(-1) == sep then
+			current = current .. part
+		else
+			current = current .. sep .. part
+		end
+		if not mkdir_if_missing(current) then
+			return false
+		end
+	end
+	return true
 end
 
 -- deep copy

--- a/plugin/resurrect/utils.lua
+++ b/plugin/resurrect/utils.lua
@@ -199,6 +199,24 @@ function utils.ensure_folder_exists(path)
 	return true
 end
 
+-- Characters that could enable command injection when a CWD is embedded in
+-- a shell command via send_text(). Blocks shell metacharacters plus \r\n
+-- (a newline in a path from a tampered state file could inject commands).
+utils.UNSAFE_CWD_PATTERN = "[;&|`$%(%)%{%}\r\n]"
+
+-- Validate that a CWD path is safe to embed in a shell command.
+---@param cwd string
+---@return boolean
+function utils.is_safe_cwd(cwd)
+	if not cwd or cwd == "" then
+		return false
+	end
+	if cwd:find(utils.UNSAFE_CWD_PATTERN) then
+		return false
+	end
+	return true
+end
+
 -- deep copy
 ---@param original table
 ---@return any copy

--- a/plugin/resurrect/window_state.lua
+++ b/plugin/resurrect/window_state.lua
@@ -81,13 +81,14 @@ function pub.restore_window(window, window_state, opts)
 		end
 	end
 
-	active_tab:activate()
+	if active_tab then
+		active_tab:activate()
+	end
 	wezterm.emit("resurrect.window_state.restore_window.finished")
 end
 
 function pub.save_window_action()
 	return wezterm.action_callback(function(win, pane)
-		local resurrect = require("resurrect")
 		local mux_win = win:mux_window()
 		if mux_win:get_title() == "" then
 			win:perform_action(

--- a/plugin/resurrect/window_state.lua
+++ b/plugin/resurrect/window_state.lua
@@ -1,6 +1,8 @@
 local wezterm = require("wezterm") --[[@as Wezterm]] --- this type cast invokes the LSP module for Wezterm
 local tab_state_mod = require("resurrect.tab_state")
+local state_manager_mod = require("resurrect.state_manager")
 local pub = {}
+
 
 ---Returns the state of the window
 ---@param window MuxWindow
@@ -95,7 +97,7 @@ function pub.save_window_action()
 						if title then
 							window:mux_window():set_title(title)
 							local state = pub.get_window_state(mux_win)
-							resurrect.save_state(state)
+							state_manager_mod.save_state(state)
 						end
 					end),
 				}),
@@ -103,7 +105,7 @@ function pub.save_window_action()
 			)
 		elseif mux_win:get_title() then
 			local state = pub.get_window_state(mux_win)
-			resurrect.save_state(state)
+			state_manager_mod.save_state(state)
 		end
 	end)
 end

--- a/plugin/resurrect/workspace_state.lua
+++ b/plugin/resurrect/workspace_state.lua
@@ -42,6 +42,11 @@ function pub.restore_workspace(workspace_state, opts)
 
 		window_state_mod.restore_window(opts.window, window_state, opts)
 	end
+	if opts.spawn_in_workspace then
+		wezterm.mux.set_active_workspace(workspace_state.workspace)
+	else
+		wezterm.mux.rename_workspace(wezterm.mux.get_active_workspace(), workspace_state.workspace)
+	end
 	wezterm.emit("resurrect.workspace_state.restore_workspace.finished")
 end
 

--- a/test_debug/verify.sh
+++ b/test_debug/verify.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# verify.sh -- Run luacheck static analysis and busted unit tests
+# for the wezterm-resurrect plugin.
+#
+# Exit codes:
+#   0  All checks passed
+#   1  One or more checks failed
+#
+# Usage:
+#   bash test_debug/verify.sh          # Run from repo root
+#   bash test_debug/verify.sh --lint   # Luacheck only
+#   bash test_debug/verify.sh --test   # Busted tests only
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Paths (portable: works from repo root on Windows Git Bash / MSYS2)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TOOLS_DIR="$SCRIPT_DIR/tools"
+
+LUACHECK="$TOOLS_DIR/luacheck.exe"
+LUA54="$TOOLS_DIR/lua54.exe"
+
+# Luarocks systree where busted and its dependencies live
+SYSTREE="C:/ProgramData/chocolatey/lib/luarocks/luarocks-2.4.4-win32/systree"
+BUSTED_SCRIPT="$SYSTREE/lib/luarocks/rocks/busted/2.3.0-1/bin/busted"
+
+# ---------------------------------------------------------------------------
+# Mode selection
+# ---------------------------------------------------------------------------
+RUN_LINT=true
+RUN_TEST=true
+
+if [[ "${1:-}" == "--lint" ]]; then
+    RUN_LINT=true
+    RUN_TEST=false
+elif [[ "${1:-}" == "--test" ]]; then
+    RUN_LINT=false
+    RUN_TEST=true
+fi
+
+FAILURES=0
+
+# ---------------------------------------------------------------------------
+# Luacheck: static analysis
+# ---------------------------------------------------------------------------
+if $RUN_LINT; then
+    echo "========================================"
+    echo "  LUACHECK -- Static Analysis"
+    echo "========================================"
+
+    if [[ ! -f "$LUACHECK" ]]; then
+        echo "SKIP: luacheck not found at $LUACHECK"
+        FAILURES=$((FAILURES + 1))
+    else
+        cd "$REPO_ROOT"
+
+        # Collect .lua files using relative paths (luacheck on Windows
+        # has issues with absolute config paths, so we run from repo root)
+        LUA_FILES=()
+        while IFS= read -r -d '' f; do
+            LUA_FILES+=("$f")
+        done < <(find plugin -name '*.lua' -print0 2>/dev/null)
+
+        if [[ ${#LUA_FILES[@]} -eq 0 ]]; then
+            echo "WARN: No .lua files found under plugin/"
+        else
+            echo "Checking ${#LUA_FILES[@]} Lua files..."
+            echo ""
+            "$LUACHECK" --config .luacheckrc "${LUA_FILES[@]}"
+            LUACHECK_EXIT=$?
+
+            echo ""
+            # luacheck exit codes: 0=clean, 1=warnings only, 2=errors
+            if [[ $LUACHECK_EXIT -eq 0 ]]; then
+                echo "LUACHECK: PASSED (no warnings)"
+            elif [[ $LUACHECK_EXIT -eq 1 ]]; then
+                echo "LUACHECK: PASSED (warnings only -- no errors)"
+            else
+                echo "LUACHECK: FAILED (errors found)"
+                FAILURES=$((FAILURES + 1))
+            fi
+        fi
+    fi
+    echo ""
+fi
+
+# ---------------------------------------------------------------------------
+# Busted: unit tests
+# ---------------------------------------------------------------------------
+if $RUN_TEST; then
+    echo "========================================"
+    echo "  BUSTED -- Unit Tests"
+    echo "========================================"
+
+    cd "$REPO_ROOT"
+
+    # Locate spec files
+    SPEC_DIR="$REPO_ROOT/plugin/resurrect/spec"
+    SPEC_COUNT=$(find "$SPEC_DIR" -name '*_spec.lua' 2>/dev/null | wc -l)
+
+    if [[ "$SPEC_COUNT" -eq 0 ]]; then
+        echo "SKIP: No spec files found in $SPEC_DIR"
+    elif [[ ! -f "$LUA54" ]]; then
+        echo "SKIP: lua54 not found at $LUA54"
+        FAILURES=$((FAILURES + 1))
+    elif [[ ! -f "$BUSTED_SCRIPT" ]]; then
+        echo "SKIP: busted not found at $BUSTED_SCRIPT"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "Running $SPEC_COUNT spec file(s)..."
+        echo ""
+
+        export LUA_PATH="$SYSTREE/share/lua/5.1/?.lua;$SYSTREE/share/lua/5.1/?/init.lua;;"
+
+        # Pass relative spec path -- busted resolves it from CWD
+        "$LUA54" "$BUSTED_SCRIPT" -o plainTerminal "plugin\\resurrect\\spec"
+        BUSTED_EXIT=$?
+
+        echo ""
+        if [[ $BUSTED_EXIT -eq 0 ]]; then
+            echo "BUSTED: PASSED"
+        else
+            echo "BUSTED: FAILED (exit code $BUSTED_EXIT)"
+            FAILURES=$((FAILURES + 1))
+        fi
+    fi
+    echo ""
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo "========================================"
+if [[ $FAILURES -eq 0 ]]; then
+    echo "  RESULT: ALL CHECKS PASSED"
+else
+    echo "  RESULT: $FAILURES CHECK(S) FAILED"
+fi
+echo "========================================"
+
+exit $FAILURES


### PR DESCRIPTION
## Summary
- Claude Code requires being launched from the original working directory for proper context loading and session restoration (`--resume` needs the correct CWD to load project context, CLAUDE.md files, etc.)
- Previously, the restore command sent only `claude --resume <uuid>` without changing directories first, causing sessions to start from `~` (the shell's default)
- Now prepends `cd <saved_cwd>` as a separate line before the resume command

## Details

**Cross-shell compatibility**: Uses `\r\n` (newline) between the `cd` and `claude` commands instead of `&&`, because PowerShell 5.x (Windows PowerShell) does not support `&&`. This works in bash, zsh, cmd.exe, PowerShell 5.x, and PowerShell 7+.

**Security**: CWD is validated with the same `UNSAFE_CWD_PATTERN` used in `tab_state.lua` to prevent command injection via tampered state files. Unsafe CWDs are logged and skipped.

**CWD source priority**: Uses `process_info.cwd` (the foreground process's directory at save time), falling back to `pane_tree.cwd` (the pane's directory).

## Test plan
- [ ] Save a WezTerm session with Claude Code running in a specific project directory
- [ ] Close and restore WezTerm
- [ ] Verify Claude resumes in the correct directory (not `~`)
- [ ] Test with both bash and PowerShell as the default shell
- [ ] Test with paths containing spaces (e.g., `project-monopoly Worktrees`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)