### PR TITLE
Fix silent crash when pane:get_foreground_process_info returns nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,3 @@ luac.out
 *.i*86
 *.x86_64
 *.hex
-
-.luarc.json

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ luac.out
 *.x86_64
 *.hex
 
+.luarc.json

--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -99,10 +99,10 @@ local function insert_panes(root, panes)
 			if root.alt_screen_active then
 				local process_info = root.pane:get_foreground_process_info()
 				if process_info ~= nil then
-          process_info.children = nil
-          process_info.pid = nil
-          process_info.ppid = nil
-        end
+					process_info.children = nil
+					process_info.pid = nil
+					process_info.ppid = nil
+				end
 				root.process = process_info
 				root.proc_name = root.pane:get_foreground_process_name()
 			else

--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -8,7 +8,7 @@ pub.max_nlines = 3500
 
 ---@alias Pane any
 ---@alias PaneInformation {left: integer, top: integer, height: integer, width: integer}
----@alias pane_tree {left: integer, top: integer, height: integer, width: integer, bottom: pane_tree?, right: pane_tree?, text: string, cwd: string, domain?: string, process?: local_process_info?, pane: Pane?, is_active: boolean, is_zoomed: boolean, alt_screen_active: boolean}
+---@alias pane_tree {left: integer, top: integer, height: integer, width: integer, bottom: pane_tree?, right: pane_tree?, text: string, cwd: string, domain?: string, process?: local_process_info?, pane: Pane?, is_active: boolean, is_zoomed: boolean, alt_screen_active: boolean, proc_name?: string}
 ---@alias local_process_info {name: string, argv: string[], cwd: string, executable: string}
 
 ---compare function returns true if a is more left than b
@@ -98,10 +98,13 @@ local function insert_panes(root, panes)
 			root.alt_screen_active = root.pane:is_alt_screen_active()
 			if root.alt_screen_active then
 				local process_info = root.pane:get_foreground_process_info()
-				process_info.children = nil
-				process_info.pid = nil
-				process_info.ppid = nil
+				if process_info ~= nil then
+          process_info.children = nil
+          process_info.pid = nil
+          process_info.ppid = nil
+        end
 				root.process = process_info
+				root.proc_name = root.pane:get_foreground_process_name()
 			else
 				local nlines = root.pane:get_dimensions().scrollback_rows
 				if nlines > pub.max_nlines then

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -151,7 +151,11 @@ function pub.default_on_pane_restore(pane_tree)
 
 	-- Spawn process if using alt screen, otherwise restore text
 	if pane_tree.alt_screen_active then
-		pane:send_text(wezterm.shell_join_args(pane_tree.process.argv) .. "\r\n")
+	  if pane_tree.process ~= nil then
+      pane:send_text(wezterm.shell_join_args(pane_tree.process.argv) .. "\r\n")
+    elseif pane_tree.proc_name ~= nil then
+      pane:send_text(pane_tree.proc_name .. "\r\n")
+    end
 	elseif pane_tree.text then
 		pane:inject_output(pane_tree.text:gsub("%s+$", ""))
 	end

--- a/plugin/resurrect/tab_state.lua
+++ b/plugin/resurrect/tab_state.lua
@@ -151,11 +151,11 @@ function pub.default_on_pane_restore(pane_tree)
 
 	-- Spawn process if using alt screen, otherwise restore text
 	if pane_tree.alt_screen_active then
-	  if pane_tree.process ~= nil then
-      pane:send_text(wezterm.shell_join_args(pane_tree.process.argv) .. "\r\n")
-    elseif pane_tree.proc_name ~= nil then
-      pane:send_text(pane_tree.proc_name .. "\r\n")
-    end
+		if pane_tree.process ~= nil then
+			pane:send_text(wezterm.shell_join_args(pane_tree.process.argv) .. "\r\n")
+		elseif pane_tree.proc_name ~= nil then
+			pane:send_text(pane_tree.proc_name .. "\r\n")
+		end
 	elseif pane_tree.text then
 		pane:inject_output(pane_tree.text:gsub("%s+$", ""))
 	end


### PR DESCRIPTION
This will close #144. I tested by saving a workspace with an active `top` and/or `ps -ef | less` process running and it successfully restored those processes on workspace restoration. The only caveat is that I any arguments the process runs with are discarded, since those can't be captured when `get_foreground_process_info` is `nil`.