### PR TITLE
feat: add save_non_local_domains opt-in flag for scrollback capture

### DIFF
--- a/plugin/resurrect/pane_tree.lua
+++ b/plugin/resurrect/pane_tree.lua
@@ -5,6 +5,7 @@ local utils = require("resurrect.utils")
 ---@field max_nlines integer
 local pub = {}
 pub.max_nlines = 3500
+pub.save_non_local_domains = false
 
 ---@alias Pane any
 ---@alias PaneInformation {left: integer, top: integer, height: integer, width: integer}
@@ -91,9 +92,9 @@ local function insert_panes(root, panes)
 			end
 		end
 
-		if domain == "local" then
-			-- pane:inject_output() is unavailable for non-local domains,
-			-- only saving local scrollback because it would slow down the process
+		if domain == "local" or pub.save_non_local_domains then
+			-- pane:inject_output() is unavailable for non-local domains; opt in via
+			-- pub.save_non_local_domains = true (restore via send_text workaround needed)
 			-- See: https://github.com/MLFlexer/resurrect.wezterm/issues/41
 			root.alt_screen_active = root.pane:is_alt_screen_active()
 			if root.alt_screen_active then


### PR DESCRIPTION
## Problem

When using WezTerm with a unix mux domain (`connect unix`), pane scrollback is not captured on save because `pane:inject_output()` is unavailable for non-local domains. The guard at line 94 (`if domain == "local" then`) silently skips scrollback for all non-local panes.

Fixes #41

## Solution

Add an opt-in config flag `pane_tree.save_non_local_domains = false` (default `false`, no behaviour change). When set to `true`, scrollback is captured for all domains.

```lua
local resurrect = require("resurrect")
resurrect.pane_tree.save_non_local_domains = true
```

Since `inject_output` is unavailable for non-local domains, callers that enable this flag need their own restore workaround (e.g. writing scrollback to a temp file and replaying via `send_text`).

## Changes

- `plugin/resurrect/pane_tree.lua`: add `pub.save_non_local_domains = false`; change condition to `domain == "local" or pub.save_non_local_domains`

## Test plan

- [ ] Default (`false`): existing behaviour unchanged — non-local panes skip scrollback capture
- [ ] Set to `true`: non-local domain panes have `text`/`alt_screen_active` populated in saved state

🤖 Generated with [Claude Code](https://claude.com/claude-code)